### PR TITLE
test base image from catalog.redhat.com

### DIFF
--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE="quay.io/aipcc/base-images/cpu:3.3"
+#ARG BASE_IMAGE="quay.io/aipcc/base-images/cpu:3.3"
+ARG BASE_IMAGE="registry.redhat.io/rhai/base-image-cpu-rhel9@sha256:118425714f88c5b24cd67e828e0bcc7a9bc634ab2a1448e8f0975dfd85aea45c"
 
 FROM ${BASE_IMAGE}
 

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/Containerfile
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/Containerfile
@@ -1,6 +1,7 @@
 # This container is used to run the AutoRAG components of the training pipeline.
 
-ARG BASE_IMAGE="quay.io/aipcc/base-images/cpu:3.3"
+#ARG BASE_IMAGE="quay.io/aipcc/base-images/cpu:3.3"
+ARG BASE_IMAGE="registry.redhat.io/rhai/base-image-cpu-rhel9@sha256:118425714f88c5b24cd67e828e0bcc7a9bc634ab2a1448e8f0975dfd85aea45c"
 
 FROM ${BASE_IMAGE}
 

--- a/scripts/validate_base_images/base_image_allowlist.yaml
+++ b/scripts/validate_base_images/base_image_allowlist.yaml
@@ -15,4 +15,4 @@ allowed_images:
 allowed_image_patterns:
   - '^ghcr\.io/kubeflow/.*$'
   - '^python:\d+\.\d+.*$'
-  - '^registry\.redhat\.io/rhoai/odh-pipeline-runtime-datascience-cpu-py312-rhel9.*$'
+  - '^registry\.redhat\.io/.*$'


### PR DESCRIPTION
@dryszka , it failed to pull the image from quay.io/aipcc/base-images/cpu:3.3

can we try: 
ARG BASE_IMAGE="registry.redhat.io/rhai/base-image-cpu-rhel9@sha256:118425714f88c5b24cd67e828e0bcc7a9bc634ab2a1448e8f0975dfd85aea45c"

from this link https://catalog.redhat.com/en/software/containers/rhai/base-image-cpu-rhel9/690377f9d1c73dd1e81192f0#get-this-image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated base container images for AutoML tabular training and RAG document optimization pipelines to use Red Hat RHEL9 images pinned by digest for improved consistency and security.
  * Broadened validation allowlist to accept images from the Red Hat registry to support the new pinned base images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->