### PR TITLE
feat: add MLflow passthrough params to all training pipelines

### DIFF
--- a/components/training/finetuning_algorithms/lora/component.py
+++ b/components/training/finetuning_algorithms/lora/component.py
@@ -178,7 +178,7 @@ def train_model(
     from typing import Dict
 
     from data import download_oci_model, prepare_jsonl, resolve_dataset
-    from output import persist_model, plot_training_loss
+    from output import extract_metrics_from_jsonl, persist_model, plot_training_loss
     from setup import configure_env, create_logger, init_k8s, parse_kv, setup_hf_token
     from training import compute_nproc, select_runtime, wait_for_training_job
 
@@ -490,10 +490,21 @@ def train_model(
         raise
 
     def get_training_metrics(root: str):
-        # TODO: Add loss chart support for LoRA once training_hub exposes a metrics/logging
-        # file for the unsloth backend. Blocked on:
-        # https://github.com/Red-Hat-AI-Innovation-Team/training_hub/pull/40
-        return {}, []
+        import os
+
+        pats = ["training_metrics.jsonl"]
+        mf = None
+        for r, _, fs in os.walk(root):
+            for p in pats:
+                if p in fs:
+                    mf = os.path.join(r, p)
+                    break
+            if mf:
+                break
+        if not mf or not os.path.exists(mf):
+            return {}, []
+        log.info(f"Metrics: {mf}")
+        return extract_metrics_from_jsonl(mf)
 
     def log_training_metrics():
         output_metrics.log_metric("num_epochs", float(params.get("num_epochs") or 3))

--- a/components/training/finetuning_algorithms/lora/component.py
+++ b/components/training/finetuning_algorithms/lora/component.py
@@ -201,6 +201,10 @@ def train_model(
     merged_env = configure_env(training_envs, default_env, log)
     setup_hf_token(merged_env, training_base_model, log)
 
+    # Configure MLflow env vars for training pods (RHOAI MLflow)
+    if training_mlflow_tracking_uri:
+        merged_env.setdefault("MLFLOW_TRACKING_INSECURE_TLS", "true")
+
     ds_dir = os.path.join(pvc_path, "dataset", "train")
     os.makedirs(ds_dir, exist_ok=True)
 
@@ -363,6 +367,25 @@ def train_model(
             import os
 
             from training_hub import lora_sft as tr
+
+            # Configure MLflow auth env vars for RHOAI MLflow server.
+            # These env vars inherit to torchrun subprocesses. The RHOAI
+            # MLflow fork (installed in training images) reads them to
+            # configure auth token and workspace header automatically.
+            mlflow_uri = (p or {}).get("mlflow_tracking_uri", "")
+            if mlflow_uri:
+                token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+                if os.path.exists(token_path):
+                    with open(token_path) as f:
+                        os.environ["MLFLOW_TRACKING_TOKEN"] = f.read().strip()
+
+                ns_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+                if os.path.exists(ns_path):
+                    with open(ns_path) as f:
+                        os.environ["MLFLOW_WORKSPACE"] = f.read().strip()
+
+                os.environ.setdefault("MLFLOW_TRACKING_INSECURE_TLS", "true")
+                print(f"[MLflow] Auth configured, workspace: {os.environ.get('MLFLOW_WORKSPACE', 'unset')}", flush=True)
 
             print("[PY] Launching LoRA training...", flush=True)
             result = tr(**(p or {}))

--- a/components/training/finetuning_algorithms/lora/component.py
+++ b/components/training/finetuning_algorithms/lora/component.py
@@ -179,7 +179,7 @@ def train_model(
 
     from data import download_oci_model, prepare_jsonl, resolve_dataset
     from output import extract_metrics_from_jsonl, persist_model, plot_training_loss
-    from setup import configure_env, create_logger, init_k8s, parse_kv, setup_hf_token
+    from setup import configure_env, create_logger, init_k8s, parse_kv, setup_hf_token, validate_mlflow_tracking_uri
     from training import compute_nproc, select_runtime, wait_for_training_job
 
     log = create_logger("train_model")
@@ -201,7 +201,8 @@ def train_model(
     merged_env = configure_env(training_envs, default_env, log)
     setup_hf_token(merged_env, training_base_model, log)
 
-    # Configure MLflow env vars for training pods (RHOAI MLflow)
+    # Validate and configure MLflow env vars for training pods (RHOAI MLflow)
+    validate_mlflow_tracking_uri(training_mlflow_tracking_uri)
     if training_mlflow_tracking_uri:
         merged_env.setdefault("MLFLOW_TRACKING_INSECURE_TLS", "true")
 
@@ -374,15 +375,17 @@ def train_model(
             # configure auth token and workspace header automatically.
             mlflow_uri = (p or {}).get("mlflow_tracking_uri", "")
             if mlflow_uri:
-                token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-                if os.path.exists(token_path):
-                    with open(token_path) as f:
+                try:
+                    with open("/var/run/secrets/kubernetes.io/serviceaccount/token") as f:
                         os.environ["MLFLOW_TRACKING_TOKEN"] = f.read().strip()
+                except FileNotFoundError:
+                    pass
 
-                ns_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-                if os.path.exists(ns_path):
-                    with open(ns_path) as f:
+                try:
+                    with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
                         os.environ["MLFLOW_WORKSPACE"] = f.read().strip()
+                except FileNotFoundError:
+                    pass
 
                 os.environ.setdefault("MLFLOW_TRACKING_INSECURE_TLS", "true")
                 print(f"[MLflow] Auth configured, workspace: {os.environ.get('MLFLOW_WORKSPACE', 'unset')}", flush=True)

--- a/components/training/finetuning_algorithms/osft/README.md
+++ b/components/training/finetuning_algorithms/osft/README.md
@@ -43,6 +43,9 @@ Train model using OSFT (Orthogonal Subspace Fine-Tuning). Outputs model artifact
 | `training_lr_scheduler_kwargs` | `str` | `""` | LR scheduler kwargs as key=val,key=val. |
 | `training_save_final_checkpoint` | `Optional[bool]` | `None` | Save final checkpoint after training. |
 | `training_fsdp_sharding_strategy` | `Optional[str]` | `None` | FSDP sharding strategy. |
+| `training_mlflow_tracking_uri` | `Optional[str]` | `None` | MLflow tracking server URI. |
+| `training_mlflow_experiment_name` | `Optional[str]` | `None` | MLflow experiment name. |
+| `training_mlflow_run_name` | `Optional[str]` | `None` | MLflow run name. |
 | `training_runtime` | `str` | `training-hub` | Name of the ClusterTrainingRuntime to use. |
 | `kubernetes_config` | `dsl.TaskConfig` | `None` | KFP TaskConfig for volumes/env/resources passthrough. |
 

--- a/components/training/finetuning_algorithms/osft/component.py
+++ b/components/training/finetuning_algorithms/osft/component.py
@@ -126,7 +126,7 @@ def train_model(
 
     from data import download_oci_model, prepare_jsonl, resolve_dataset
     from output import extract_metrics_from_jsonl, persist_model, plot_training_loss
-    from setup import configure_env, create_logger, init_k8s, parse_kv, setup_hf_token
+    from setup import configure_env, create_logger, init_k8s, parse_kv, setup_hf_token, validate_mlflow_tracking_uri
     from training import compute_nproc, select_runtime, wait_for_training_job
 
     log = create_logger("train_model")
@@ -148,7 +148,8 @@ def train_model(
     merged_env = configure_env(training_envs, default_env, log)
     setup_hf_token(merged_env, training_base_model, log)
 
-    # Configure MLflow env vars for training pods (RHOAI MLflow)
+    # Validate and configure MLflow env vars for training pods (RHOAI MLflow)
+    validate_mlflow_tracking_uri(training_mlflow_tracking_uri)
     if training_mlflow_tracking_uri:
         merged_env.setdefault("MLFLOW_TRACKING_INSECURE_TLS", "true")
 
@@ -268,15 +269,17 @@ def train_model(
 
             mlflow_uri = a.get("mlflow_tracking_uri", "")
             if mlflow_uri:
-                token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-                if os.path.exists(token_path):
-                    with open(token_path) as f:
+                try:
+                    with open("/var/run/secrets/kubernetes.io/serviceaccount/token") as f:
                         os.environ["MLFLOW_TRACKING_TOKEN"] = f.read().strip()
+                except FileNotFoundError:
+                    pass
 
-                ns_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-                if os.path.exists(ns_path):
-                    with open(ns_path) as f:
+                try:
+                    with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
                         os.environ["MLFLOW_WORKSPACE"] = f.read().strip()
+                except FileNotFoundError:
+                    pass
 
                 os.environ.setdefault("MLFLOW_TRACKING_INSECURE_TLS", "true")
                 print(f"[MLflow] Auth configured, workspace: {os.environ.get('MLFLOW_WORKSPACE', 'unset')}", flush=True)

--- a/components/training/finetuning_algorithms/osft/component.py
+++ b/components/training/finetuning_algorithms/osft/component.py
@@ -257,6 +257,8 @@ def train_model(
         params = _params()
 
         def _train_func(p):
+            import os
+
             a = dict(p or {})
             fsdp = a.pop("fsdp_sharding_strategy", None)
             from training_hub import osft as tr
@@ -265,7 +267,6 @@ def train_model(
             # These env vars inherit to torchrun subprocesses. The RHOAI
             # MLflow fork (installed in training images) reads them to
             # configure auth token and workspace header automatically.
-            import os
 
             mlflow_uri = a.get("mlflow_tracking_uri", "")
             if mlflow_uri:

--- a/components/training/finetuning_algorithms/osft/component.py
+++ b/components/training/finetuning_algorithms/osft/component.py
@@ -148,6 +148,10 @@ def train_model(
     merged_env = configure_env(training_envs, default_env, log)
     setup_hf_token(merged_env, training_base_model, log)
 
+    # Configure MLflow env vars for training pods (RHOAI MLflow)
+    if training_mlflow_tracking_uri:
+        merged_env.setdefault("MLFLOW_TRACKING_INSECURE_TLS", "true")
+
     ds_dir = os.path.join(pvc_path, "dataset", "train")
     os.makedirs(ds_dir, exist_ok=True)
 
@@ -255,6 +259,27 @@ def train_model(
             a = dict(p or {})
             fsdp = a.pop("fsdp_sharding_strategy", None)
             from training_hub import osft as tr
+
+            # Configure MLflow auth env vars for RHOAI MLflow server.
+            # These env vars inherit to torchrun subprocesses. The RHOAI
+            # MLflow fork (installed in training images) reads them to
+            # configure auth token and workspace header automatically.
+            import os
+
+            mlflow_uri = a.get("mlflow_tracking_uri", "")
+            if mlflow_uri:
+                token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+                if os.path.exists(token_path):
+                    with open(token_path) as f:
+                        os.environ["MLFLOW_TRACKING_TOKEN"] = f.read().strip()
+
+                ns_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+                if os.path.exists(ns_path):
+                    with open(ns_path) as f:
+                        os.environ["MLFLOW_WORKSPACE"] = f.read().strip()
+
+                os.environ.setdefault("MLFLOW_TRACKING_INSECURE_TLS", "true")
+                print(f"[MLflow] Auth configured, workspace: {os.environ.get('MLFLOW_WORKSPACE', 'unset')}", flush=True)
 
             print("[PY] Launching OSFT training...", flush=True)
 

--- a/components/training/finetuning_algorithms/osft/component.py
+++ b/components/training/finetuning_algorithms/osft/component.py
@@ -68,6 +68,10 @@ def train_model(
     training_lr_scheduler_kwargs: str = "",
     training_save_final_checkpoint: Optional[bool] = None,
     training_fsdp_sharding_strategy: Optional[str] = None,
+    # Logging integration params
+    training_mlflow_tracking_uri: Optional[str] = None,
+    training_mlflow_experiment_name: Optional[str] = None,
+    training_mlflow_run_name: Optional[str] = None,
     training_runtime: str = "training-hub",
     kubernetes_config: dsl.TaskConfig = None,
 ) -> str:
@@ -107,6 +111,9 @@ def train_model(
         training_lr_scheduler_kwargs: LR scheduler kwargs as key=val,key=val.
         training_save_final_checkpoint: Save final checkpoint after training.
         training_fsdp_sharding_strategy: FSDP sharding strategy.
+        training_mlflow_tracking_uri: MLflow tracking server URI.
+        training_mlflow_experiment_name: MLflow experiment name.
+        training_mlflow_run_name: MLflow run name.
         training_runtime: Name of the ClusterTrainingRuntime to use.
         kubernetes_config: KFP TaskConfig for volumes/env/resources passthrough.
 
@@ -232,6 +239,14 @@ def train_model(
                 b["save_final_checkpoint"] = bool(training_save_final_checkpoint)
             if training_fsdp_sharding_strategy:
                 b["fsdp_sharding_strategy"] = training_fsdp_sharding_strategy.upper().strip()
+
+            # Logging integration params
+            if training_mlflow_tracking_uri:
+                b["mlflow_tracking_uri"] = training_mlflow_tracking_uri
+            if training_mlflow_experiment_name:
+                b["mlflow_experiment_name"] = training_mlflow_experiment_name
+            if training_mlflow_run_name:
+                b["mlflow_run_name"] = training_mlflow_run_name
             return b
 
         params = _params()

--- a/components/training/finetuning_algorithms/sft/README.md
+++ b/components/training/finetuning_algorithms/sft/README.md
@@ -38,6 +38,9 @@ Train model using SFT (Supervised Fine-Tuning). Outputs model artifact and metri
 | `training_save_samples` | `Optional[int]` | `None` | Number of samples to save. |
 | `training_accelerate_full_state_at_epoch` | `Optional[bool]` | `None` | Save full accelerate state. |
 | `training_fsdp_sharding_strategy` | `Optional[str]` | `None` | FSDP sharding strategy. |
+| `training_mlflow_tracking_uri` | `Optional[str]` | `None` | MLflow tracking server URI. |
+| `training_mlflow_experiment_name` | `Optional[str]` | `None` | MLflow experiment name. |
+| `training_mlflow_run_name` | `Optional[str]` | `None` | MLflow run name. |
 | `training_runtime` | `str` | `training-hub` | Name of the ClusterTrainingRuntime to use. |
 | `kubernetes_config` | `dsl.TaskConfig` | `None` | KFP TaskConfig for volumes/env/resources passthrough. |
 

--- a/components/training/finetuning_algorithms/sft/component.py
+++ b/components/training/finetuning_algorithms/sft/component.py
@@ -227,6 +227,8 @@ def train_model(
         params = _params()
 
         def _train_func(p):
+            import os
+
             a = dict(p or {})
             fsdp = a.pop("fsdp_sharding_strategy", None)
             from training_hub import sft as tr
@@ -235,7 +237,6 @@ def train_model(
             # These env vars inherit to torchrun subprocesses. The RHOAI
             # MLflow fork (installed in training images) reads them to
             # configure auth token and workspace header automatically.
-            import os
 
             mlflow_uri = a.get("mlflow_tracking_uri", "")
             if mlflow_uri:

--- a/components/training/finetuning_algorithms/sft/component.py
+++ b/components/training/finetuning_algorithms/sft/component.py
@@ -138,6 +138,10 @@ def train_model(
     merged_env = configure_env(training_envs, default_env, log)
     setup_hf_token(merged_env, training_base_model, log)
 
+    # Configure MLflow env vars for training pods (RHOAI MLflow)
+    if training_mlflow_tracking_uri:
+        merged_env.setdefault("MLFLOW_TRACKING_INSECURE_TLS", "true")
+
     ds_dir = os.path.join(pvc_path, "dataset", "train")
     os.makedirs(ds_dir, exist_ok=True)
 
@@ -225,6 +229,27 @@ def train_model(
             a = dict(p or {})
             fsdp = a.pop("fsdp_sharding_strategy", None)
             from training_hub import sft as tr
+
+            # Configure MLflow auth env vars for RHOAI MLflow server.
+            # These env vars inherit to torchrun subprocesses. The RHOAI
+            # MLflow fork (installed in training images) reads them to
+            # configure auth token and workspace header automatically.
+            import os
+
+            mlflow_uri = a.get("mlflow_tracking_uri", "")
+            if mlflow_uri:
+                token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+                if os.path.exists(token_path):
+                    with open(token_path) as f:
+                        os.environ["MLFLOW_TRACKING_TOKEN"] = f.read().strip()
+
+                ns_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+                if os.path.exists(ns_path):
+                    with open(ns_path) as f:
+                        os.environ["MLFLOW_WORKSPACE"] = f.read().strip()
+
+                os.environ.setdefault("MLFLOW_TRACKING_INSECURE_TLS", "true")
+                print(f"[MLflow] Auth configured, workspace: {os.environ.get('MLFLOW_WORKSPACE', 'unset')}", flush=True)
 
             print("[PY] Launching SFT training...", flush=True)
 

--- a/components/training/finetuning_algorithms/sft/component.py
+++ b/components/training/finetuning_algorithms/sft/component.py
@@ -116,7 +116,7 @@ def train_model(
 
     from data import download_oci_model, prepare_jsonl, resolve_dataset
     from output import extract_metrics_from_jsonl, persist_model, plot_training_loss
-    from setup import configure_env, create_logger, init_k8s, parse_kv, setup_hf_token
+    from setup import configure_env, create_logger, init_k8s, parse_kv, setup_hf_token, validate_mlflow_tracking_uri
     from training import compute_nproc, select_runtime, wait_for_training_job
 
     log = create_logger("train_model")
@@ -138,7 +138,8 @@ def train_model(
     merged_env = configure_env(training_envs, default_env, log)
     setup_hf_token(merged_env, training_base_model, log)
 
-    # Configure MLflow env vars for training pods (RHOAI MLflow)
+    # Validate and configure MLflow env vars for training pods (RHOAI MLflow)
+    validate_mlflow_tracking_uri(training_mlflow_tracking_uri)
     if training_mlflow_tracking_uri:
         merged_env.setdefault("MLFLOW_TRACKING_INSECURE_TLS", "true")
 
@@ -238,15 +239,17 @@ def train_model(
 
             mlflow_uri = a.get("mlflow_tracking_uri", "")
             if mlflow_uri:
-                token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-                if os.path.exists(token_path):
-                    with open(token_path) as f:
+                try:
+                    with open("/var/run/secrets/kubernetes.io/serviceaccount/token") as f:
                         os.environ["MLFLOW_TRACKING_TOKEN"] = f.read().strip()
+                except FileNotFoundError:
+                    pass
 
-                ns_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-                if os.path.exists(ns_path):
-                    with open(ns_path) as f:
+                try:
+                    with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
                         os.environ["MLFLOW_WORKSPACE"] = f.read().strip()
+                except FileNotFoundError:
+                    pass
 
                 os.environ.setdefault("MLFLOW_TRACKING_INSECURE_TLS", "true")
                 print(f"[MLflow] Auth configured, workspace: {os.environ.get('MLFLOW_WORKSPACE', 'unset')}", flush=True)

--- a/components/training/finetuning_algorithms/sft/component.py
+++ b/components/training/finetuning_algorithms/sft/component.py
@@ -63,6 +63,10 @@ def train_model(
     training_save_samples: Optional[int] = None,
     training_accelerate_full_state_at_epoch: Optional[bool] = None,
     training_fsdp_sharding_strategy: Optional[str] = None,
+    # Logging integration params
+    training_mlflow_tracking_uri: Optional[str] = None,
+    training_mlflow_experiment_name: Optional[str] = None,
+    training_mlflow_run_name: Optional[str] = None,
     training_runtime: str = "training-hub",
     kubernetes_config: dsl.TaskConfig = None,
 ) -> str:
@@ -97,6 +101,9 @@ def train_model(
         training_save_samples: Number of samples to save.
         training_accelerate_full_state_at_epoch: Save full accelerate state.
         training_fsdp_sharding_strategy: FSDP sharding strategy.
+        training_mlflow_tracking_uri: MLflow tracking server URI.
+        training_mlflow_experiment_name: MLflow experiment name.
+        training_mlflow_run_name: MLflow run name.
         training_runtime: Name of the ClusterTrainingRuntime to use.
         kubernetes_config: KFP TaskConfig for volumes/env/resources passthrough.
 
@@ -202,6 +209,14 @@ def train_model(
                 b["seed"] = int(training_seed)
             if training_fsdp_sharding_strategy:
                 b["fsdp_sharding_strategy"] = training_fsdp_sharding_strategy.upper().strip()
+
+            # Logging integration params
+            if training_mlflow_tracking_uri:
+                b["mlflow_tracking_uri"] = training_mlflow_tracking_uri
+            if training_mlflow_experiment_name:
+                b["mlflow_experiment_name"] = training_mlflow_experiment_name
+            if training_mlflow_run_name:
+                b["mlflow_run_name"] = training_mlflow_run_name
             return b
 
         params = _params()

--- a/components/training/finetuning_algorithms/shared/setup.py
+++ b/components/training/finetuning_algorithms/shared/setup.py
@@ -124,3 +124,30 @@ def setup_hf_token(menv: Dict[str, str], training_base_model: str, log: logging.
         b = training_base_model.strip()
         if b.startswith("hf://") or ("/" in b and not b.startswith("oci://") and not os.path.exists(b)):
             log.warning(f"HF_TOKEN not set; only public models accessible for '{training_base_model}'")
+
+
+def validate_mlflow_tracking_uri(uri: Optional[str]) -> Optional[str]:
+    """Validate and sanitize an MLflow tracking URI.
+
+    Ensures the URI uses http(s) scheme and does not contain embedded credentials.
+
+    Args:
+        uri: MLflow tracking URI string, or None.
+
+    Returns:
+        Sanitized URI string, or None if input was empty/None.
+
+    Raises:
+        ValueError: If the URI has an invalid scheme or contains embedded credentials.
+    """
+    if not uri:
+        return None
+    from urllib.parse import urlsplit
+
+    value = uri.strip()
+    parsed = urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"training_mlflow_tracking_uri must be a valid http(s) URL, got: {value}")
+    if parsed.username or parsed.password:
+        raise ValueError("Do not embed credentials in training_mlflow_tracking_uri; use Kubernetes secrets instead")
+    return value

--- a/pipelines/training/finetuning/lora_minimal/README.md
+++ b/pipelines/training/finetuning/lora_minimal/README.md
@@ -36,6 +36,9 @@ A minimal 4-stage ML pipeline for fine-tuning language models with LoRA:
 | `phase_02_train_opt_lora_load_in_4bit` | `bool` | `True` | [QLoRA] Enable 4-bit quantization (cannot use with 8-bit) |
 | `phase_02_train_opt_lora_load_in_8bit` | `bool` | `False` | [QLoRA] Enable 8-bit quantization (cannot use with 4-bit) |
 | `phase_02_train_opt_runtime` | `str` | `training-hub` | Name of the ClusterTrainingRuntime to use. |
+| `phase_02_train_opt_mlflow_tracking_uri` | `str` | `""` | MLflow tracking server URI. |
+| `phase_02_train_opt_mlflow_experiment_name` | `str` | `""` | MLflow experiment name. |
+| `phase_02_train_opt_mlflow_run_name` | `str` | `""` | MLflow run name. |
 | `phase_04_registry_opt_port` | `int` | `8080` | Model registry server port |
 
 ## Metadata 🗂️

--- a/pipelines/training/finetuning/lora_minimal/pipeline.py
+++ b/pipelines/training/finetuning/lora_minimal/pipeline.py
@@ -79,6 +79,9 @@ def lora_minimal_pipeline(
     phase_02_train_opt_lora_load_in_4bit: bool = True,
     phase_02_train_opt_lora_load_in_8bit: bool = False,
     phase_02_train_opt_runtime: str = "training-hub",
+    phase_02_train_opt_mlflow_tracking_uri: str = "",
+    phase_02_train_opt_mlflow_experiment_name: str = "",
+    phase_02_train_opt_mlflow_run_name: str = "",
     phase_04_registry_opt_port: int = 8080,
 ):
     """LoRA Minimal Training Pipeline - Parameter-efficient fine-tuning.
@@ -113,6 +116,9 @@ def lora_minimal_pipeline(
         phase_02_train_opt_lora_load_in_4bit: [QLoRA] Enable 4-bit quantization (cannot use with 8-bit)
         phase_02_train_opt_lora_load_in_8bit: [QLoRA] Enable 8-bit quantization (cannot use with 4-bit)
         phase_02_train_opt_runtime: Name of the ClusterTrainingRuntime to use.
+        phase_02_train_opt_mlflow_tracking_uri: MLflow tracking server URI.
+        phase_02_train_opt_mlflow_experiment_name: MLflow experiment name.
+        phase_02_train_opt_mlflow_run_name: MLflow run name.
         phase_04_registry_opt_port: Model registry server port
     """
     # =========================================================================
@@ -177,6 +183,10 @@ def lora_minimal_pipeline(
         # Hardcoded to 1 until unsloth/training_hub add multi-node LoRA support.
         training_resource_num_workers=1,
         training_runtime=phase_02_train_opt_runtime,
+        # MLflow
+        training_mlflow_tracking_uri=phase_02_train_opt_mlflow_tracking_uri,
+        training_mlflow_experiment_name=phase_02_train_opt_mlflow_experiment_name,
+        training_mlflow_run_name=phase_02_train_opt_mlflow_run_name,
     )
     training_task.set_caching_options(False)
     kfp.kubernetes.set_image_pull_policy(training_task, "IfNotPresent")

--- a/pipelines/training/finetuning/osft/README.md
+++ b/pipelines/training/finetuning/osft/README.md
@@ -48,6 +48,9 @@ A 4-stage ML pipeline for fine-tuning language models with OSFT:
 | `phase_02_train_opt_unmask` | `bool` | `False` | [OSFT] Unmask all tokens (False=assistant only) |
 | `phase_02_train_opt_use_liger` | `bool` | `True` | [OSFT] Enable Liger kernel optimizations. Recommended |
 | `phase_02_train_opt_runtime` | `str` | `training-hub` | Name of the ClusterTrainingRuntime to use. |
+| `phase_02_train_opt_mlflow_tracking_uri` | `str` | `""` | MLflow tracking server URI. |
+| `phase_02_train_opt_mlflow_experiment_name` | `str` | `""` | MLflow experiment name. |
+| `phase_02_train_opt_mlflow_run_name` | `str` | `""` | MLflow run name. |
 | `phase_03_eval_opt_batch` | `str` | `auto` | Eval batch size ('auto' or integer) |
 | `phase_03_eval_opt_gen_kwargs` | `dict` | `{}` | Generation params dict (max_tokens, temperature) |
 | `phase_03_eval_opt_limit` | `int` | `-1` | Max samples per task (-1 = all) |

--- a/pipelines/training/finetuning/osft/pipeline.py
+++ b/pipelines/training/finetuning/osft/pipeline.py
@@ -87,6 +87,9 @@ def osft_pipeline(
     phase_02_train_opt_unmask: bool = False,
     phase_02_train_opt_use_liger: bool = True,
     phase_02_train_opt_runtime: str = "training-hub",
+    phase_02_train_opt_mlflow_tracking_uri: str = "",
+    phase_02_train_opt_mlflow_experiment_name: str = "",
+    phase_02_train_opt_mlflow_run_name: str = "",
     phase_03_eval_opt_batch: str = "auto",
     phase_03_eval_opt_gen_kwargs: dict = {},
     phase_03_eval_opt_limit: int = -1,
@@ -142,6 +145,9 @@ def osft_pipeline(
             phase_02_train_opt_unmask: [OSFT] Unmask all tokens (False=assistant only)
             phase_02_train_opt_use_liger: [OSFT] Enable Liger kernel optimizations. Recommended
             phase_02_train_opt_runtime: Name of the ClusterTrainingRuntime to use.
+            phase_02_train_opt_mlflow_tracking_uri: MLflow tracking server URI.
+            phase_02_train_opt_mlflow_experiment_name: MLflow experiment name.
+            phase_02_train_opt_mlflow_run_name: MLflow run name.
             phase_03_eval_opt_batch: Eval batch size ('auto' or integer)
             phase_03_eval_opt_gen_kwargs: Generation params dict (max_tokens, temperature)
             phase_03_eval_opt_limit: Max samples per task (-1 = all)
@@ -215,6 +221,10 @@ def osft_pipeline(
         training_resource_num_procs_per_worker=phase_02_train_opt_num_procs,
         training_resource_num_workers=phase_02_train_man_train_workers,
         training_runtime=phase_02_train_opt_runtime,
+        # MLflow
+        training_mlflow_tracking_uri=phase_02_train_opt_mlflow_tracking_uri,
+        training_mlflow_experiment_name=phase_02_train_opt_mlflow_experiment_name,
+        training_mlflow_run_name=phase_02_train_opt_mlflow_run_name,
     )
     training_task.set_caching_options(False)
     kfp.kubernetes.set_image_pull_policy(training_task, "IfNotPresent")

--- a/pipelines/training/finetuning/osft_minimal/README.md
+++ b/pipelines/training/finetuning/osft_minimal/README.md
@@ -32,6 +32,9 @@ A minimal 4-stage ML pipeline for fine-tuning language models with OSFT:
 | `phase_02_train_opt_max_seq_len` | `int` | `8192` | Max sequence length in tokens |
 | `phase_02_train_opt_use_liger` | `bool` | `True` | [OSFT] Enable Liger kernel optimizations. Recommended |
 | `phase_02_train_opt_runtime` | `str` | `training-hub` | Name of the ClusterTrainingRuntime to use. |
+| `phase_02_train_opt_mlflow_tracking_uri` | `str` | `""` | MLflow tracking server URI. |
+| `phase_02_train_opt_mlflow_experiment_name` | `str` | `""` | MLflow experiment name. |
+| `phase_02_train_opt_mlflow_run_name` | `str` | `""` | MLflow run name. |
 | `phase_04_registry_opt_port` | `int` | `8080` | Model registry server port |
 
 ## Metadata 🗂️

--- a/pipelines/training/finetuning/osft_minimal/pipeline.py
+++ b/pipelines/training/finetuning/osft_minimal/pipeline.py
@@ -71,6 +71,9 @@ def osft_minimal_pipeline(
     phase_02_train_opt_max_seq_len: int = 8192,
     phase_02_train_opt_use_liger: bool = True,
     phase_02_train_opt_runtime: str = "training-hub",
+    phase_02_train_opt_mlflow_tracking_uri: str = "",
+    phase_02_train_opt_mlflow_experiment_name: str = "",
+    phase_02_train_opt_mlflow_run_name: str = "",
     phase_04_registry_opt_port: int = 8080,
 ):
     """OSFT Minimal Training Pipeline - Continual learning without catastrophic forgetting.
@@ -101,6 +104,9 @@ def osft_minimal_pipeline(
         phase_02_train_opt_max_seq_len: Max sequence length in tokens
         phase_02_train_opt_use_liger: [OSFT] Enable Liger kernel optimizations. Recommended
         phase_02_train_opt_runtime: Name of the ClusterTrainingRuntime to use.
+        phase_02_train_opt_mlflow_tracking_uri: MLflow tracking server URI.
+        phase_02_train_opt_mlflow_experiment_name: MLflow experiment name.
+        phase_02_train_opt_mlflow_run_name: MLflow run name.
         phase_04_registry_opt_port: Model registry server port
     """
     # =========================================================================
@@ -157,6 +163,10 @@ def osft_minimal_pipeline(
         training_resource_num_procs_per_worker="auto",
         training_resource_num_workers=phase_02_train_man_train_workers,
         training_runtime=phase_02_train_opt_runtime,
+        # MLflow
+        training_mlflow_tracking_uri=phase_02_train_opt_mlflow_tracking_uri,
+        training_mlflow_experiment_name=phase_02_train_opt_mlflow_experiment_name,
+        training_mlflow_run_name=phase_02_train_opt_mlflow_run_name,
     )
     training_task.set_caching_options(False)
     kfp.kubernetes.set_image_pull_policy(training_task, "IfNotPresent")

--- a/pipelines/training/finetuning/sft/README.md
+++ b/pipelines/training/finetuning/sft/README.md
@@ -45,6 +45,9 @@ A 4-stage ML pipeline for fine-tuning language models:
 | `phase_02_train_opt_seed` | `int` | `42` | Random seed for reproducibility. |
 | `phase_02_train_opt_use_liger` | `bool` | `False` | Enable Liger kernel optimizations. |
 | `phase_02_train_opt_runtime` | `str` | `training-hub` | Name of the ClusterTrainingRuntime to use. |
+| `phase_02_train_opt_mlflow_tracking_uri` | `str` | `""` | MLflow tracking server URI. |
+| `phase_02_train_opt_mlflow_experiment_name` | `str` | `""` | MLflow experiment name. |
+| `phase_02_train_opt_mlflow_run_name` | `str` | `""` | MLflow run name. |
 | `phase_03_eval_opt_batch` | `str` | `auto` | Batch size for evaluation (auto or int). |
 | `phase_03_eval_opt_gen_kwargs` | `dict` | `{}` | Generation kwargs for evaluation. |
 | `phase_03_eval_opt_limit` | `int` | `-1` | Limit examples per task (-1 = no limit). |

--- a/pipelines/training/finetuning/sft/pipeline.py
+++ b/pipelines/training/finetuning/sft/pipeline.py
@@ -85,6 +85,9 @@ def sft_pipeline(
     phase_02_train_opt_seed: int = 42,
     phase_02_train_opt_use_liger: bool = False,
     phase_02_train_opt_runtime: str = "training-hub",
+    phase_02_train_opt_mlflow_tracking_uri: str = "",
+    phase_02_train_opt_mlflow_experiment_name: str = "",
+    phase_02_train_opt_mlflow_run_name: str = "",
     phase_03_eval_opt_batch: str = "auto",
     phase_03_eval_opt_gen_kwargs: dict = {},
     phase_03_eval_opt_limit: int = -1,
@@ -137,6 +140,9 @@ def sft_pipeline(
         phase_02_train_opt_seed: Random seed for reproducibility.
         phase_02_train_opt_use_liger: Enable Liger kernel optimizations.
         phase_02_train_opt_runtime: Name of the ClusterTrainingRuntime to use.
+        phase_02_train_opt_mlflow_tracking_uri: MLflow tracking server URI.
+        phase_02_train_opt_mlflow_experiment_name: MLflow experiment name.
+        phase_02_train_opt_mlflow_run_name: MLflow run name.
         phase_03_eval_opt_batch: Batch size for evaluation (auto or int).
         phase_03_eval_opt_gen_kwargs: Generation kwargs for evaluation.
         phase_03_eval_opt_limit: Limit examples per task (-1 = no limit).
@@ -207,6 +213,10 @@ def sft_pipeline(
         training_resource_num_procs_per_worker=phase_02_train_opt_num_procs,
         training_resource_num_workers=phase_02_train_man_workers,
         training_runtime=phase_02_train_opt_runtime,
+        # MLflow
+        training_mlflow_tracking_uri=phase_02_train_opt_mlflow_tracking_uri,
+        training_mlflow_experiment_name=phase_02_train_opt_mlflow_experiment_name,
+        training_mlflow_run_name=phase_02_train_opt_mlflow_run_name,
     )
     training_task.set_caching_options(False)
     kfp.kubernetes.set_image_pull_policy(training_task, "IfNotPresent")

--- a/pipelines/training/finetuning/sft_minimal/README.md
+++ b/pipelines/training/finetuning/sft_minimal/README.md
@@ -33,6 +33,9 @@ A 4-stage ML pipeline for fine-tuning language models:
 | `phase_02_train_opt_fsdp_sharding` | `str` | `FULL_SHARD` | FSDP strategy (FULL_SHARD, HYBRID_SHARD, NO_SHARD) |
 | `phase_02_train_opt_use_liger` | `bool` | `False` | Enable Liger kernel optimizations |
 | `phase_02_train_opt_runtime` | `str` | `training-hub` | Name of the ClusterTrainingRuntime to use. |
+| `phase_02_train_opt_mlflow_tracking_uri` | `str` | `""` | MLflow tracking server URI. |
+| `phase_02_train_opt_mlflow_experiment_name` | `str` | `""` | MLflow experiment name. |
+| `phase_02_train_opt_mlflow_run_name` | `str` | `""` | MLflow run name. |
 | `phase_04_registry_opt_port` | `int` | `8080` | Model Registry server port. |
 
 ## Metadata 🗂️

--- a/pipelines/training/finetuning/sft_minimal/pipeline.py
+++ b/pipelines/training/finetuning/sft_minimal/pipeline.py
@@ -82,6 +82,9 @@ def sft_minimal_pipeline(
     phase_02_train_opt_fsdp_sharding: str = "FULL_SHARD",
     phase_02_train_opt_use_liger: bool = False,
     phase_02_train_opt_runtime: str = "training-hub",
+    phase_02_train_opt_mlflow_tracking_uri: str = "",
+    phase_02_train_opt_mlflow_experiment_name: str = "",
+    phase_02_train_opt_mlflow_run_name: str = "",
     phase_04_registry_opt_port: int = 8080,
 ):
     """SFT Training Pipeline - Standard supervised fine-tuning with instructlab-training.
@@ -112,6 +115,9 @@ def sft_minimal_pipeline(
         phase_02_train_opt_fsdp_sharding: FSDP strategy (FULL_SHARD, HYBRID_SHARD, NO_SHARD)
         phase_02_train_opt_use_liger: Enable Liger kernel optimizations
         phase_02_train_opt_runtime: Name of the ClusterTrainingRuntime to use.
+        phase_02_train_opt_mlflow_tracking_uri: MLflow tracking server URI.
+        phase_02_train_opt_mlflow_experiment_name: MLflow experiment name.
+        phase_02_train_opt_mlflow_run_name: MLflow run name.
         phase_04_registry_opt_port: Model Registry server port.
     """
     # =========================================================================
@@ -170,6 +176,10 @@ def sft_minimal_pipeline(
         training_resource_num_procs_per_worker="auto",
         training_resource_num_workers=phase_02_train_man_workers,
         training_runtime=phase_02_train_opt_runtime,
+        # MLflow
+        training_mlflow_tracking_uri=phase_02_train_opt_mlflow_tracking_uri,
+        training_mlflow_experiment_name=phase_02_train_opt_mlflow_experiment_name,
+        training_mlflow_run_name=phase_02_train_opt_mlflow_run_name,
     )
     training_task.set_caching_options(False)
     kfp.kubernetes.set_image_pull_policy(training_task, "IfNotPresent")


### PR DESCRIPTION
## Summary

- Add MLflow tracking parameters (`tracking_uri`, `experiment_name`, `run_name`) to SFT and OSFT training components, matching the existing LoRA pattern
- Wire MLflow params through all 6 finetuning pipelines (LoRA, SFT, OSFT + minimal variants)
- Fix LoRA component's `get_training_metrics()` to extract metrics from `training_metrics.jsonl`

These optional parameters allow users to pass through MLflow configuration to the training_hub backend, which handles logging per-step training metrics (loss curves, learning rate schedules, gradient norms) to an MLflow tracking server.

[RHOAIENG-56159](https://redhat.atlassian.net/browse/RHOAIENG-56159)

## Verification

- [x] Component unit tests pass (28/28) — `PYTHONPATH=. uv run pytest components/training/finetuning_algorithms/{lora,sft,osft}/tests/ -v`
- [x] Pipeline compile tests pass (12/12) — `PYTHONPATH=. uv run pytest pipelines/training/finetuning/ -v`
- [x] READMEs are in sync — `PYTHONPATH=. uv run python scripts/generate_readme/cli.py --component/--pipeline <path>`

## Test plan

- [ ] Deploy MLflow on cluster (available as RHOAI 3.4 component)
- [ ] Run SFT minimal pipeline with MLflow params:
  ```json
  {
    "phase_01_dataset_man_data_uri": "hf://HuggingFaceH4/ultrafeedback_binarized",
    "phase_01_dataset_opt_subset": 100,
    "phase_02_train_man_workers": 1,
    "phase_02_train_man_gpu": 1,
    "phase_02_train_man_epochs": 1,
    "phase_02_train_opt_mlflow_tracking_uri": "<cluster MLflow URI>",
    "phase_02_train_opt_mlflow_experiment_name": "sft-test",
    "phase_02_train_opt_mlflow_run_name": "sft-run-1"
  }
  ```
- [ ] Run LoRA minimal pipeline with same MLflow params
- [ ] Run OSFT minimal pipeline with same MLflow params
- [ ] Confirm per-step training metrics (loss, learning rate, gradient norm) appear in MLflow UI for each run
- [ ] Confirm pipelines still work correctly when MLflow params are left empty (default behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MLflow tracking options added to training (tracking URI, experiment name, run name) across SFT, OSFT, and LoRA pipelines.
  * Training pods can auto-configure MLflow auth/environment when a tracking URI is provided.
* **Improvements**
  * LoRA training now discovers and parses training metrics via recursive file search.
* **Bug Fixes**
  * Tracking URI validation added to catch invalid URIs and reject embedded credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->