### PR TITLE
ci: support stable branch in container-build

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -31,6 +31,7 @@ env:
   IMAGE_PREFIX: ghcr.io/kubeflow/pipelines-components
   SHOULD_PUSH: >-
     ${{ github.ref == 'refs/heads/main' ||
+        github.ref == 'refs/heads/stable' ||
         startsWith(github.ref, 'refs/heads/release-') ||
         startsWith(github.ref, 'refs/tags/v') }}
   PYTHONPATH: ${{ github.workspace }}
@@ -82,6 +83,7 @@ jobs:
             type=sha,prefix=,format=long,enable=${{ github.event_name == 'pull_request' }}
             type=ref,event=tag
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=stable,enable=${{ github.ref == 'refs/heads/stable' }}
 
       - name: Determine container build file (Containerfile or Dockerfile)
         id: buildfile
@@ -184,6 +186,8 @@ jobs:
           fi
 
           if [[ "$BRANCH" == "main" ]]; then
+            echo "tag=main" >> "$GITHUB_OUTPUT"
+          elif [[ "$BRANCH" == "stable" ]]; then
             echo "tag=main" >> "$GITHUB_OUTPUT"
           elif [[ "$BRANCH" =~ ^release-([0-9]+\.[0-9]+)$ ]]; then
             # Release branch release-1.11 expects tag v1.11.0


### PR DESCRIPTION
**Description of your changes:**

- `SHOULD_PUSH` – Includes `github.ref == 'refs/heads/stable' `so pushes on stable can publish to GHCR (with QEMU/login/multi-arch as before).
- docker/metadata-action tags – type=raw,value=stable when the ref is refs/heads/stable.
- Determine expected base_image tag – For base branch stable, expected tag is main (same as the main branch for check_base_image_tags).
 
**Checklist:**

### Pre-Submission Checklist

- [ ] All tests and CI checks pass
- [ ] Pre-commit hooks pass without errors
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
