### PR TITLE
fix(components, AutoML): align model.json between tabular and timeseries

### DIFF
--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -145,7 +145,8 @@ Each model directory contains a `model.json` file with the model's metadata, mat
   "location": {
     "model_directory": "LightGBM_BAG_L1_FULL",
     "predictor": "LightGBM_BAG_L1_FULL/predictor",
-    "notebook": "LightGBM_BAG_L1_FULL/notebooks/automl_predictor_notebook.ipynb"
+    "notebooks": "LightGBM_BAG_L1_FULL/notebooks/automl_predictor_notebook.ipynb",
+    "metrics": "LightGBM_BAG_L1_FULL/metrics"
   },
   "metrics": {
     "test_data": {"root_mean_squared_error": 0.42, "r2": 0.85}
@@ -179,7 +180,7 @@ Each entry in **`context.models`** contains:
 | Key | Type | Description |
 | --- | ---- | ----------- |
 | `name` | `str` | Model name with `_FULL` suffix (e.g. `"LightGBM_BAG_L1_FULL"`). |
-| `location` | `dict` | Paths relative to `models_artifact.path`: `model_directory`, `predictor`, `notebook`. |
+| `location` | `dict` | Paths relative to `models_artifact.path`: `model_directory`, `predictor`, `notebooks`, `metrics`. |
 | `metrics` | `dict` | `test_data` — evaluation results dict from `evaluate_predictions` (metric names → values). |
 
 Example:
@@ -201,7 +202,8 @@ Example:
         "location": {
           "model_directory": "LightGBM_BAG_L1_FULL",
           "predictor": "LightGBM_BAG_L1_FULL/predictor",
-          "notebook": "LightGBM_BAG_L1_FULL/notebooks/automl_predictor_notebook.ipynb"
+          "notebooks": "LightGBM_BAG_L1_FULL/notebooks/automl_predictor_notebook.ipynb",
+          "metrics": "LightGBM_BAG_L1_FULL/metrics"
         },
         "metrics": {
           "test_data": {"root_mean_squared_error": 0.42, "r2": 0.85}
@@ -212,7 +214,8 @@ Example:
         "location": {
           "model_directory": "CatBoost_BAG_L1_FULL",
           "predictor": "CatBoost_BAG_L1_FULL/predictor",
-          "notebook": "CatBoost_BAG_L1_FULL/notebooks/automl_predictor_notebook.ipynb"
+          "notebooks": "CatBoost_BAG_L1_FULL/notebooks/automl_predictor_notebook.ipynb",
+          "metrics": "CatBoost_BAG_L1_FULL/metrics"
         },
         "metrics": {
           "test_data": {"root_mean_squared_error": 0.51, "r2": 0.80}

--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -145,7 +145,7 @@ Each model directory contains a `model.json` file with the model's metadata, mat
   "location": {
     "model_directory": "LightGBM_BAG_L1_FULL",
     "predictor": "LightGBM_BAG_L1_FULL/predictor",
-    "notebooks": "LightGBM_BAG_L1_FULL/notebooks/automl_predictor_notebook.ipynb",
+    "notebook": "LightGBM_BAG_L1_FULL/notebooks/automl_predictor_notebook.ipynb",
     "metrics": "LightGBM_BAG_L1_FULL/metrics"
   },
   "metrics": {
@@ -180,7 +180,7 @@ Each entry in **`context.models`** contains:
 | Key | Type | Description |
 | --- | ---- | ----------- |
 | `name` | `str` | Model name with `_FULL` suffix (e.g. `"LightGBM_BAG_L1_FULL"`). |
-| `location` | `dict` | Paths relative to `models_artifact.path`: `model_directory`, `predictor`, `notebooks`, `metrics`. |
+| `location` | `dict` | Paths relative to `models_artifact.path`: `model_directory`, `predictor`, `notebook`, `metrics`. |
 | `metrics` | `dict` | `test_data` — evaluation results dict from `evaluate_predictions` (metric names → values). |
 
 Example:
@@ -202,7 +202,7 @@ Example:
         "location": {
           "model_directory": "LightGBM_BAG_L1_FULL",
           "predictor": "LightGBM_BAG_L1_FULL/predictor",
-          "notebooks": "LightGBM_BAG_L1_FULL/notebooks/automl_predictor_notebook.ipynb",
+          "notebook": "LightGBM_BAG_L1_FULL/notebooks/automl_predictor_notebook.ipynb",
           "metrics": "LightGBM_BAG_L1_FULL/metrics"
         },
         "metrics": {
@@ -214,7 +214,7 @@ Example:
         "location": {
           "model_directory": "CatBoost_BAG_L1_FULL",
           "predictor": "CatBoost_BAG_L1_FULL/predictor",
-          "notebooks": "CatBoost_BAG_L1_FULL/notebooks/automl_predictor_notebook.ipynb",
+          "notebook": "CatBoost_BAG_L1_FULL/notebooks/automl_predictor_notebook.ipynb",
           "metrics": "CatBoost_BAG_L1_FULL/metrics"
         },
         "metrics": {

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -316,7 +316,8 @@ def autogluon_models_training(
             "location": {
                 "model_directory": model_name_full,
                 "predictor": str(Path(model_name_full) / "predictor"),
-                "notebook": str(Path(model_name_full) / "notebooks" / "automl_predictor_notebook.ipynb"),
+                "notebooks": str(Path(model_name_full) / "notebooks" / "automl_predictor_notebook.ipynb"),
+                "metrics": str(Path(model_name_full) / "metrics"),
             },
             "metrics": {
                 "test_data": eval_results,

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -316,7 +316,7 @@ def autogluon_models_training(
             "location": {
                 "model_directory": model_name_full,
                 "predictor": str(Path(model_name_full) / "predictor"),
-                "notebooks": str(Path(model_name_full) / "notebooks" / "automl_predictor_notebook.ipynb"),
+                "notebook": str(Path(model_name_full) / "notebooks" / "automl_predictor_notebook.ipynb"),
                 "metrics": str(Path(model_name_full) / "metrics"),
             },
             "metrics": {

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -265,7 +265,8 @@ class TestAutogluonModelsTrainingUnitTests:
             assert model_meta["name"] == model_name_full
             assert model_meta["location"]["model_directory"] == model_name_full
             assert "predictor" in model_meta["location"]
-            assert "notebook" in model_meta["location"]
+            assert "notebooks" in model_meta["location"]
+            assert "metrics" in model_meta["location"]
             assert "test_data" in model_meta["metrics"]
             nb_path = Path(models_output_dir) / model_name_full / "notebooks" / "automl_predictor_notebook.ipynb"
             assert nb_path.exists()
@@ -620,18 +621,20 @@ class TestAutogluonModelsTrainingUnitTests:
         assert lgbm["name"] == "LightGBM_BAG_L1_FULL"
         assert lgbm["location"]["model_directory"] == "LightGBM_BAG_L1_FULL"
         assert lgbm["location"]["predictor"] == str(Path("LightGBM_BAG_L1_FULL") / "predictor")
-        assert lgbm["location"]["notebook"] == str(
+        assert lgbm["location"]["notebooks"] == str(
             Path("LightGBM_BAG_L1_FULL") / "notebooks" / "automl_predictor_notebook.ipynb"
         )
+        assert lgbm["location"]["metrics"] == str(Path("LightGBM_BAG_L1_FULL") / "metrics")
         assert lgbm["metrics"]["test_data"] == {"r2": 0.9, "root_mean_squared_error": 0.31}
 
         cat = models[1]
         assert cat["name"] == "CatBoost_BAG_L1_FULL"
         assert cat["location"]["model_directory"] == "CatBoost_BAG_L1_FULL"
         assert cat["location"]["predictor"] == str(Path("CatBoost_BAG_L1_FULL") / "predictor")
-        assert cat["location"]["notebook"] == str(
+        assert cat["location"]["notebooks"] == str(
             Path("CatBoost_BAG_L1_FULL") / "notebooks" / "automl_predictor_notebook.ipynb"
         )
+        assert cat["location"]["metrics"] == str(Path("CatBoost_BAG_L1_FULL") / "metrics")
         assert cat["metrics"]["test_data"] == {"r2": 0.85, "root_mean_squared_error": 0.42}
 
         # Shared context fields still present alongside models

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -265,7 +265,7 @@ class TestAutogluonModelsTrainingUnitTests:
             assert model_meta["name"] == model_name_full
             assert model_meta["location"]["model_directory"] == model_name_full
             assert "predictor" in model_meta["location"]
-            assert "notebooks" in model_meta["location"]
+            assert "notebook" in model_meta["location"]
             assert "metrics" in model_meta["location"]
             assert "test_data" in model_meta["metrics"]
             nb_path = Path(models_output_dir) / model_name_full / "notebooks" / "automl_predictor_notebook.ipynb"
@@ -621,7 +621,7 @@ class TestAutogluonModelsTrainingUnitTests:
         assert lgbm["name"] == "LightGBM_BAG_L1_FULL"
         assert lgbm["location"]["model_directory"] == "LightGBM_BAG_L1_FULL"
         assert lgbm["location"]["predictor"] == str(Path("LightGBM_BAG_L1_FULL") / "predictor")
-        assert lgbm["location"]["notebooks"] == str(
+        assert lgbm["location"]["notebook"] == str(
             Path("LightGBM_BAG_L1_FULL") / "notebooks" / "automl_predictor_notebook.ipynb"
         )
         assert lgbm["location"]["metrics"] == str(Path("LightGBM_BAG_L1_FULL") / "metrics")
@@ -631,7 +631,7 @@ class TestAutogluonModelsTrainingUnitTests:
         assert cat["name"] == "CatBoost_BAG_L1_FULL"
         assert cat["location"]["model_directory"] == "CatBoost_BAG_L1_FULL"
         assert cat["location"]["predictor"] == str(Path("CatBoost_BAG_L1_FULL") / "predictor")
-        assert cat["location"]["notebooks"] == str(
+        assert cat["location"]["notebook"] == str(
             Path("CatBoost_BAG_L1_FULL") / "notebooks" / "automl_predictor_notebook.ipynb"
         )
         assert cat["location"]["metrics"] == str(Path("CatBoost_BAG_L1_FULL") / "metrics")

--- a/components/training/automl/autogluon_timeseries_models_full_refit/README.md
+++ b/components/training/automl/autogluon_timeseries_models_full_refit/README.md
@@ -7,7 +7,7 @@
 Refit a single AutoGluon timeseries model on full training data.
 
 This component takes a model selected during the selection phase and refits it on the full training dataset (selection + extra train data) for improved performance. The refitted model is optimized and saved for deployment. Each model directory contains a ``model.json`` file with model metadata
-(name, base model, location, metrics).
+(name, location, metrics).
 
 ## Inputs 📥
 
@@ -113,7 +113,7 @@ The refitted model artifact is written under `model_artifact.path` with the foll
 ```text
 model_artifact/
 └── <ModelName>_FULL/              # e.g. ETS_FULL
-    ├── model.json                 # Model metadata (name, base_model, location, metrics)
+    ├── model.json                 # Model metadata (name, location, metrics)
     ├── predictor/                 # AutoGluon TimeSeriesPredictor files
     │   ├── predictor.pkl
     │   └── predictor_metadata.json
@@ -130,12 +130,11 @@ Each model directory contains a `model.json` file with the model's metadata:
 ```json
 {
   "name": "ETS_FULL",
-  "base_model": "ETS",
   "location": {
     "model_directory": "ETS_FULL",
     "predictor": "ETS_FULL/predictor",
-    "metrics": "ETS_FULL/metrics",
-    "notebooks": "ETS_FULL/notebooks"
+    "notebooks": "ETS_FULL/notebooks/automl_predictor_notebook.ipynb",
+    "metrics": "ETS_FULL/metrics"
   },
   "metrics": {
     "test_data": {"MASE": -0.85, "WAPE": -0.12, "RMSE": -150.3}

--- a/components/training/automl/autogluon_timeseries_models_full_refit/README.md
+++ b/components/training/automl/autogluon_timeseries_models_full_refit/README.md
@@ -133,7 +133,7 @@ Each model directory contains a `model.json` file with the model's metadata:
   "location": {
     "model_directory": "ETS_FULL",
     "predictor": "ETS_FULL/predictor",
-    "notebooks": "ETS_FULL/notebooks/automl_predictor_notebook.ipynb",
+    "notebook": "ETS_FULL/notebooks/automl_predictor_notebook.ipynb",
     "metrics": "ETS_FULL/metrics"
   },
   "metrics": {

--- a/components/training/automl/autogluon_timeseries_models_full_refit/component.py
+++ b/components/training/automl/autogluon_timeseries_models_full_refit/component.py
@@ -31,7 +31,7 @@ def autogluon_timeseries_models_full_refit(
     refits it on the full training dataset (selection + extra train data)
     for improved performance. The refitted model is optimized and saved
     for deployment. Each model directory contains a ``model.json`` file
-    with model metadata (name, base model, location, metrics).
+    with model metadata (name, location, metrics).
 
     Args:
         model_name: Name of the model to refit.
@@ -251,12 +251,11 @@ def autogluon_timeseries_models_full_refit(
     # Write model.json alongside predictor/, metrics/, notebooks/
     model_metadata = {
         "name": model_name_full,
-        "base_model": model_name,
         "location": {
             "model_directory": model_name_full,
             "predictor": f"{model_name_full}/predictor",
+            "notebooks": f"{model_name_full}/notebooks/automl_predictor_notebook.ipynb",
             "metrics": f"{model_name_full}/metrics",
-            "notebooks": f"{model_name_full}/notebooks",
         },
         "metrics": {
             "test_data": metrics_dict,
@@ -275,8 +274,8 @@ def autogluon_timeseries_models_full_refit(
         "location": {
             "model_directory": model_name_full,
             "predictor": f"{model_name_full}/predictor",
+            "notebooks": f"{model_name_full}/notebooks/automl_predictor_notebook.ipynb",
             "metrics": f"{model_name_full}/metrics",
-            "notebooks": f"{model_name_full}/notebooks",
         },
         "pipeline_info": {
             "pipeline_name": pipeline_name,

--- a/components/training/automl/autogluon_timeseries_models_full_refit/component.py
+++ b/components/training/automl/autogluon_timeseries_models_full_refit/component.py
@@ -254,7 +254,7 @@ def autogluon_timeseries_models_full_refit(
         "location": {
             "model_directory": model_name_full,
             "predictor": f"{model_name_full}/predictor",
-            "notebooks": f"{model_name_full}/notebooks/automl_predictor_notebook.ipynb",
+            "notebook": f"{model_name_full}/notebooks/automl_predictor_notebook.ipynb",
             "metrics": f"{model_name_full}/metrics",
         },
         "metrics": {
@@ -274,7 +274,7 @@ def autogluon_timeseries_models_full_refit(
         "location": {
             "model_directory": model_name_full,
             "predictor": f"{model_name_full}/predictor",
-            "notebooks": f"{model_name_full}/notebooks/automl_predictor_notebook.ipynb",
+            "notebook": f"{model_name_full}/notebooks/automl_predictor_notebook.ipynb",
             "metrics": f"{model_name_full}/metrics",
         },
         "pipeline_info": {

--- a/components/training/automl/autogluon_timeseries_models_full_refit/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_full_refit/tests/test_component_unit.py
@@ -228,11 +228,11 @@ class TestTimeseriesModelsFullRefitUnitTests:
         assert model_json_path.exists()
         model_meta = json.loads(model_json_path.read_text(encoding="utf-8"))
         assert model_meta["name"] == "DeepAR_FULL"
-        assert model_meta["base_model"] == "DeepAR"
+        assert "base_model" not in model_meta
         assert model_meta["location"]["model_directory"] == "DeepAR_FULL"
         assert "predictor" in model_meta["location"]
-        assert "metrics" in model_meta["location"]
-        assert "notebooks" in model_meta["location"]
+        assert model_meta["location"]["notebooks"] == "DeepAR_FULL/notebooks/automl_predictor_notebook.ipynb"
+        assert model_meta["location"]["metrics"] == "DeepAR_FULL/metrics"
         assert model_meta["metrics"]["test_data"] == {"MASE": 1.23}
 
         assert model_artifact.metadata["display_name"] == "DeepAR_FULL"

--- a/components/training/automl/autogluon_timeseries_models_full_refit/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_full_refit/tests/test_component_unit.py
@@ -231,7 +231,7 @@ class TestTimeseriesModelsFullRefitUnitTests:
         assert "base_model" not in model_meta
         assert model_meta["location"]["model_directory"] == "DeepAR_FULL"
         assert "predictor" in model_meta["location"]
-        assert model_meta["location"]["notebooks"] == "DeepAR_FULL/notebooks/automl_predictor_notebook.ipynb"
+        assert model_meta["location"]["notebook"] == "DeepAR_FULL/notebooks/automl_predictor_notebook.ipynb"
         assert model_meta["location"]["metrics"] == "DeepAR_FULL/metrics"
         assert model_meta["metrics"]["test_data"] == {"MASE": 1.23}
 


### PR DESCRIPTION
Assisted-by: Claude Code

**Description of your changes:**
Align model.json schema between tabular and timeseries components
                                                                                                                                                                                                                                 
  This PR aligns the model.json artifact schema produced by the tabular (autogluon_models_training) and timeseries (autogluon_timeseries_models_full_refit) components so both use the same field names and structure under
  location.                                                                                                                                                                                                                      
                  
  Tabular component (autogluon_models_training)                                                                                                                                                                                  
                  
  - Renamed location.notebook → location.notebooks to match the timeseries schema.                                                                                                                                               
  - Added location.metrics pointing to <model_name_full>/metrics, which was previously absent from tabular but present in timeseries.
                                                                                                                                                                                                                                 
  Timeseries component (autogluon_timeseries_models_full_refit)                                                                                                                                                                  
                                                                                                                                                                                                                                 
  - Changed location.notebooks from a directory path (ETS_FULL/notebooks) to a specific file path (ETS_FULL/notebooks/automl_predictor_notebook.ipynb), matching the tabular pattern.                                            
  - Removed the base_model field from model.json (the original model name without the _FULL suffix), which had no equivalent in the tabular schema.
                                                                                                                                                                                                                                 
  After these changes both schemas are:                                                                                                                                                                                          
   
```python                                                                                                                                                                                                                              
  {                                                                                                                                                                                                                              
    "name": "<ModelName>_FULL",
    "location": {
      "model_directory": "<ModelName>_FULL",                                                                                                                                                                                     
      "predictor": "<ModelName>_FULL/predictor",                                                                                                                                                                                 
      "notebook": "<ModelName>_FULL/notebooks/automl_predictor_notebook.ipynb",                                                                                                                                                 
      "metrics": "<ModelName>_FULL/metrics"                                                                                                                                                                                      
    },                                                                                                                                                                                                                           
    "metrics": {                                                                                                                                                                                                                 
      "test_data": { ... }                                                                                                                                                                                                       
    }             
  }                       
```                                                                                                                                                                                                       
   
  Unit tests and README docs updated accordingly for both components.  

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated model metadata documentation to properly reflect structured path tracking for generated notebooks and evaluation metrics across all model types.

* **Bug Fixes**
  * Refined model artifact location references by replacing directory paths with specific file locations; removed obsolete base_model metadata field from full-refit model artifacts.

* **Tests**
  * Updated test suites to validate new model metadata structure, field requirements, and path specifications across training components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->