### PR TITLE
fix: AutoRAG S3 secrets - make `AWS_DEFAULT_REGION` optional

### DIFF
--- a/components/data_processing/autorag/documents_discovery/component.py
+++ b/components/data_processing/autorag/documents_discovery/component.py
@@ -27,7 +27,8 @@ def documents_discovery(
         discovered_documents: Output artifact containing the documents descriptor JSON file.
 
     Environment variables (required when run with pipeline secret injection):
-        AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT, AWS_DEFAULT_REGION.
+        AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT.
+        AWS_DEFAULT_REGION is optional.
     """
     import json
     import logging
@@ -64,13 +65,11 @@ def documents_discovery(
     """Validate S3 credentials, list objects, sample, and write JSON descriptor."""
     from botocore.exceptions import SSLError
 
-    s3_creds = {
-        k: os.environ.get(k)
-        for k in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_S3_ENDPOINT", "AWS_DEFAULT_REGION"]
-    }
+    s3_creds = {k: os.environ.get(k) for k in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_S3_ENDPOINT"]}
     for k, v in s3_creds.items():
         if v is None:
             raise ValueError("%s environment variable not set. Check if kubernetes secret was configured properly" % k)
+    s3_creds["AWS_DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION")
 
     def _make_s3_client(verify=True):
         return boto3.client(

--- a/components/data_processing/autorag/documents_discovery/tests/test_component_unit.py
+++ b/components/data_processing/autorag/documents_discovery/tests/test_component_unit.py
@@ -15,6 +15,11 @@ MOCKED_ENV_VARIABLES = {
     "AWS_S3_ENDPOINT": "https://s3.example.com",
     "AWS_DEFAULT_REGION": "us-east-1",
 }
+MOCKED_ENV_VARIABLES_NO_REGION = {
+    "AWS_ACCESS_KEY_ID": "test_key",
+    "AWS_SECRET_ACCESS_KEY": "test_secret",
+    "AWS_S3_ENDPOINT": "https://s3.example.com",
+}
 
 
 class _MockSSLError(Exception):
@@ -83,6 +88,38 @@ class TestDocumentsDiscoveryUnitTests:
         assert payload["bucket"] == "my-bucket"
         assert payload["count"] == 2
         assert payload["total_size_bytes"] == 3000
+
+    @mock.patch.dict("os.environ", MOCKED_ENV_VARIABLES_NO_REGION, clear=True)
+    def test_missing_region_is_allowed(self, tmp_path):
+        """Component works when AWS_DEFAULT_REGION is not present."""
+        mock_boto3 = mock.MagicMock()
+        mock_s3 = mock.MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": [{"Key": "docs/a.pdf", "Size": 1000}]}
+        mock_boto3.client.return_value = mock_s3
+        mock_botocore, mock_botocore_exceptions = _make_botocore_modules()
+
+        discovered = mock.MagicMock()
+        discovered.path = str(tmp_path / "descriptor")
+
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "boto3": mock_boto3,
+                "botocore": mock_botocore,
+                "botocore.exceptions": mock_botocore_exceptions,
+            },
+        ):
+            documents_discovery.python_func(
+                input_data_bucket_name="my-bucket",
+                input_data_path="docs/",
+                discovered_documents=discovered,
+                sampling_enabled=False,
+            )
+
+        client_kwargs = mock_boto3.client.call_args.kwargs
+        assert client_kwargs["region_name"] is None
+        descriptor_file = tmp_path / "descriptor" / "documents_descriptor.json"
+        assert descriptor_file.exists()
 
     @mock.patch.dict("os.environ", MOCKED_ENV_VARIABLES, clear=True)
     def test_ssl_error_retries_with_verify_false(self, tmp_path):

--- a/components/data_processing/autorag/test_data_loader/component.py
+++ b/components/data_processing/autorag/test_data_loader/component.py
@@ -21,7 +21,8 @@ def test_data_loader(test_data_bucket_name: str, test_data_path: str, test_data:
         test_data: Output artifact that receives the downloaded file.
 
     Environment variables (required when run with pipeline secret injection):
-        AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT, AWS_DEFAULT_REGION.
+        AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT.
+        AWS_DEFAULT_REGION is optional.
 
     Raises:
         ValueError: If S3 credentials are missing or misconfigured.
@@ -50,15 +51,13 @@ def test_data_loader(test_data_bucket_name: str, test_data_path: str, test_data:
         class TestDataLoaderException(Exception):
             pass
 
-        s3_creds = {
-            k: os.environ.get(k)
-            for k in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_S3_ENDPOINT", "AWS_DEFAULT_REGION"]
-        }
+        s3_creds = {k: os.environ.get(k) for k in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_S3_ENDPOINT"]}
         for k, v in s3_creds.items():
             if v is None:
                 raise ValueError(
                     "%s environment variable not set. Check if kubernetes secret was configured properly" % k
                 )
+        s3_creds["AWS_DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION")
 
         def _make_s3_client(verify=True):
             return boto3.client(

--- a/components/data_processing/autorag/test_data_loader/tests/test_component_unit.py
+++ b/components/data_processing/autorag/test_data_loader/tests/test_component_unit.py
@@ -15,6 +15,11 @@ MOCKED_ENV_VARIABLES = {
     "AWS_S3_ENDPOINT": "https://s3.example.com",
     "AWS_DEFAULT_REGION": "us-east-1",
 }
+MOCKED_ENV_VARIABLES_NO_REGION = {
+    "AWS_ACCESS_KEY_ID": "test_key",
+    "AWS_SECRET_ACCESS_KEY": "test_secret",
+    "AWS_S3_ENDPOINT": "https://s3.example.com",
+}
 
 
 class _MockSSLError(Exception):
@@ -90,6 +95,43 @@ class TestTestDataLoaderUnitTests:
         assert out_path.exists()
         assert json.loads(out_path.read_text(encoding="utf-8"))["dataset"] == "ok"
         mock_s3.download_file.assert_called_once()
+
+    @mock.patch.dict("os.environ", MOCKED_ENV_VARIABLES_NO_REGION, clear=True)
+    def test_missing_region_is_allowed(self, tmp_path):
+        """Component works when AWS_DEFAULT_REGION is not present."""
+        mock_boto3 = mock.MagicMock()
+        mock_s3 = mock.MagicMock()
+
+        out_path = tmp_path / "test_data.json"
+
+        def _write_valid_json(_bucket, _key, destination):
+            with open(destination, "w", encoding="utf-8") as f:
+                json.dump({"dataset": "ok"}, f)
+
+        mock_s3.download_file.side_effect = _write_valid_json
+        mock_boto3.client.return_value = mock_s3
+
+        mock_botocore, mock_botocore_exceptions = _mock_botocore_modules()
+        test_data_artifact = mock.MagicMock()
+        test_data_artifact.path = str(out_path)
+
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "boto3": mock_boto3,
+                "botocore": mock_botocore,
+                "botocore.exceptions": mock_botocore_exceptions,
+            },
+        ):
+            test_data_loader.python_func(
+                test_data_bucket_name="my-bucket",
+                test_data_path="data/test.json",
+                test_data=test_data_artifact,
+            )
+
+        client_kwargs = mock_boto3.client.call_args.kwargs
+        assert client_kwargs["region_name"] is None
+        assert out_path.exists()
 
     @mock.patch.dict("os.environ", MOCKED_ENV_VARIABLES, clear=True)
     def test_ssl_error_retries_with_verify_false(self, tmp_path):

--- a/components/data_processing/autorag/text_extraction/component.py
+++ b/components/data_processing/autorag/text_extraction/component.py
@@ -60,7 +60,7 @@ def text_extraction(
     for k, v in s3_creds.items():
         if v is None:
             raise ValueError(f"{k} environment variable not set. Check if kubernetes secret was configured properly.")
-    s3_creds["AWS_DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION", "")
+    s3_creds["AWS_DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION")
 
     logger = logging.getLogger("Text Extraction component logger")
     logger.setLevel(logging.INFO)

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/README.md
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/README.md
@@ -16,10 +16,10 @@ The system integrates with llama-stack API for inference and vector database ope
 
 | Parameter | Type | Default | Description |
 | --------- | ---- | ------- | ----------- |
-| `test_data_secret_name` | `str` | `None` | Name of the Kubernetes secret holding S3-compatible credentials for test data access. The following environment variables are required: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT, AWS_DEFAULT_REGION. |
+| `test_data_secret_name` | `str` | `None` | Name of the Kubernetes secret holding S3-compatible credentials for test data access. The following environment variables are required: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT. AWS_DEFAULT_REGION is optional. |
 | `test_data_bucket_name` | `str` | `None` | S3 (or compatible) bucket name for the test data file. |
 | `test_data_key` | `str` | `None` | Object key (path) of the test data JSON file in the test data bucket. |
-| `input_data_secret_name` | `str` | `None` | Name of the Kubernetes secret holding S3-compatible credentials for input document data access. The following environment variables are required: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT, AWS_DEFAULT_REGION. |
+| `input_data_secret_name` | `str` | `None` | Name of the Kubernetes secret holding S3-compatible credentials for input document data access. The following environment variables are required: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT. AWS_DEFAULT_REGION is optional. |
 | `input_data_bucket_name` | `str` | `None` | S3 (or compatible) bucket name for the input documents. |
 | `llama_stack_secret_name` | `str` | `None` | Name of the Kubernetes secret for llama-stack API connection. The secret must define: LLAMA_STACK_CLIENT_API_KEY, LLAMA_STACK_CLIENT_BASE_URL. |
 | `llama_stack_vector_io_provider_id` | `str` | `None` | Vector I/O provider id (e.g., registered in llama-stack Milvus). |

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/pipeline.py
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/pipeline.py
@@ -64,12 +64,14 @@ def documents_rag_optimization_pipeline(
     Args:
         test_data_secret_name: Name of the Kubernetes secret holding S3-compatible credentials for
             test data access. The following environment variables are required:
-            AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT, AWS_DEFAULT_REGION.
+            AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT.
+            AWS_DEFAULT_REGION is optional.
         test_data_bucket_name: S3 (or compatible) bucket name for the test data file.
         test_data_key: Object key (path) of the test data JSON file in the test data bucket.
         input_data_secret_name: Name of the Kubernetes secret holding S3-compatible credentials
             for input document data access. The following environment variables are required:
-            AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT, AWS_DEFAULT_REGION.
+            AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT.
+            AWS_DEFAULT_REGION is optional.
         input_data_bucket_name: S3 (or compatible) bucket name for the input documents.
         llama_stack_secret_name: Name of the Kubernetes secret for llama-stack API connection.
             The secret must define: LLAMA_STACK_CLIENT_API_KEY, LLAMA_STACK_CLIENT_BASE_URL.
@@ -126,6 +128,7 @@ def documents_rag_optimization_pipeline(
                 "AWS_S3_ENDPOINT": "AWS_S3_ENDPOINT",
                 "AWS_DEFAULT_REGION": "AWS_DEFAULT_REGION",
             },
+            optional=True,
         )
 
     mps_task = search_space_preparation(


### PR DESCRIPTION
Assisted-by: <Cursor>

**Description of your changes:**

AutoRAG no longer requires `AWS_DEFAULT_REGION` in S3 secrets, matching AutoML.
Added tests to cover the missing `AWS_DEFAULT_REGION` case.

**Checklist:**

### Pre-Submission Checklist

- [ ] All tests and CI checks pass
- [ ] Pre-commit hooks pass without errors
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AWS_DEFAULT_REGION is now optional for S3 integration components; components can operate without explicitly specifying a region when not provided.

* **Documentation**
  * Updated component documentation to reflect AWS_DEFAULT_REGION as optional across data processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->