### PR TITLE
fix: AutoRAG context correctness always 0 for .txt input documents

### DIFF
--- a/components/data_processing/autorag/documents_discovery/component.py
+++ b/components/data_processing/autorag/documents_discovery/component.py
@@ -35,6 +35,7 @@ def documents_discovery(
     import os
     import sys
     from math import inf
+    from pathlib import Path
 
     import boto3
 
@@ -105,7 +106,7 @@ def documents_discovery(
 
     test_data_docs_names = get_test_data_docs_names()
     if test_data_docs_names:
-        supported_files.sort(key=lambda c: c["Key"] not in test_data_docs_names)
+        supported_files.sort(key=lambda c: Path(c["Key"]).name not in test_data_docs_names)
 
     total_size = 0
     selected = []

--- a/components/data_processing/autorag/documents_discovery/component.py
+++ b/components/data_processing/autorag/documents_discovery/component.py
@@ -106,7 +106,8 @@ def documents_discovery(
 
     test_data_docs_names = get_test_data_docs_names()
     if test_data_docs_names:
-        supported_files.sort(key=lambda c: Path(c["Key"]).name not in test_data_docs_names)
+        test_keys_set = {c["Key"] for c in supported_files if Path(c["Key"]).name in test_data_docs_names}
+        supported_files.sort(key=lambda c: c["Key"] not in test_keys_set)
 
     total_size = 0
     selected = []

--- a/components/data_processing/autorag/documents_discovery/tests/test_component_unit.py
+++ b/components/data_processing/autorag/documents_discovery/tests/test_component_unit.py
@@ -9,6 +9,9 @@ import pytest
 
 from ..component import documents_discovery
 
+_GiB = 1024**3
+_MiB = 1024**2
+
 MOCKED_ENV_VARIABLES = {
     "AWS_ACCESS_KEY_ID": "test_key",
     "AWS_SECRET_ACCESS_KEY": "test_secret",
@@ -212,3 +215,180 @@ class TestDocumentsDiscoveryUnitTests:
                     input_data_path="docs/",
                     discovered_documents=discovered,
                 )
+
+
+class TestDocumentsDiscoverySampling:
+    """Unit tests for the sampling and test-data-priority logic in documents_discovery."""
+
+    def _run(
+        self,
+        tmp_path,
+        contents,
+        test_data_json=None,
+        sampling_enabled=True,
+        sampling_max_size=1.0,
+    ):
+        """Run the component with mocked S3 and return the parsed descriptor dict."""
+        mock_boto3 = mock.MagicMock()
+        mock_s3 = mock.MagicMock()
+        mock_s3.list_objects_v2.return_value = {"Contents": contents}
+        mock_boto3.client.return_value = mock_s3
+        mock_botocore, mock_botocore_exceptions = _make_botocore_modules()
+
+        discovered = mock.MagicMock()
+        discovered.path = str(tmp_path / "descriptor")
+
+        test_data_artifact = None
+        if test_data_json is not None:
+            td_file = tmp_path / "test_data.json"
+            td_file.write_text(json.dumps(test_data_json), encoding="utf-8")
+            test_data_artifact = mock.MagicMock()
+            test_data_artifact.path = str(td_file)
+
+        with mock.patch.dict("os.environ", MOCKED_ENV_VARIABLES, clear=True):
+            with mock.patch.dict(
+                sys.modules,
+                {
+                    "boto3": mock_boto3,
+                    "botocore": mock_botocore,
+                    "botocore.exceptions": mock_botocore_exceptions,
+                },
+            ):
+                documents_discovery.python_func(
+                    input_data_bucket_name="my-bucket",
+                    input_data_path="docs/",
+                    test_data=test_data_artifact,
+                    sampling_enabled=sampling_enabled,
+                    sampling_max_size=sampling_max_size,
+                    discovered_documents=discovered,
+                )
+
+        descriptor_file = tmp_path / "descriptor" / "documents_descriptor.json"
+        return json.loads(descriptor_file.read_text(encoding="utf-8"))
+
+    def test_sampling_disabled_includes_all_supported_docs(self, tmp_path):
+        """With sampling disabled every supported doc is selected regardless of total size."""
+        contents = [
+            {"Key": "docs/a.pdf", "Size": 5 * _GiB},
+            {"Key": "docs/b.txt", "Size": 5 * _GiB},
+            {"Key": "docs/c.docx", "Size": 5 * _GiB},
+        ]
+        payload = self._run(tmp_path, contents, sampling_enabled=False)
+        assert payload["count"] == 3
+
+    def test_sampling_limits_total_size(self, tmp_path):
+        """Docs are accumulated until adding the next one would exceed the size cap."""
+        contents = [
+            {"Key": "docs/a.pdf", "Size": 400 * _MiB},
+            {"Key": "docs/b.pdf", "Size": 400 * _MiB},
+            {"Key": "docs/c.pdf", "Size": 400 * _MiB},
+        ]
+        payload = self._run(tmp_path, contents, sampling_max_size=1.0)
+        assert payload["count"] == 2
+        assert payload["total_size_bytes"] == 800 * _MiB
+
+    def test_doc_exactly_at_size_limit_is_included(self, tmp_path):
+        """A document whose size exactly equals the cap is selected."""
+        contents = [{"Key": "docs/a.pdf", "Size": _GiB}]
+        payload = self._run(tmp_path, contents, sampling_max_size=1.0)
+        assert payload["count"] == 1
+
+    def test_all_docs_exceed_size_limit_raises_value_error(self, tmp_path):
+        """ValueError is raised when every individual doc is larger than the cap."""
+        contents = [
+            {"Key": "docs/a.pdf", "Size": 2 * _GiB},
+            {"Key": "docs/b.pdf", "Size": 2 * _GiB},
+        ]
+        with pytest.raises(ValueError, match="No documents to process"):
+            self._run(tmp_path, contents, sampling_max_size=1.0)
+
+    def test_test_data_priority_flat_keys(self, tmp_path):
+        """Docs named in test data are selected first when S3 keys have no prefix."""
+        contents = [
+            {"Key": "irrelevant.pdf", "Size": 600 * _MiB},
+            {"Key": "important.txt", "Size": 600 * _MiB},
+        ]
+        test_data = [{"question": "q", "correct_answer_document_ids": ["important.txt"]}]
+        payload = self._run(tmp_path, contents, test_data_json=test_data, sampling_max_size=1.0)
+        assert payload["count"] == 1
+        assert payload["documents"][0]["key"] == "important.txt"
+
+    def test_test_data_priority_prefixed_keys(self, tmp_path):
+        """Docs named in test data are selected first when S3 keys include a folder prefix."""
+        contents = [
+            {"Key": "docs/irrelevant.pdf", "Size": 600 * _MiB},
+            {"Key": "docs/important.txt", "Size": 600 * _MiB},
+        ]
+        test_data = [{"question": "q", "correct_answer_document_ids": ["important.txt"]}]
+        payload = self._run(tmp_path, contents, test_data_json=test_data, sampling_max_size=1.0)
+        assert payload["count"] == 1
+        assert payload["documents"][0]["key"] == "docs/important.txt"
+
+    def test_test_data_priority_deeply_nested_prefix(self, tmp_path):
+        """Priority matching works for multi-level S3 key prefixes."""
+        contents = [
+            {"Key": "a/b/c/irrelevant.pdf", "Size": 600 * _MiB},
+            {"Key": "a/b/c/important.txt", "Size": 600 * _MiB},
+        ]
+        test_data = [{"question": "q", "correct_answer_document_ids": ["important.txt"]}]
+        payload = self._run(tmp_path, contents, test_data_json=test_data, sampling_max_size=1.0)
+        assert payload["count"] == 1
+        assert payload["documents"][0]["key"] == "a/b/c/important.txt"
+
+    def test_no_test_data_selects_all_within_limit(self, tmp_path):
+        """When test_data is None no priority sort is applied; docs within limit are selected."""
+        contents = [
+            {"Key": "docs/a.pdf", "Size": 400 * _MiB},
+            {"Key": "docs/b.pdf", "Size": 400 * _MiB},
+        ]
+        payload = self._run(tmp_path, contents, test_data_json=None, sampling_max_size=1.0)
+        assert payload["count"] == 2
+
+    def test_empty_benchmark_no_priority_sorting(self, tmp_path):
+        """An empty benchmark list is treated the same as no test data."""
+        contents = [
+            {"Key": "docs/a.pdf", "Size": 400 * _MiB},
+            {"Key": "docs/b.pdf", "Size": 400 * _MiB},
+        ]
+        payload = self._run(tmp_path, contents, test_data_json=[], sampling_max_size=1.0)
+        assert payload["count"] == 2
+
+    def test_referenced_doc_absent_from_s3_does_not_raise(self, tmp_path):
+        """Test data referencing a doc not present in S3 is silently ignored."""
+        contents = [{"Key": "docs/a.pdf", "Size": 100}]
+        test_data = [{"question": "q", "correct_answer_document_ids": ["ghost.txt"]}]
+        payload = self._run(tmp_path, contents, test_data_json=test_data)
+        assert payload["count"] == 1
+        assert payload["documents"][0]["key"] == "docs/a.pdf"
+
+    def test_doc_referenced_by_multiple_questions_selected_once(self, tmp_path):
+        """A doc cited in several questions appears exactly once in the output."""
+        contents = [
+            {"Key": "docs/irrelevant.pdf", "Size": 600 * _MiB},
+            {"Key": "docs/shared.txt", "Size": 600 * _MiB},
+        ]
+        test_data = [
+            {"question": "q1", "correct_answer_document_ids": ["shared.txt"]},
+            {"question": "q2", "correct_answer_document_ids": ["shared.txt"]},
+        ]
+        payload = self._run(tmp_path, contents, test_data_json=test_data, sampling_max_size=1.0)
+        assert payload["count"] == 1
+        assert payload["documents"][0]["key"] == "docs/shared.txt"
+
+    def test_multiple_referenced_docs_all_prioritised(self, tmp_path):
+        """All docs named across test data questions are sorted ahead of non-referenced docs."""
+        contents = [
+            {"Key": "docs/filler1.pdf", "Size": 100 * _MiB},
+            {"Key": "docs/filler2.pdf", "Size": 100 * _MiB},
+            {"Key": "docs/ref_a.txt", "Size": 100 * _MiB},
+            {"Key": "docs/ref_b.docx", "Size": 100 * _MiB},
+        ]
+        test_data = [
+            {"question": "q1", "correct_answer_document_ids": ["ref_a.txt"]},
+            {"question": "q2", "correct_answer_document_ids": ["ref_b.docx"]},
+        ]
+        # Cap allows 3 docs; referenced docs should occupy the first 2 slots
+        payload = self._run(tmp_path, contents, test_data_json=test_data, sampling_max_size=300 / 1024)
+        selected_keys = {d["key"] for d in payload["documents"]}
+        assert "docs/ref_a.txt" in selected_keys
+        assert "docs/ref_b.docx" in selected_keys

--- a/components/data_processing/autorag/documents_indexing/component.py
+++ b/components/data_processing/autorag/documents_indexing/component.py
@@ -129,7 +129,7 @@ def documents_indexing(
         api_key=os.getenv("LLAMA_STACK_CLIENT_API_KEY"),
     )
 
-    paths = sorted(Path(extracted_text.path).glob("*.md"))
+    paths = sorted(p for ext in ("*.md", "*.txt") for p in Path(extracted_text.path).glob(ext))
     total_documents = len(paths)
     logger.info("Found %s documents to index", total_documents)
 
@@ -157,7 +157,7 @@ def documents_indexing(
         batch_documents = [
             Document(
                 page_content=p.read_text(encoding="utf-8", errors="replace"),
-                metadata={"document_id": p.stem},
+                metadata={"document_id": p.stem if p.suffix == ".md" else p.name},
             )
             for p in batch_paths
         ]

--- a/components/data_processing/autorag/documents_indexing/component.py
+++ b/components/data_processing/autorag/documents_indexing/component.py
@@ -129,7 +129,8 @@ def documents_indexing(
         api_key=os.getenv("LLAMA_STACK_CLIENT_API_KEY"),
     )
 
-    paths = sorted(p for ext in ("*.md", "*.txt") for p in Path(extracted_text.path).glob(ext))
+    base = Path(extracted_text.path)
+    paths = sorted(p for p in base.iterdir() if p.is_file() and p.suffix.lower() == ".md")
     total_documents = len(paths)
     logger.info("Found %s documents to index", total_documents)
 
@@ -157,7 +158,7 @@ def documents_indexing(
         batch_documents = [
             Document(
                 page_content=p.read_text(encoding="utf-8", errors="replace"),
-                metadata={"document_id": p.stem if p.suffix == ".md" else p.name},
+                metadata={"document_id": p.stem},
             )
             for p in batch_paths
         ]

--- a/components/data_processing/autorag/text_extraction/component.py
+++ b/components/data_processing/autorag/text_extraction/component.py
@@ -234,11 +234,12 @@ def text_extraction(
         try:
             input_file = Path(file_path_str)
             output_dir = Path(output_dir_str)
-            output_file = output_dir / f"{input_file.name}.md"
-
             if input_file.suffix.lower() == ".txt":
+                output_file = output_dir / input_file.name
                 output_file.write_text(input_file.read_text(encoding="utf-8"), encoding="utf-8")
                 return True, None
+
+            output_file = output_dir / f"{input_file.name}.md"
 
             converter = getattr(sys.modules[__name__], "_mp_worker_converter", None)
             if converter is None:

--- a/components/data_processing/autorag/text_extraction/component.py
+++ b/components/data_processing/autorag/text_extraction/component.py
@@ -234,12 +234,10 @@ def text_extraction(
         try:
             input_file = Path(file_path_str)
             output_dir = Path(output_dir_str)
+            output_file = output_dir / f"{input_file.name}.md"
             if input_file.suffix.lower() == ".txt":
-                output_file = output_dir / input_file.name
                 output_file.write_text(input_file.read_text(encoding="utf-8"), encoding="utf-8")
                 return True, None
-
-            output_file = output_dir / f"{input_file.name}.md"
 
             converter = getattr(sys.modules[__name__], "_mp_worker_converter", None)
             if converter is None:

--- a/components/data_processing/autorag/text_extraction/tests/test_component_unit.py
+++ b/components/data_processing/autorag/text_extraction/tests/test_component_unit.py
@@ -472,8 +472,9 @@ class TestTextExtractionMultiFormatUnitTests:
         assert len(converter_calls) == 0
 
         output_dir = Path(extracted_text_artifact.path)
-        output_files = list(output_dir.glob("*.md"))
+        output_files = list(output_dir.glob("*.txt"))
         assert len(output_files) == 1
+        assert output_files[0].name == "file1.txt"
         assert output_files[0].read_text() == "This is a text file content"
 
 
@@ -580,13 +581,15 @@ class TestMultiFormatProcessing:
             )
 
         output_dir = Path(extracted_text_artifact.path)
-        output_files = list(output_dir.glob("*.md"))
-        assert len(output_files) == 1, f"Expected 1 output file for {file_name}, found {len(output_files)}"
-        assert output_files[0].name == f"{file_name}.md"
-
         if file_extension == ".txt":
+            output_files = list(output_dir.glob("*.txt"))
+            assert len(output_files) == 1, f"Expected 1 output file for {file_name}, found {len(output_files)}"
+            assert output_files[0].name == file_name
             mock_docling_components["converter_instance"].convert.assert_not_called()
         else:
+            output_files = list(output_dir.glob("*.md"))
+            assert len(output_files) == 1, f"Expected 1 output file for {file_name}, found {len(output_files)}"
+            assert output_files[0].name == f"{file_name}.md"
             mock_docling_components["converter_instance"].convert.assert_called_once()
 
     @mock.patch.dict("os.environ", MOCKED_ENV_VARIABLES)
@@ -660,18 +663,18 @@ class TestMultiFormatProcessing:
             )
 
         output_dir = Path(extracted_text_artifact.path)
-        output_files = list(output_dir.glob("*.md"))
-        assert len(output_files) == 6, f"Expected 6 output files, found {len(output_files)}"
+        all_output_files = list(output_dir.glob("*.md")) + list(output_dir.glob("*.txt"))
+        assert len(all_output_files) == 6, f"Expected 6 output files, found {len(all_output_files)}"
 
         expected_files = {
             "sample.pdf.md",
             "sample.docx.md",
-            "sample.txt.md",
+            "sample.txt",
             "sample.html.md",
             "sample.md.md",
             "sample.pptx.md",
         }
-        actual_files = {f.name for f in output_files}
+        actual_files = {f.name for f in all_output_files}
         assert actual_files == expected_files
 
         assert mock_docling_components["converter_instance"].convert.call_count == 5

--- a/components/data_processing/autorag/text_extraction/tests/test_component_unit.py
+++ b/components/data_processing/autorag/text_extraction/tests/test_component_unit.py
@@ -472,9 +472,9 @@ class TestTextExtractionMultiFormatUnitTests:
         assert len(converter_calls) == 0
 
         output_dir = Path(extracted_text_artifact.path)
-        output_files = list(output_dir.glob("*.txt"))
+        output_files = list(output_dir.glob("*.md"))
         assert len(output_files) == 1
-        assert output_files[0].name == "file1.txt"
+        assert output_files[0].name == "file1.txt.md"
         assert output_files[0].read_text() == "This is a text file content"
 
 
@@ -581,15 +581,12 @@ class TestMultiFormatProcessing:
             )
 
         output_dir = Path(extracted_text_artifact.path)
+        output_files = list(output_dir.glob("*.md"))
+        assert len(output_files) == 1, f"Expected 1 output file for {file_name}, found {len(output_files)}"
+        assert output_files[0].name == f"{file_name}.md"
         if file_extension == ".txt":
-            output_files = list(output_dir.glob("*.txt"))
-            assert len(output_files) == 1, f"Expected 1 output file for {file_name}, found {len(output_files)}"
-            assert output_files[0].name == file_name
             mock_docling_components["converter_instance"].convert.assert_not_called()
         else:
-            output_files = list(output_dir.glob("*.md"))
-            assert len(output_files) == 1, f"Expected 1 output file for {file_name}, found {len(output_files)}"
-            assert output_files[0].name == f"{file_name}.md"
             mock_docling_components["converter_instance"].convert.assert_called_once()
 
     @mock.patch.dict("os.environ", MOCKED_ENV_VARIABLES)
@@ -663,13 +660,13 @@ class TestMultiFormatProcessing:
             )
 
         output_dir = Path(extracted_text_artifact.path)
-        all_output_files = list(output_dir.glob("*.md")) + list(output_dir.glob("*.txt"))
+        all_output_files = list(output_dir.glob("*.md"))
         assert len(all_output_files) == 6, f"Expected 6 output files, found {len(all_output_files)}"
 
         expected_files = {
             "sample.pdf.md",
             "sample.docx.md",
-            "sample.txt",
+            "sample.txt.md",
             "sample.html.md",
             "sample.md.md",
             "sample.pptx.md",

--- a/components/training/autorag/rag_templates_optimization/component.py
+++ b/components/training/autorag/rag_templates_optimization/component.py
@@ -593,16 +593,18 @@ def rag_templates_optimization(
         if path.is_dir():
             for doc_path in path.iterdir():
                 with doc_path.open("r", encoding="utf-8") as doc:
+                    doc_id = doc_path.stem if doc_path.suffix == ".md" else doc_path.name
                     documents.append(
                         Document(
                             page_content=doc.read(),
-                            metadata={"document_id": doc_path.stem},
+                            metadata={"document_id": doc_id},
                         )
                     )
 
         elif path.is_file():
+            doc_id = path.stem if path.suffix == ".md" else path.name
             with path.open("r", encoding="utf-8") as doc:
-                documents.append(Document(page_content=doc.read(), metadata={"document_id": path.stem}))
+                documents.append(Document(page_content=doc.read(), metadata={"document_id": doc_id}))
 
         return documents
 

--- a/components/training/autorag/search_space_preparation/component.py
+++ b/components/training/autorag/search_space_preparation/component.py
@@ -231,16 +231,18 @@ def search_space_preparation(
         if path.is_dir():
             for doc_path in path.iterdir():
                 with doc_path.open("r", encoding="utf-8") as doc:
+                    doc_id = doc_path.stem if doc_path.suffix == ".md" else doc_path.name
                     documents.append(
                         Document(
                             page_content=doc.read(),
-                            metadata={"document_id": doc_path.stem},
+                            metadata={"document_id": doc_id},
                         )
                     )
 
         elif path.is_file():
+            doc_id = path.stem if path.suffix == ".md" else path.name
             with path.open("r", encoding="utf-8") as doc:
-                documents.append(Document(page_content=doc.read(), metadata={"document_id": path.stem}))
+                documents.append(Document(page_content=doc.read(), metadata={"document_id": doc_id}))
 
         return documents
 


### PR DESCRIPTION
Related issue: https://redhat.atlassian.net/browse/RHOAIENG-60783

**Description of your changes:**

Two bugs caused `context_correctness` to score 0 when using .txt input documents:

  1. text_extraction appended .md to every output file, so `hash_0.txt` became `hash_0.txt.md`. ai4rag then added another .md internally, producing `hash_0.txt.md.md` as the document ID - mismatching the benchmark's `hash_0.txt`.
  2. documents_discovery sampling priority compared full S3 keys (e.g. `docs/hash_0.txt`) against bare benchmark filenames (`hash_0.txt`), so priority sorting never worked.

  Changes

  - text_extraction: .txt files now keep their original extension; other formats still produce <name>.md.
  - documents_indexing / search_space_preparation / rag_templates_optimization: document ID derivation updated to match - stem for .md files, name for .txt files.
  - documents_discovery: sampling sort now uses `Path(c["Key"]).name` to match against benchmark document IDs.
  - Tests: existing tests updated; 12 new sampling tests added.

**Checklist:**

### Pre-Submission Checklist

- [ ] All tests and CI checks pass
- [ ] Pre-commit hooks pass without errors
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserve plain-text (.txt) files in the document pipeline and discover Markdown files case‑insensitively.

* **Bug Fixes**
  * Corrected document identifier handling so non‑Markdown filenames keep their extensions.
  * Document sampling now respects provided test-data ordering when prioritizing documents.

* **Tests**
  * Expanded tests for sampling behavior, size caps, and test-data prioritization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->