### PR TITLE
fix(autorag): support pre-compiled pipeline YAML override and retry S3 artifact lookup

### DIFF
--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/tests/.env.example
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/tests/.env.example
@@ -23,6 +23,11 @@ AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1
 RHOAI_TEST_ARTIFACTS_BUCKET=
 
+# Optional: path to a pre-compiled pipeline YAML. When set, the integration
+# test uses this file instead of compiling the pipeline locally. Useful when
+# the cluster runtime image supports a different kfp version than the local env.
+# RHOAI_COMPILED_PIPELINE_PATH=
+
 # Optional: timeout in seconds for pipeline run (default 3600)
 # RHOAI_PIPELINE_RUN_TIMEOUT=3600
 

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/tests/conftest.py
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/tests/conftest.py
@@ -80,10 +80,13 @@ def s3_client(docrag_integration_config):
     except ImportError:
         return None
     c = docrag_integration_config
+    verify_ssl = os.environ.get("KFP_VERIFY_SSL", "true").strip().lower()
+    verify_ssl = verify_ssl not in ("0", "false", "no")
     return boto3.client(
         "s3",
         endpoint_url=c["s3_endpoint"],
         aws_access_key_id=c["s3_access_key"],
         aws_secret_access_key=c["s3_secret_key"],
         region_name=c["s3_region"],
+        verify=verify_ssl,
     )

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/tests/conftest.py
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/tests/conftest.py
@@ -42,7 +42,14 @@ def kfp_client(docrag_integration_config):
 
 @pytest.fixture(scope="session")
 def compiled_pipeline_path():
-    """Compile the Documents RAG Optimization pipeline to a temp YAML file."""
+    """Use an override YAML when provided, otherwise compile the pipeline locally."""
+    override_path = os.environ.get("RHOAI_COMPILED_PIPELINE_PATH", "").strip()
+    if override_path:
+        if not Path(override_path).is_file():
+            pytest.fail(f"RHOAI_COMPILED_PIPELINE_PATH does not exist: {override_path}")
+        yield override_path
+        return
+
     from kfp import compiler
 
     from ..pipeline import documents_rag_optimization_pipeline

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/tests/test_pipeline_integration.py
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/tests/test_pipeline_integration.py
@@ -10,10 +10,15 @@ Scenarios:
   (leaderboard HTML, rag_patterns, .ipynb notebooks, v1_responses_body.json) in S3 when configured.
 """
 
+import logging
+import os
 import secrets
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 import pytest
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _skip_if_no_rag_integration_config():
@@ -59,69 +64,95 @@ def _run_succeeded(detail):
     return False
 
 
+def _collect_artifact_keys(s3_client, bucket, prefix):
+    """List object keys under prefix and group them by artifact type."""
+    html_keys = []
+    ipynb_keys = []
+    pattern_keys = []
+    responses_body_keys = []
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents") or []:
+            key = obj["Key"]
+            if "leaderboard" in key.lower() or key.endswith(".html"):
+                html_keys.append(key)
+            elif key.endswith(".ipynb"):
+                ipynb_keys.append(key)
+            elif "v1_responses_body.json" in key:
+                responses_body_keys.append(key)
+            elif "rag_patterns" in key or "pattern" in key.lower():
+                pattern_keys.append(key)
+    return html_keys, ipynb_keys, pattern_keys, responses_body_keys
+
+
+def _derive_external_s3_endpoint(endpoint):
+    """Derive the public MinIO route from RHOAI_URL when only a cluster-local endpoint is available."""
+    if ".svc.cluster.local" not in (endpoint or ""):
+        return None
+    rhoai_url = os.environ.get("RHOAI_URL", "").strip()
+    if not rhoai_url:
+        return None
+    host = urlparse(rhoai_url).hostname or ""
+    _, sep, cluster_domain = host.partition(".apps.")
+    if not sep or not cluster_domain:
+        return None
+    return f"https://minio-api-minio.apps.{cluster_domain}"
+
+
+def _make_retry_s3_client(endpoint):
+    """Build an ad-hoc S3 client for artifact lookup retries."""
+    try:
+        import boto3
+    except ImportError:
+        return None
+    access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+    secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    if not endpoint or not access_key or not secret_key:
+        return None
+    verify_ssl = os.environ.get("KFP_VERIFY_SSL", "true").strip().lower()
+    verify_ssl = verify_ssl not in ("0", "false", "no")
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region,
+        verify=verify_ssl,
+    )
+
+
 def _find_artifacts_in_s3(s3_client, bucket, prefix):
     """List object keys under prefix.
 
     When the primary S3 client cannot reach the endpoint (e.g. it points at a
     cluster-internal address), fall back to the external MinIO route derived
-    from ``RHOAI_URL`` and retry with ``verify=False``.
+    from ``RHOAI_URL`` and retry using ``KFP_VERIFY_SSL`` for TLS verification.
 
     Returns:
         Tuple of key lists: leaderboard HTML, .ipynb notebooks, rag/pattern-related paths,
         and ``v1_responses_body.json`` files from ``prepare_responses_api_requests``.
     """
-    html_keys = []
-    ipynb_keys = []
-    pattern_keys = []
-    responses_body_keys = []
-
-    def _collect(client):
-        h, n, p, r = [], [], [], []
-        paginator = client.get_paginator("list_objects_v2")
-        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
-            for obj in page.get("Contents") or []:
-                key = obj["Key"]
-                if "leaderboard" in key.lower() or key.endswith(".html"):
-                    h.append(key)
-                elif key.endswith(".ipynb"):
-                    n.append(key)
-                elif "v1_responses_body.json" in key:
-                    r.append(key)
-                elif "rag_patterns" in key or "pattern" in key.lower():
-                    p.append(key)
-        return h, n, p, r
-
     try:
-        html_keys, ipynb_keys, pattern_keys, responses_body_keys = _collect(s3_client)
+        return _collect_artifact_keys(s3_client, bucket, prefix)
     except Exception as exc:
-        import logging
-        import os
+        endpoint = getattr(getattr(s3_client, "meta", None), "endpoint_url", None) or ""
+        LOGGER.warning(
+            "Artifact lookup failed for s3://%s/%s via %s: %s",
+            bucket, prefix, endpoint or "<unknown>", exc,
+        )
 
-        logging.getLogger(__name__).warning("Primary S3 artifact lookup failed: %s", exc)
-        rhoai_url = os.environ.get("RHOAI_URL", "")
-        if rhoai_url:
-            import re
-
-            import boto3
-
-            m = re.search(r"\.apps\.(.*)", rhoai_url.rstrip("/"))
-            if m:
-                ext_endpoint = f"https://minio-api-minio.apps.{m.group(1)}"
-                logging.getLogger(__name__).info("Retrying artifact lookup via %s", ext_endpoint)
+        derived_endpoint = _derive_external_s3_endpoint(endpoint)
+        if derived_endpoint:
+            retry_client = _make_retry_s3_client(derived_endpoint)
+            if retry_client is not None:
+                LOGGER.info("Retrying artifact lookup via %s", derived_endpoint)
                 try:
-                    ext_client = boto3.client(
-                        "s3",
-                        endpoint_url=ext_endpoint,
-                        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", ""),
-                        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
-                        region_name=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
-                        verify=False,
-                    )
-                    html_keys, ipynb_keys, pattern_keys, responses_body_keys = _collect(ext_client)
+                    return _collect_artifact_keys(retry_client, bucket, prefix)
                 except Exception as retry_exc:
-                    logging.getLogger(__name__).warning("Retry via external route also failed: %s", retry_exc)
-
-    return html_keys, ipynb_keys, pattern_keys, responses_body_keys
+                    LOGGER.warning("Retry via external route also failed: %s", retry_exc)
+                    raise retry_exc from exc
+        raise
 
 
 def _pipeline_arguments_from_config(config):

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/tests/test_pipeline_integration.py
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/tests/test_pipeline_integration.py
@@ -139,7 +139,10 @@ def _find_artifacts_in_s3(s3_client, bucket, prefix):
         endpoint = getattr(getattr(s3_client, "meta", None), "endpoint_url", None) or ""
         LOGGER.warning(
             "Artifact lookup failed for s3://%s/%s via %s: %s",
-            bucket, prefix, endpoint or "<unknown>", exc,
+            bucket,
+            prefix,
+            endpoint or "<unknown>",
+            exc,
         )
 
         derived_endpoint = _derive_external_s3_endpoint(endpoint)

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/tests/test_pipeline_integration.py
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/tests/test_pipeline_integration.py
@@ -62,6 +62,10 @@ def _run_succeeded(detail):
 def _find_artifacts_in_s3(s3_client, bucket, prefix):
     """List object keys under prefix.
 
+    When the primary S3 client cannot reach the endpoint (e.g. it points at a
+    cluster-internal address), fall back to the external MinIO route derived
+    from ``RHOAI_URL`` and retry with ``verify=False``.
+
     Returns:
         Tuple of key lists: leaderboard HTML, .ipynb notebooks, rag/pattern-related paths,
         and ``v1_responses_body.json`` files from ``prepare_responses_api_requests``.
@@ -70,21 +74,53 @@ def _find_artifacts_in_s3(s3_client, bucket, prefix):
     ipynb_keys = []
     pattern_keys = []
     responses_body_keys = []
-    try:
-        paginator = s3_client.get_paginator("list_objects_v2")
+
+    def _collect(client):
+        h, n, p, r = [], [], [], []
+        paginator = client.get_paginator("list_objects_v2")
         for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
             for obj in page.get("Contents") or []:
                 key = obj["Key"]
                 if "leaderboard" in key.lower() or key.endswith(".html"):
-                    html_keys.append(key)
+                    h.append(key)
                 elif key.endswith(".ipynb"):
-                    ipynb_keys.append(key)
+                    n.append(key)
                 elif "v1_responses_body.json" in key:
-                    responses_body_keys.append(key)
+                    r.append(key)
                 elif "rag_patterns" in key or "pattern" in key.lower():
-                    pattern_keys.append(key)
-    except Exception:
-        pass
+                    p.append(key)
+        return h, n, p, r
+
+    try:
+        html_keys, ipynb_keys, pattern_keys, responses_body_keys = _collect(s3_client)
+    except Exception as exc:
+        import logging
+        import os
+
+        logging.getLogger(__name__).warning("Primary S3 artifact lookup failed: %s", exc)
+        rhoai_url = os.environ.get("RHOAI_URL", "")
+        if rhoai_url:
+            import re
+
+            import boto3
+
+            m = re.search(r"\.apps\.(.*)", rhoai_url.rstrip("/"))
+            if m:
+                ext_endpoint = f"https://minio-api-minio.apps.{m.group(1)}"
+                logging.getLogger(__name__).info("Retrying artifact lookup via %s", ext_endpoint)
+                try:
+                    ext_client = boto3.client(
+                        "s3",
+                        endpoint_url=ext_endpoint,
+                        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID", ""),
+                        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
+                        region_name=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+                        verify=False,
+                    )
+                    html_keys, ipynb_keys, pattern_keys, responses_body_keys = _collect(ext_client)
+                except Exception as retry_exc:
+                    logging.getLogger(__name__).warning("Retry via external route also failed: %s", retry_exc)
+
     return html_keys, ipynb_keys, pattern_keys, responses_body_keys
 
 


### PR DESCRIPTION
## Summary
- Allow CI to supply a pre-compiled pipeline YAML via `RHOAI_COMPILED_PIPELINE_PATH` instead of always compiling locally. This is needed when the cluster runtime image supports a different kfp version than the local environment (e.g. runtime has kfp 2.15.2 but local venv has 2.16.1).
- When the S3 artifact lookup fails (e.g. cluster-internal MinIO endpoint unreachable from Jenkins or a local test runner), derive the external MinIO route from `RHOAI_URL` and retry with `verify=False`.

## Context
The Shepard CI pipeline downloads a pre-compiled pipeline YAML from a release branch and passes it via `RHOAI_COMPILED_PIPELINE_PATH`. Without this fix, the `conftest.py` fixture always recompiles the pipeline locally, ignoring the override, which causes kfp version mismatches on clusters running older runtime images.

The S3 artifact retry was previously submitted as [red-hat-data-services#35](https://github.com/red-hat-data-services/pipelines-components/pull/35) and redirected here per maintainer feedback.

## Changes
- `conftest.py`: `compiled_pipeline_path` fixture checks `RHOAI_COMPILED_PIPELINE_PATH` env var before compiling locally
- `test_pipeline_integration.py`: `_find_artifacts_in_s3` logs failures and retries via external MinIO route derived from `RHOAI_URL`

## Test plan
- [x] Verified locally that `RHOAI_COMPILED_PIPELINE_PATH` is respected when set
- [x] Verified locally that the S3 artifact retry derives the external MinIO route and finds artifacts
- [x] Ran AutoRAG integration tests against rhoai-autorag cluster with pre-compiled rhoai-3.4 pipeline YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Support using a precompiled pipeline via RHOAI_COMPILED_PIPELINE_PATH to override local compilation during integration tests.
  * S3 artifact discovery gains structured helpers, a resilient retry path that derives an external endpoint and attempts a fallback client when listing fails, and logs failures; TLS verification for S3 clients now follows KFP_VERIFY_SSL.

* **Documentation**
  * Added RHOAI_COMPILED_PIPELINE_PATH to the test environment example with usage notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->