### PR TITLE
[fix]: add ipython to automl requirements to resolve the fastai issue

### DIFF
--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
@@ -71,6 +71,7 @@ httptools==0.7.1
 httpx==0.28.1
 huggingface_hub==0.36.2
 idna==3.11
+ipython==9.10.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
 jmespath==1.1.0

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
@@ -71,7 +71,7 @@ httptools==0.7.1
 httpx==0.28.1
 huggingface_hub==0.36.2
 idna==3.11
-ipython==9.10.0
+ipython==9.13.0
 itsdangerous==2.2.0
 Jinja2==3.1.6
 jmespath==1.1.0


### PR DESCRIPTION
**Description of your changes:**
Currently, when running tabular experiment, in model training components logs, we can spot:
```
Fitting model: NeuralNetFastAI_BAG_L2 ... Training model for up to 1741.60s of the 1741.59s of remaining time.
	Fitting 4 child models (S1F1 - S1F4) | Fitting with SequentialLocalFoldFittingStrategy (sequential: cpus=24, gpus=0)
	Warning: Exception caused NeuralNetFastAI_BAG_L2 to fail during training (ImportError)... Skipping this model.
		Import fastai failed. A quick tip is to install via `pip install autogluon.tabular[fastai]==1.5.0+rhaiv.1`.
```

The problem comes from the package `fastprogress==1.1.5` (https://github.com/AnswerDotAI/fastprogress/issues/117), which is dependency of `fastai==2.8.7`.  To fix the import error in automl experiment, it is enough to add `ipython` package to the list of packages installed in the automl image. We cannot downgrade the `fastprogress` because the problematic import is present in versions `>1.0.5` and only `1.1.5` is available in RH index.

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x]  The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
