### PR TITLE
feat(piplines,components)[AutoML]: add experiment settings like presets and eval metric

### DIFF
--- a/components/training/automl/autogluon_leaderboard_evaluation/component.py
+++ b/components/training/automl/autogluon_leaderboard_evaluation/component.py
@@ -65,6 +65,7 @@ def leaderboard_evaluation(
     import json
     import logging
     from pathlib import Path
+    from typing import NamedTuple
 
     import pandas as pd
     from leaderboard_utils import _build_leaderboard_html, _build_leaderboard_table, _round_metrics

--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -31,7 +31,7 @@ output artifact so the pipeline does not require a ParallelFor loop. Each model 
 | `split_config` | `Optional[dict]` | `None` | Data split config stored in artifact metadata. |
 | `extra_train_data_path` | `str` | `""` | Optional path to extra training CSV passed to ``refit_full``. |
 | `preset` | `str` | `medium_quality` | AutoGluon quality tier. ``"medium_quality"`` or ``"good_quality"``. |
-| `eval_metric` | `Optional[str]` | `None` | Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults to ``"r2"`` for regression and ``"accuracy"`` otherwise. |
+| `eval_metric` | `str` | `""` | Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults to ``"r2"`` for regression and ``"accuracy"`` otherwise. |
 
 ## Outputs 📤
 

--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -30,6 +30,8 @@ output artifact so the pipeline does not require a ParallelFor loop. Each model 
 | `sampling_config` | `Optional[dict]` | `None` | Data sampling config stored in artifact metadata. |
 | `split_config` | `Optional[dict]` | `None` | Data split config stored in artifact metadata. |
 | `extra_train_data_path` | `str` | `""` | Optional path to extra training CSV passed to ``refit_full``. |
+| `preset` | `str` | `medium_quality` | AutoGluon quality tier. ``"medium_quality"`` or ``"good_quality"``. |
+| `eval_metric` | `Optional[str]` | `None` | Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults to ``"root_mean_squared_error"`` for regression and ``"accuracy"`` otherwise. |
 
 ## Outputs 📤
 

--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -31,7 +31,7 @@ output artifact so the pipeline does not require a ParallelFor loop. Each model 
 | `split_config` | `Optional[dict]` | `None` | Data split config stored in artifact metadata. |
 | `extra_train_data_path` | `str` | `""` | Optional path to extra training CSV passed to ``refit_full``. |
 | `preset` | `str` | `medium_quality` | AutoGluon quality tier. ``"medium_quality"`` or ``"good_quality"``. |
-| `eval_metric` | `Optional[str]` | `None` | Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults to ``"root_mean_squared_error"`` for regression and ``"accuracy"`` otherwise. |
+| `eval_metric` | `Optional[str]` | `None` | Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults to ``"r2"`` for regression and ``"accuracy"`` otherwise. |
 
 ## Outputs 📤
 

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -27,6 +27,8 @@ def autogluon_models_training(
     sampling_config: Optional[dict] = None,
     split_config: Optional[dict] = None,
     extra_train_data_path: str = "",
+    preset: str = "medium_quality",
+    eval_metric: Optional[str] = None,
 ) -> NamedTuple("outputs", eval_metric=str):
     """Train AutoGluon models, select the top N, and refit each on the full dataset.
 
@@ -60,6 +62,9 @@ def autogluon_models_training(
         sampling_config: Data sampling config stored in artifact metadata.
         split_config: Data split config stored in artifact metadata.
         extra_train_data_path: Optional path to extra training CSV passed to ``refit_full``.
+        preset: AutoGluon quality tier. ``"medium_quality"`` or ``"good_quality"``.
+        eval_metric: Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults
+            to ``"root_mean_squared_error"`` for regression and ``"accuracy"`` otherwise.
 
     Returns:
         NamedTuple with ``eval_metric`` (the metric used for ranking, e.g. ``"r2"`` or ``"accuracy"``).
@@ -82,6 +87,7 @@ def autogluon_models_training(
     from autogluon.tabular import TabularPredictor
 
     VALID_TASK_TYPES = {"binary", "multiclass", "regression"}
+    VALID_PRESETS = {"medium_quality", "good_quality"}
     TOP_N_MAX = 10
 
     # Input parameters validation
@@ -89,6 +95,8 @@ def autogluon_models_training(
         raise TypeError("label_column must be a non-empty string.")
     if task_type not in VALID_TASK_TYPES:
         raise ValueError(f"task_type must be one of {VALID_TASK_TYPES}; got {task_type!r}.")
+    if preset not in VALID_PRESETS:
+        raise ValueError(f"preset must be one of {VALID_PRESETS}; got {preset!r}.")
     if not train_data_path or not isinstance(train_data_path, str) or not train_data_path.strip():
         raise TypeError("train_data_path must be a non-empty string.")
     if not workspace_path or not isinstance(workspace_path, str) or not workspace_path.strip():
@@ -118,9 +126,6 @@ def autogluon_models_training(
         raise ValueError("sample_row must be a JSON array list of row objects.")
 
     logger = logging.getLogger(__name__)
-
-    DEFAULT_PRESET = "medium_quality"
-    DEFAULT_TIME_LIMIT = 30 * 60  # 30 minutes
 
     # 1. models selection stage
 
@@ -152,24 +157,40 @@ def autogluon_models_training(
             logger.warning("Extra train CSV is empty; passing train_data_extra=None to refit_full.")
             extra_train_df = None
 
-    eval_metric = "r2" if task_type == "regression" else "accuracy"
+    if eval_metric is None:
+        eval_metric = "root_mean_squared_error" if task_type == "regression" else "accuracy"
 
     predictor_path = Path(workspace_path) / "autogluon_predictor"
-    predictor = TabularPredictor(
+    _predictor_instance = TabularPredictor(
         problem_type=task_type,
         label=label_column,
         eval_metric=eval_metric,
         path=predictor_path,
         verbosity=2,
-    ).fit(
-        train_data=train_data_df,
-        num_stack_levels=1,
-        num_bag_folds=4,
-        use_bag_holdout=True,
-        holdout_frac=0.2,
-        time_limit=DEFAULT_TIME_LIMIT,
-        presets=DEFAULT_PRESET,
     )
+
+    if preset == "good_quality":
+        DEFAULT_TIME_LIMIT = 60 * 60  # 60 minutes - extend time limit for good_quality preset
+        predictor = _predictor_instance.fit(
+            train_data=train_data_df,
+            presets=preset,
+            # Pipeline handles refit explicitly via refit_full(); disable AutoGluon's built-in refit
+            # to prevent double-refit and incorrect model selection.
+            refit_full=False,
+            set_best_to_refit_full=False,
+            # Required so refit_full() can access bag fold models after fit().
+            save_bag_folds=True,
+            time_limit=DEFAULT_TIME_LIMIT,
+        )
+    else:
+        DEFAULT_TIME_LIMIT = 30 * 60  # 30 minutes
+        predictor = _predictor_instance.fit(
+            train_data=train_data_df,
+            use_bag_holdout=True,
+            holdout_frac=0.2,
+            time_limit=DEFAULT_TIME_LIMIT,
+            presets=preset,
+        )
 
     # Select top N models
     leaderboard = predictor.leaderboard(test_data_df)
@@ -177,7 +198,7 @@ def autogluon_models_training(
     top_models = leaderboard.head(top_n)["model"].values.tolist()
 
     model_config = {
-        "preset": DEFAULT_PRESET,
+        "preset": preset,
         "eval_metric": eval_metric,
         "time_limit": DEFAULT_TIME_LIMIT,
     }
@@ -340,7 +361,7 @@ def autogluon_models_training(
         "models": models_metadata,
     }
 
-    return NamedTuple("outputs", eval_metric=str)(eval_metric=str(predictor.eval_metric))
+    return NamedTuple("outputs", eval_metric=str)(eval_metric=eval_metric)
 
 
 if __name__ == "__main__":

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -64,7 +64,7 @@ def autogluon_models_training(
         extra_train_data_path: Optional path to extra training CSV passed to ``refit_full``.
         preset: AutoGluon quality tier. ``"medium_quality"`` or ``"good_quality"``.
         eval_metric: Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults
-            to ``"root_mean_squared_error"`` for regression and ``"accuracy"`` otherwise.
+            to ``"r2"`` for regression and ``"accuracy"`` otherwise.
 
     Returns:
         NamedTuple with ``eval_metric`` (the metric used for ranking, e.g. ``"r2"`` or ``"accuracy"``).
@@ -82,6 +82,7 @@ def autogluon_models_training(
     import shutil
     from concurrent.futures import ThreadPoolExecutor
     from pathlib import Path
+    from typing import NamedTuple
 
     import pandas as pd
     from autogluon.tabular import TabularPredictor
@@ -158,7 +159,7 @@ def autogluon_models_training(
             extra_train_df = None
 
     if eval_metric is None:
-        eval_metric = "root_mean_squared_error" if task_type == "regression" else "accuracy"
+        eval_metric = "r2" if task_type == "regression" else "accuracy"
 
     predictor_path = Path(workspace_path) / "autogluon_predictor"
     _predictor_instance = TabularPredictor(
@@ -183,13 +184,23 @@ def autogluon_models_training(
             time_limit=DEFAULT_TIME_LIMIT,
         )
     else:
+        import copy
+
+        from autogluon.tabular.configs.hyperparameter_configs import get_hyperparameter_config
+
         DEFAULT_TIME_LIMIT = 30 * 60  # 30 minutes
+        RF_XT_MAX_DEPTH = 10
+        hyperparams = copy.deepcopy(get_hyperparameter_config("default"))
+        for model_type in ("RF", "XT"):
+            for config in hyperparams.get(model_type, []):
+                config["max_depth"] = RF_XT_MAX_DEPTH
         predictor = _predictor_instance.fit(
             train_data=train_data_df,
             use_bag_holdout=True,
             holdout_frac=0.2,
             time_limit=DEFAULT_TIME_LIMIT,
             presets=preset,
+            hyperparameters=hyperparams,
         )
 
     # Select top N models

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -28,7 +28,7 @@ def autogluon_models_training(
     split_config: Optional[dict] = None,
     extra_train_data_path: str = "",
     preset: str = "medium_quality",
-    eval_metric: Optional[str] = None,
+    eval_metric: str = "",
 ) -> NamedTuple("outputs", eval_metric=str):
     """Train AutoGluon models, select the top N, and refit each on the full dataset.
 
@@ -158,7 +158,7 @@ def autogluon_models_training(
             logger.warning("Extra train CSV is empty; passing train_data_extra=None to refit_full.")
             extra_train_df = None
 
-    if eval_metric is None:
+    if not eval_metric:
         eval_metric = "r2" if task_type == "regression" else "accuracy"
 
     predictor_path = Path(workspace_path) / "autogluon_predictor"

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -171,7 +171,7 @@ def autogluon_models_training(
     )
 
     if preset == "good_quality":
-        DEFAULT_TIME_LIMIT = 60 * 60  # 60 minutes - extend time limit for good_quality preset
+        time_limit = 60 * 60  # 60 minutes - extend time limit for good_quality preset
         predictor = _predictor_instance.fit(
             train_data=train_data_df,
             presets=preset,
@@ -181,14 +181,14 @@ def autogluon_models_training(
             set_best_to_refit_full=False,
             # Required so refit_full() can access bag fold models after fit().
             save_bag_folds=True,
-            time_limit=DEFAULT_TIME_LIMIT,
+            time_limit=time_limit,
         )
     else:
         import copy
 
         from autogluon.tabular.configs.hyperparameter_configs import get_hyperparameter_config
 
-        DEFAULT_TIME_LIMIT = 30 * 60  # 30 minutes
+        time_limit = 30 * 60  # 30 minutes
         RF_XT_MAX_DEPTH = 10
         hyperparams = copy.deepcopy(get_hyperparameter_config("default"))
         for model_type in ("RF", "XT"):
@@ -198,7 +198,7 @@ def autogluon_models_training(
             train_data=train_data_df,
             use_bag_holdout=True,
             holdout_frac=0.2,
-            time_limit=DEFAULT_TIME_LIMIT,
+            time_limit=time_limit,
             presets=preset,
             hyperparameters=hyperparams,
         )
@@ -211,7 +211,7 @@ def autogluon_models_training(
     model_config = {
         "preset": preset,
         "eval_metric": eval_metric,
-        "time_limit": DEFAULT_TIME_LIMIT,
+        "time_limit": time_limit,
     }
 
     def retrieve_pipeline_name(name: str) -> str:

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -24,6 +24,11 @@ def isolated_sys_modules():
             if sub == "autogluon.core":
                 _m.__path__ = []
             mocked_modules[sub] = _m
+        for sub in ("autogluon.tabular.configs", "autogluon.tabular.configs.hyperparameter_configs"):
+            _m = mock.MagicMock()
+            _m.__spec__ = None
+            _m.get_hyperparameter_config.return_value = {}
+            mocked_modules[sub] = _m
         yield
 
 
@@ -182,25 +187,23 @@ class TestAutogluonModelsTrainingUnitTests:
             split_config={"split": 0.8},
         )
 
-        # Return value — default for regression is now root_mean_squared_error
-        assert result.eval_metric == "root_mean_squared_error"
+        assert result.eval_metric == "r2"
 
         # TabularPredictor constructed and fitted with correct params
         mock_predictor_class.assert_called_once_with(
             problem_type="regression",
             label="target",
-            eval_metric="root_mean_squared_error",
+            eval_metric="r2",
             path=Path(workspace_path) / "autogluon_predictor",
             verbosity=2,
         )
         mock_predictor_class.return_value.fit.assert_called_once_with(
             train_data=mock_train_df,
-            num_stack_levels=1,
-            num_bag_folds=4,
             use_bag_holdout=True,
             holdout_frac=0.2,
             time_limit=1800,
             presets="medium_quality",
+            hyperparameters={},
         )
 
         # read_csv: train, test, extra
@@ -1004,6 +1007,63 @@ class TestAutogluonModelsTrainingUnitTests:
         assert fit_call_kwargs.get("presets") == "medium_quality"
         assert "auto_stack" not in fit_call_kwargs
 
+    @mock.patch("autogluon.tabular.configs.hyperparameter_configs.get_hyperparameter_config")
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_medium_quality_rf_xt_max_depth_set(
+        self, mock_predictor_class, mock_read_csv, mock_get_hp_config, mock_notebooks, tmp_path
+    ):
+        """medium_quality injects max_depth=10 into every RF and XT hyperparameter config."""
+        mock_get_hp_config.return_value = {
+            "GBM": [{}],
+            "RF": [
+                {"criterion": "gini", "ag_args": {"name_suffix": "Gini"}},
+                {"criterion": "entropy", "ag_args": {"name_suffix": "Entr"}},
+            ],
+            "XT": [
+                {"criterion": "gini", "ag_args": {"name_suffix": "Gini"}},
+            ],
+        }
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"r2": 0.9}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = str(tmp_path / "out")
+        Path(mock_models_artifact.path).mkdir()
+        mock_models_artifact.metadata = {}
+
+        autogluon_models_training.python_func(
+            label_column="target",
+            task_type="regression",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            notebooks=mock_notebooks,
+            preset="medium_quality",
+        )
+
+        fit_hyperparams = mock_predictor_class.return_value.fit.call_args[1]["hyperparameters"]
+        mock_get_hp_config.assert_called_once_with("default")
+        assert fit_hyperparams["GBM"] == [{}]  # unchanged
+        assert all(c["max_depth"] == 10 for c in fit_hyperparams["RF"])
+        assert all(c["max_depth"] == 10 for c in fit_hyperparams["XT"])
+
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.tabular.TabularPredictor")
     def test_good_quality_preset_expanded(self, mock_predictor_class, mock_read_csv, mock_notebooks, tmp_path):
@@ -1106,10 +1166,10 @@ class TestAutogluonModelsTrainingUnitTests:
 
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.tabular.TabularPredictor")
-    def test_eval_metric_none_regression_resolves_to_rmse(
+    def test_eval_metric_none_regression_resolves_to_r2(
         self, mock_predictor_class, mock_read_csv, mock_notebooks, tmp_path
     ):
-        """eval_metric=None with regression resolves to 'root_mean_squared_error'."""
+        """eval_metric=None with regression resolves to 'r2'."""
         mock_predictor = mock.MagicMock()
         mock_predictor_clone = mock.MagicMock()
         mock_predictor_class.return_value.fit.return_value = mock_predictor
@@ -1117,7 +1177,7 @@ class TestAutogluonModelsTrainingUnitTests:
         mock_predictor.problem_type = "regression"
         mock_predictor.label = "target"
         _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
-        mock_predictor_clone.evaluate_predictions.return_value = {"root_mean_squared_error": 0.1}
+        mock_predictor_clone.evaluate_predictions.return_value = {"r2": 0.9}
         mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
         mock_predictor_clone.predict.return_value = mock.MagicMock()
         mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
@@ -1146,8 +1206,8 @@ class TestAutogluonModelsTrainingUnitTests:
         )
 
         ctor_kwargs = mock_predictor_class.call_args[1]
-        assert ctor_kwargs["eval_metric"] == "root_mean_squared_error"
-        assert result.eval_metric == "root_mean_squared_error"
+        assert ctor_kwargs["eval_metric"] == "r2"
+        assert result.eval_metric == "r2"
 
     @mock.patch("autogluon.core.metrics.confusion_matrix")
     @mock.patch("pandas.read_csv")
@@ -1284,4 +1344,4 @@ class TestAutogluonModelsTrainingUnitTests:
         model_config = mock_models_artifact.metadata["context"]["model_config"]
         assert model_config["preset"] == "good_quality"
         assert model_config["eval_metric"] == "r2"
-        assert model_config["time_limit"] == 1800
+        assert model_config["time_limit"] == 3600

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -182,14 +182,14 @@ class TestAutogluonModelsTrainingUnitTests:
             split_config={"split": 0.8},
         )
 
-        # Return value
-        assert result.eval_metric == "r2"
+        # Return value — default for regression is now root_mean_squared_error
+        assert result.eval_metric == "root_mean_squared_error"
 
         # TabularPredictor constructed and fitted with correct params
         mock_predictor_class.assert_called_once_with(
             problem_type="regression",
             label="target",
-            eval_metric="r2",
+            eval_metric="root_mean_squared_error",
             path=Path(workspace_path) / "autogluon_predictor",
             verbosity=2,
         )
@@ -733,6 +733,24 @@ class TestAutogluonModelsTrainingUnitTests:
         a.metadata = {}
         return a
 
+    def test_rejects_invalid_preset(self, mock_notebooks):
+        """Reject unknown ``preset`` value."""
+        with pytest.raises(ValueError, match="preset must be one of"):
+            autogluon_models_training.python_func(
+                label_column="target",
+                task_type="regression",
+                top_n=1,
+                train_data_path="/tmp/train.csv",
+                test_data=mock.MagicMock(path="/tmp/test.csv"),
+                workspace_path="/tmp/ws",
+                pipeline_name=PIPELINE_NAME,
+                run_id=RUN_ID,
+                sample_row=SAMPLE_ROW,
+                models_artifact=self._minimal_artifact(),
+                notebooks=mock_notebooks,
+                preset="best_quality",
+            )
+
     def test_rejects_empty_label_column(self, mock_notebooks):
         """Reject blank ``label_column``."""
         with pytest.raises(TypeError, match="label_column must be a non-empty string"):
@@ -938,3 +956,332 @@ class TestAutogluonModelsTrainingUnitTests:
                 notebooks=mock_notebooks,
                 split_config=[],
             )
+
+    # ── preset / eval_metric parameters ───────────────────────────────────────
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_medium_quality_preset_forwarded_as_string(
+        self, mock_predictor_class, mock_read_csv, mock_notebooks, tmp_path
+    ):
+        """Default preset is forwarded as the string 'medium_quality' to predictor.fit()."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"root_mean_squared_error": 0.1}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        autogluon_models_training.python_func(
+            label_column="target",
+            task_type="regression",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            notebooks=mock_notebooks,
+            # No preset — should default to "medium_quality"
+        )
+
+        fit_call_kwargs = mock_predictor_class.return_value.fit.call_args[1]
+        assert fit_call_kwargs.get("presets") == "medium_quality"
+        assert "auto_stack" not in fit_call_kwargs
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_good_quality_preset_expanded(self, mock_predictor_class, mock_read_csv, mock_notebooks, tmp_path):
+        """good_quality preset is forwarded as-is; only refit-conflict flags are overridden."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"root_mean_squared_error": 0.1}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        autogluon_models_training.python_func(
+            label_column="target",
+            task_type="regression",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            notebooks=mock_notebooks,
+            preset="good_quality",
+        )
+
+        fit_call_kwargs = mock_predictor_class.return_value.fit.call_args[1]
+        # good_quality: preset string forwarded; only refit-conflict flags overridden
+        assert fit_call_kwargs["presets"] == "good_quality"
+        assert fit_call_kwargs["refit_full"] is False
+        assert fit_call_kwargs["set_best_to_refit_full"] is False
+        assert fit_call_kwargs["save_bag_folds"] is True
+        # Manual expansion kwargs must NOT be present — AutoGluon handles them via the preset
+        assert "auto_stack" not in fit_call_kwargs
+        assert "dynamic_stacking" not in fit_call_kwargs
+        assert "hyperparameters" not in fit_call_kwargs
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_eval_metric_explicit_forwarded_to_predictor(
+        self, mock_predictor_class, mock_read_csv, mock_notebooks, tmp_path
+    ):
+        """Explicit eval_metric is passed through to TabularPredictor constructor and returned."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"r2": 0.9}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        result = autogluon_models_training.python_func(
+            label_column="target",
+            task_type="regression",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            notebooks=mock_notebooks,
+            eval_metric="r2",
+        )
+
+        mock_predictor_class.assert_called_once_with(
+            problem_type="regression",
+            label="target",
+            eval_metric="r2",
+            path=Path(workspace_path) / "autogluon_predictor",
+            verbosity=2,
+        )
+        assert result.eval_metric == "r2"
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_eval_metric_none_regression_resolves_to_rmse(
+        self, mock_predictor_class, mock_read_csv, mock_notebooks, tmp_path
+    ):
+        """eval_metric=None with regression resolves to 'root_mean_squared_error'."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"root_mean_squared_error": 0.1}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        result = autogluon_models_training.python_func(
+            label_column="target",
+            task_type="regression",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            notebooks=mock_notebooks,
+            eval_metric=None,
+        )
+
+        ctor_kwargs = mock_predictor_class.call_args[1]
+        assert ctor_kwargs["eval_metric"] == "root_mean_squared_error"
+        assert result.eval_metric == "root_mean_squared_error"
+
+    @mock.patch("autogluon.core.metrics.confusion_matrix")
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_eval_metric_none_binary_resolves_to_accuracy(
+        self, mock_predictor_class, mock_read_csv, mock_confusion_matrix, mock_notebooks, tmp_path
+    ):
+        """eval_metric=None with binary resolves to 'accuracy' — no behavior change."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "binary"
+        mock_predictor.label = "target"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"accuracy": 0.9}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_confusion_matrix.return_value = mock.MagicMock(to_dict=lambda: {"0": {"0": 5}})
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        result = autogluon_models_training.python_func(
+            label_column="target",
+            task_type="binary",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            notebooks=mock_notebooks,
+        )
+
+        assert mock_predictor_class.call_args[1]["eval_metric"] == "accuracy"
+        assert result.eval_metric == "accuracy"
+
+    @mock.patch("autogluon.core.metrics.confusion_matrix")
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_eval_metric_none_multiclass_resolves_to_accuracy(
+        self, mock_predictor_class, mock_read_csv, mock_confusion_matrix, mock_notebooks, tmp_path
+    ):
+        """eval_metric=None with multiclass resolves to 'accuracy' — no behavior change."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "multiclass"
+        mock_predictor.label = "target"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"accuracy": 0.88}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_confusion_matrix.return_value = mock.MagicMock(to_dict=lambda: {"0": {"0": 5}})
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        result = autogluon_models_training.python_func(
+            label_column="target",
+            task_type="multiclass",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            notebooks=mock_notebooks,
+        )
+
+        assert mock_predictor_class.call_args[1]["eval_metric"] == "accuracy"
+        assert result.eval_metric == "accuracy"
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_model_config_reflects_preset_and_resolved_metric(
+        self, mock_predictor_class, mock_read_csv, mock_notebooks, tmp_path
+    ):
+        """model_config in artifact metadata contains the resolved preset and eval_metric."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"r2": 0.9}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        autogluon_models_training.python_func(
+            label_column="target",
+            task_type="regression",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            notebooks=mock_notebooks,
+            preset="good_quality",
+            eval_metric="r2",
+        )
+
+        model_config = mock_models_artifact.metadata["context"]["model_config"]
+        assert model_config["preset"] == "good_quality"
+        assert model_config["eval_metric"] == "r2"
+        assert model_config["time_limit"] == 1800

--- a/components/training/automl/autogluon_timeseries_models_selection/README.md
+++ b/components/training/automl/autogluon_timeseries_models_selection/README.md
@@ -25,7 +25,7 @@ The TimeSeriesPredictor automatically trains various model types (DeepAR, TFT, A
 | `prediction_length` | `int` | `1` | Forecast horizon (number of timesteps). |
 | `known_covariates_names` | `Optional[List[str]]` | `None` | Optional list of known covariate column names. |
 | `preset` | `str` | `fast_training` | AutoGluon quality tier (e.g. ``"fast_training"``, ``"medium_quality"``). |
-| `eval_metric` | `str` | `MASE` | Metric for model ranking in acronym or snake_case form (e.g. ``"MASE"``). |
+| `eval_metric` | `Optional[str]` | `None` | Metric for model ranking in acronym or snake_case form (e.g. ``"MASE"``). Defaults to ``"MASE"`` when ``None``. |
 
 ## Outputs 📤
 

--- a/components/training/automl/autogluon_timeseries_models_selection/README.md
+++ b/components/training/automl/autogluon_timeseries_models_selection/README.md
@@ -24,6 +24,8 @@ The TimeSeriesPredictor automatically trains various model types (DeepAR, TFT, A
 | `workspace_path` | `str` | `None` | Workspace directory where predictor will be saved. |
 | `prediction_length` | `int` | `1` | Forecast horizon (number of timesteps). |
 | `known_covariates_names` | `Optional[List[str]]` | `None` | Optional list of known covariate column names. |
+| `preset` | `str` | `fast_training` | AutoGluon quality tier (e.g. ``"fast_training"``, ``"medium_quality"``). |
+| `eval_metric` | `str` | `MASE` | Metric for model ranking in acronym or snake_case form (e.g. ``"MASE"``). |
 
 ## Outputs 📤
 

--- a/components/training/automl/autogluon_timeseries_models_selection/component.py
+++ b/components/training/automl/autogluon_timeseries_models_selection/component.py
@@ -17,6 +17,8 @@ def autogluon_timeseries_models_selection(
     workspace_path: str,
     prediction_length: int = 1,
     known_covariates_names: Optional[List[str]] = None,
+    preset: str = "fast_training",
+    eval_metric: str = "MASE",
 ) -> NamedTuple(
     "outputs",
     top_models=List[str],
@@ -45,6 +47,8 @@ def autogluon_timeseries_models_selection(
         workspace_path: Workspace directory where predictor will be saved.
         prediction_length: Forecast horizon (number of timesteps).
         known_covariates_names: Optional list of known covariate column names.
+        preset: AutoGluon quality tier (e.g. ``"fast_training"``, ``"medium_quality"``).
+        eval_metric: Metric for model ranking in acronym or snake_case form (e.g. ``"MASE"``).
 
     Returns:
         NamedTuple: top_models list, predictor_path, eval_metric_name, model_config.
@@ -57,9 +61,6 @@ def autogluon_timeseries_models_selection(
 
     logger = logging.getLogger(__name__)
 
-    # Set constants
-    DEFAULT_PRESETS = "fast_training"
-    DEFAULT_EVAL_METRIC = "MASE"
     DEFAULT_TIME_LIMIT = 600  # 10 minutes
 
     TOP_N_MAX = 7
@@ -109,7 +110,6 @@ def autogluon_timeseries_models_selection(
     # Create predictor path in workspace
     predictor_path = Path(workspace_path) / "timeseries_predictor"
 
-    eval_metric = DEFAULT_EVAL_METRIC
     # Create TimeSeriesPredictor
     predictor = TimeSeriesPredictor(
         prediction_length=prediction_length,
@@ -121,17 +121,18 @@ def autogluon_timeseries_models_selection(
     )
 
     logger.info(
-        "Timeseries selection: training (preset=%s, time_limit=%ss, prediction_length=%s)...",
-        DEFAULT_PRESETS,
+        "Timeseries selection: training (preset=%s, eval_metric=%s, time_limit=%ss, prediction_length=%s)...",
+        preset,
+        eval_metric,
         DEFAULT_TIME_LIMIT,
         prediction_length,
     )
     try:
         predictor.fit(
             train_data=train_ts,
-            presets=DEFAULT_PRESETS,
+            presets=preset,
             time_limit=DEFAULT_TIME_LIMIT,
-            # exclude deep learning models pretrained on large time series datasets
+            # exclude models that download from HuggingFace Hub (disconnected environments)
             excluded_model_types=["Chronos", "Toto", "Chronos2"],
         )
     except Exception as e:
@@ -160,11 +161,11 @@ def autogluon_timeseries_models_selection(
     # Create model config
     model_config = {
         "prediction_length": prediction_length,
-        "eval_metric": eval_metric,
+        "eval_metric": eval_metric,  # always snake_case for downstream consumers
         "target": target,
         "id_column": id_column,
         "timestamp_column": timestamp_column,
-        "presets": DEFAULT_PRESETS,
+        "presets": preset,  # keep "presets" key (plural) — refit component reads this key
         "time_limit": DEFAULT_TIME_LIMIT,
         "known_covariates_names": known_covariates_names or [],
         "num_models_trained": len(leaderboard),
@@ -180,7 +181,7 @@ def autogluon_timeseries_models_selection(
     return outputs(
         top_models=top_models,
         predictor_path=str(predictor_path),
-        eval_metric_name=eval_metric,
+        eval_metric_name=eval_metric,  # snake_case for leaderboard metric lookup
         model_config=model_config,
     )
 

--- a/components/training/automl/autogluon_timeseries_models_selection/component.py
+++ b/components/training/automl/autogluon_timeseries_models_selection/component.py
@@ -18,7 +18,7 @@ def autogluon_timeseries_models_selection(
     prediction_length: int = 1,
     known_covariates_names: Optional[List[str]] = None,
     preset: str = "fast_training",
-    eval_metric: str = "MASE",
+    eval_metric: Optional[str] = None,
 ) -> NamedTuple(
     "outputs",
     top_models=List[str],
@@ -49,6 +49,7 @@ def autogluon_timeseries_models_selection(
         known_covariates_names: Optional list of known covariate column names.
         preset: AutoGluon quality tier (e.g. ``"fast_training"``, ``"medium_quality"``).
         eval_metric: Metric for model ranking in acronym or snake_case form (e.g. ``"MASE"``).
+            Defaults to ``"MASE"`` when ``None``.
 
     Returns:
         NamedTuple: top_models list, predictor_path, eval_metric_name, model_config.
@@ -83,6 +84,9 @@ def autogluon_timeseries_models_selection(
         raise TypeError("prediction_length must be an integer.")
     if prediction_length <= 0:
         raise ValueError("prediction_length must be greater than 0.")
+    if eval_metric is None:
+        eval_metric = "MASE"
+
     if known_covariates_names is not None:
         if not isinstance(known_covariates_names, list) or any(
             (not isinstance(v, str) or not v.strip()) for v in known_covariates_names

--- a/components/training/automl/autogluon_timeseries_models_selection/component.py
+++ b/components/training/automl/autogluon_timeseries_models_selection/component.py
@@ -65,6 +65,7 @@ def autogluon_timeseries_models_selection(
     DEFAULT_TIME_LIMIT = 600  # 10 minutes
 
     TOP_N_MAX = 7
+    VALID_PRESETS = {"fast_training", "medium_quality"}
 
     # Input validation
     for param, value in (
@@ -84,6 +85,8 @@ def autogluon_timeseries_models_selection(
         raise TypeError("prediction_length must be an integer.")
     if prediction_length <= 0:
         raise ValueError("prediction_length must be greater than 0.")
+    if preset not in VALID_PRESETS:
+        raise ValueError(f"preset must be one of {VALID_PRESETS}; got {preset!r}.")
     if eval_metric is None:
         eval_metric = "MASE"
 

--- a/components/training/automl/autogluon_timeseries_models_selection/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_selection/tests/test_component_unit.py
@@ -305,6 +305,35 @@ class TestTimeseriesModelsSelectionUnitTests:
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
     @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_eval_metric_none_resolves_to_mase(self, mock_predictor_cls, mock_ts_df_cls, mock_read_csv):
+        """eval_metric=None resolves to 'MASE' and is forwarded to predictor and model_config."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor_cls.return_value = mock_predictor
+        mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df()]
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        result = autogluon_timeseries_models_selection.python_func(
+            target="sales",
+            id_column="item_id",
+            timestamp_column="timestamp",
+            train_data_path="/tmp/train.csv",
+            test_data=test_data,
+            top_n=1,
+            workspace_path="/tmp/workspace",
+            eval_metric=None,
+        )
+
+        ctor_kwargs = mock_predictor_cls.call_args[1]
+        assert ctor_kwargs["eval_metric"] == "MASE"
+        assert result.eval_metric_name == "MASE"
+        assert result.model_config["eval_metric"] == "MASE"
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
     def test_eval_metric_passes_through_unchanged(self, mock_predictor_cls, mock_ts_df_cls, mock_read_csv):
         """eval_metric is forwarded as-is to AutoGluon (no normalization); AutoGluon handles both forms."""
         cases = ["MASE", "WQL", "MAE", "RMSE", "mean_absolute_scaled_error"]

--- a/components/training/automl/autogluon_timeseries_models_selection/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_selection/tests/test_component_unit.py
@@ -244,6 +244,20 @@ class TestTimeseriesModelsSelectionUnitTests:
 
     # ── preset / eval_metric parameters ───────────────────────────────────────
 
+    def test_rejects_invalid_preset(self):
+        """Reject unknown ``preset`` value before any IO occurs."""
+        with pytest.raises(ValueError, match="preset must be one of"):
+            autogluon_timeseries_models_selection.python_func(
+                target="sales",
+                id_column="item_id",
+                timestamp_column="timestamp",
+                train_data_path="/tmp/train.csv",
+                test_data=mock.MagicMock(path="/tmp/test.csv"),
+                top_n=1,
+                workspace_path="/tmp/workspace",
+                preset="best_quality",
+            )
+
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
     @mock.patch("autogluon.timeseries.TimeSeriesPredictor")

--- a/components/training/automl/autogluon_timeseries_models_selection/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_selection/tests/test_component_unit.py
@@ -109,6 +109,7 @@ class TestTimeseriesModelsSelectionUnitTests:
         assert result.eval_metric_name == "MASE"
         assert result.predictor_path == "/tmp/workspace/timeseries_predictor"
         assert result.model_config["prediction_length"] == 24
+        assert result.model_config["eval_metric"] == "MASE"
         assert result.model_config["presets"] == "fast_training"
         assert result.model_config["time_limit"] == 600
         assert result.model_config["known_covariates_names"] == []
@@ -240,6 +241,127 @@ class TestTimeseriesModelsSelectionUnitTests:
                 top_n=2,
                 workspace_path="/tmp/workspace",
             )
+
+    # ── preset / eval_metric parameters ───────────────────────────────────────
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_preset_parameter_forwarded_to_fit(self, mock_predictor_cls, mock_ts_df_cls, mock_read_csv):
+        """Preset parameter is passed to predictor.fit(presets=...) unchanged."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor_cls.return_value = mock_predictor
+        mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df()]
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        autogluon_timeseries_models_selection.python_func(
+            target="sales",
+            id_column="item_id",
+            timestamp_column="timestamp",
+            train_data_path="/tmp/train.csv",
+            test_data=test_data,
+            top_n=1,
+            workspace_path="/tmp/workspace",
+            preset="medium_quality",
+        )
+
+        fit_kwargs = mock_predictor.fit.call_args[1]
+        assert fit_kwargs["presets"] == "medium_quality"
+        assert fit_kwargs["excluded_model_types"] == ["Chronos", "Toto", "Chronos2"]
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_excluded_model_types_always_present_regardless_of_preset(
+        self, mock_predictor_cls, mock_ts_df_cls, mock_read_csv
+    ):
+        """excluded_model_types is set in every fit() call regardless of preset."""
+        for preset_value in ("fast_training", "medium_quality"):
+            mock_predictor = mock.MagicMock()
+            mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+            mock_predictor_cls.return_value = mock_predictor
+            mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df()]
+            mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+            test_data = mock.MagicMock()
+            test_data.path = "/tmp/test.csv"
+
+            autogluon_timeseries_models_selection.python_func(
+                target="sales",
+                id_column="item_id",
+                timestamp_column="timestamp",
+                train_data_path="/tmp/train.csv",
+                test_data=test_data,
+                top_n=1,
+                workspace_path="/tmp/workspace",
+                preset=preset_value,
+            )
+
+            fit_kwargs = mock_predictor.fit.call_args[1]
+            assert fit_kwargs["excluded_model_types"] == ["Chronos", "Toto", "Chronos2"], preset_value
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_eval_metric_passes_through_unchanged(self, mock_predictor_cls, mock_ts_df_cls, mock_read_csv):
+        """eval_metric is forwarded as-is to AutoGluon (no normalization); AutoGluon handles both forms."""
+        cases = ["MASE", "WQL", "MAE", "RMSE", "mean_absolute_scaled_error"]
+        for metric in cases:
+            mock_predictor = mock.MagicMock()
+            mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+            mock_predictor_cls.return_value = mock_predictor
+            mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df()]
+            mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+            test_data = mock.MagicMock()
+            test_data.path = "/tmp/test.csv"
+
+            result = autogluon_timeseries_models_selection.python_func(
+                target="sales",
+                id_column="item_id",
+                timestamp_column="timestamp",
+                train_data_path="/tmp/train.csv",
+                test_data=test_data,
+                top_n=1,
+                workspace_path="/tmp/workspace",
+                eval_metric=metric,
+            )
+
+            ctor_kwargs = mock_predictor_cls.call_args[1]
+            assert ctor_kwargs["eval_metric"] == metric, f"metric={metric!r}"
+            assert result.eval_metric_name == metric, f"metric={metric!r}"
+            assert result.model_config["eval_metric"] == metric, f"metric={metric!r}"
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_model_config_presets_key_and_eval_metric_forwarded(
+        self, mock_predictor_cls, mock_ts_df_cls, mock_read_csv
+    ):
+        """model_config has 'presets' key (plural) matching preset param, and eval_metric forwarded as-is."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor_cls.return_value = mock_predictor
+        mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df()]
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        result = autogluon_timeseries_models_selection.python_func(
+            target="sales",
+            id_column="item_id",
+            timestamp_column="timestamp",
+            train_data_path="/tmp/train.csv",
+            test_data=test_data,
+            top_n=1,
+            workspace_path="/tmp/workspace",
+            preset="medium_quality",
+            eval_metric="WQL",
+        )
+
+        assert result.model_config["presets"] == "medium_quality"
+        assert result.model_config["eval_metric"] == "WQL"
 
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
@@ -55,7 +55,7 @@ The pipeline leverages AutoGluon's unique ensembling strategy that combines mult
 | `task_type` | `str` | `None` | "binary", "multiclass", or "regression"; drives metrics and model types. |
 | `top_n` | `int` | `3` | Number of top models to select and refit (default: 3); positive integer from range [1, 10]. |
 | `preset` | `str` | `medium_quality` | AutoGluon quality tier (default: ``"medium_quality"``, 4 vCPU / 16 GiB). ``"good_quality"`` trains stronger models at higher resource cost (5 vCPU / 16 GiB). |
-| `eval_metric` | `Optional[str]` | `None` | Metric used for model ranking. When None, AutoGluon's task-type default applies ("accuracy" for classification, "r2" for regression). |
+| `eval_metric` | `str` | `""` | Metric used for model ranking. Empty string (default) lets AutoGluon pick the task-type default ("accuracy" for classification, "r2" for regression). |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
@@ -54,8 +54,8 @@ The pipeline leverages AutoGluon's unique ensembling strategy that combines mult
 | `label_column` | `str` | `None` | Name of the target/label column in the dataset. |
 | `task_type` | `str` | `None` | "binary", "multiclass", or "regression"; drives metrics and model types. |
 | `top_n` | `int` | `3` | Number of top models to select and refit (default: 3); positive integer from range [1, 10]. |
-| `preset` | `str` | `medium_quality` | AutoGluon quality tier (default: "medium_quality", 4 vCPU / 16 GiB). "good_quality" trains stronger models at higher resource cost (8 vCPU / 32 GiB). |
-| `eval_metric` | `Optional[str]` | `None` | Metric used for model ranking. When None, AutoGluon's task-type default applies ("accuracy" for classification, "root_mean_squared_error" for regression). |
+| `preset` | `str` | `medium_quality` | AutoGluon quality tier (default: ``"medium_quality"``, 4 vCPU / 16 GiB). ``"good_quality"`` trains stronger models at higher resource cost (5 vCPU / 16 GiB). |
+| `eval_metric` | `Optional[str]` | `None` | Metric used for model ranking. When None, AutoGluon's task-type default applies ("accuracy" for classification, "r2" for regression). |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
@@ -54,6 +54,8 @@ The pipeline leverages AutoGluon's unique ensembling strategy that combines mult
 | `label_column` | `str` | `None` | Name of the target/label column in the dataset. |
 | `task_type` | `str` | `None` | "binary", "multiclass", or "regression"; drives metrics and model types. |
 | `top_n` | `int` | `3` | Number of top models to select and refit (default: 3); positive integer from range [1, 10]. |
+| `preset` | `str` | `medium_quality` | AutoGluon quality tier (default: "medium_quality", 4 vCPU / 16 GiB). "good_quality" trains stronger models at higher resource cost (8 vCPU / 32 GiB). |
+| `eval_metric` | `Optional[str]` | `None` | Metric used for model ranking. When None, AutoGluon's task-type default applies ("accuracy" for classification, "root_mean_squared_error" for regression). |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from kfp import dsl
 from kfp_components.components.data_processing.automl.tabular_data_loader import automl_data_loader
 from kfp_components.components.training.automl.autogluon_leaderboard_evaluation import leaderboard_evaluation
@@ -37,6 +39,8 @@ def autogluon_tabular_training_pipeline(
     label_column: str,
     task_type: str,
     top_n: int = 3,
+    preset: str = "medium_quality",
+    eval_metric: Optional[str] = None,
 ):
     """AutoGluon Tabular Training Pipeline.
 
@@ -111,6 +115,8 @@ def autogluon_tabular_training_pipeline(
         label_column: Name of the target/label column in the dataset.
         task_type: "binary", "multiclass", or "regression"; drives metrics and model types.
         top_n: Number of top models to select and refit (default: 3); positive integer from range [1, 10].
+        preset: AutoGluon quality tier (default: "medium_quality", 4 vCPU / 16 GiB). "good_quality" trains stronger models at higher resource cost (8 vCPU / 32 GiB).
+        eval_metric: Metric used for model ranking. When None, AutoGluon's task-type default applies ("accuracy" for classification, "root_mean_squared_error" for regression).
 
     Returns:
         HTML artifact with leaderboard of refitted models ranked by task_type metric (e.g. accuracy, r2).
@@ -161,7 +167,7 @@ def autogluon_tabular_training_pipeline(
     )
 
     # Stage 1 + 2: Model selection and sequential refit of top N models
-    training_task = autogluon_models_training(
+    _training_kwargs = dict(
         label_column=label_column,
         task_type=task_type,
         top_n=top_n,
@@ -174,14 +180,30 @@ def autogluon_tabular_training_pipeline(
         sampling_config=data_loader_task.outputs["sample_config"],
         split_config=data_loader_task.outputs["split_config"],
         extra_train_data_path=data_loader_task.outputs["extra_train_data_path"],
+        preset=preset,
+        eval_metric=eval_metric,
     )
-    training_task.set_caching_options(False)
-    training_task.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(MAX_MEMORY)
+
+    with dsl.If(preset == "good_quality"):
+        training_task_gq = autogluon_models_training(**_training_kwargs)
+        training_task_gq.set_caching_options(False)
+        training_task_gq.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
+
+    with dsl.Else():
+        training_task_mq = autogluon_models_training(**_training_kwargs)
+        training_task_mq.set_caching_options(False)
+        training_task_mq.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
 
     # Generate leaderboard
     leaderboard_evaluation_task = leaderboard_evaluation(
-        models_artifact=training_task.outputs["models_artifact"],
-        eval_metric=training_task.outputs["eval_metric"],
+        models_artifact=dsl.OneOf(
+            training_task_gq.outputs["models_artifact"], training_task_mq.outputs["models_artifact"]
+        ),
+        eval_metric=dsl.OneOf(training_task_gq.outputs["eval_metric"], training_task_mq.outputs["eval_metric"]),
     )
     leaderboard_evaluation_task.set_caching_options(False)
     leaderboard_evaluation_task.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
@@ -186,8 +186,7 @@ def autogluon_tabular_training_pipeline(
     with dsl.If(preset == "good_quality"):
         training_task_gq = autogluon_models_training(**_training_kwargs)
         training_task_gq.set_caching_options(False)
-        # TODO: change to the planned size
-        training_task_gq.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+        training_task_gq.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
             MAX_MEMORY
         )
 
@@ -203,7 +202,7 @@ def autogluon_tabular_training_pipeline(
     with dsl.Else():
         training_task_mq = autogluon_models_training(**_training_kwargs)
         training_task_mq.set_caching_options(False)
-        training_task_mq.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+        training_task_mq.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
             MAX_MEMORY
         )
         leaderboard_evaluation_task = leaderboard_evaluation(

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
@@ -115,8 +115,9 @@ def autogluon_tabular_training_pipeline(
         label_column: Name of the target/label column in the dataset.
         task_type: "binary", "multiclass", or "regression"; drives metrics and model types.
         top_n: Number of top models to select and refit (default: 3); positive integer from range [1, 10].
-        preset: AutoGluon quality tier (default: "medium_quality", 4 vCPU / 16 GiB). "good_quality" trains stronger models at higher resource cost (8 vCPU / 32 GiB).
-        eval_metric: Metric used for model ranking. When None, AutoGluon's task-type default applies ("accuracy" for classification, "root_mean_squared_error" for regression).
+        preset: AutoGluon quality tier (default: ``"medium_quality"``, 4 vCPU / 16 GiB).
+            ``"good_quality"`` trains stronger models at higher resource cost (5 vCPU / 16 GiB).
+        eval_metric: Metric used for model ranking. When None, AutoGluon's task-type default applies ("accuracy" for classification, "r2" for regression).
 
     Returns:
         HTML artifact with leaderboard of refitted models ranked by task_type metric (e.g. accuracy, r2).
@@ -183,32 +184,38 @@ def autogluon_tabular_training_pipeline(
         preset=preset,
         eval_metric=eval_metric,
     )
-
+    # TODO: when possible, the leaderboard evaluation task should be outside the if/else block
     with dsl.If(preset == "good_quality"):
         training_task_gq = autogluon_models_training(**_training_kwargs)
         training_task_gq.set_caching_options(False)
-        training_task_gq.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+        # TODO: change to the planned size
+        training_task_gq.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
             MAX_MEMORY
         )
+
+        leaderboard_evaluation_task = leaderboard_evaluation(
+            models_artifact=training_task_gq.outputs["models_artifact"],
+            eval_metric=training_task_gq.outputs["eval_metric"],
+        )
+        leaderboard_evaluation_task.set_caching_options(False)
+        leaderboard_evaluation_task.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(
+            MAX_CPUS
+        ).set_memory_limit(MAX_MEMORY)
 
     with dsl.Else():
         training_task_mq = autogluon_models_training(**_training_kwargs)
         training_task_mq.set_caching_options(False)
-        training_task_mq.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+        training_task_mq.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
             MAX_MEMORY
         )
-
-    # Generate leaderboard
-    leaderboard_evaluation_task = leaderboard_evaluation(
-        models_artifact=dsl.OneOf(
-            training_task_gq.outputs["models_artifact"], training_task_mq.outputs["models_artifact"]
-        ),
-        eval_metric=dsl.OneOf(training_task_gq.outputs["eval_metric"], training_task_mq.outputs["eval_metric"]),
-    )
-    leaderboard_evaluation_task.set_caching_options(False)
-    leaderboard_evaluation_task.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
-        MAX_MEMORY
-    )
+        leaderboard_evaluation_task = leaderboard_evaluation(
+            models_artifact=training_task_mq.outputs["models_artifact"],
+            eval_metric=training_task_mq.outputs["eval_metric"],
+        )
+        leaderboard_evaluation_task.set_caching_options(False)
+        leaderboard_evaluation_task.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(
+            MAX_CPUS
+        ).set_memory_limit(MAX_MEMORY)
 
 
 if __name__ == "__main__":

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from kfp import dsl
 from kfp_components.components.data_processing.automl.tabular_data_loader import automl_data_loader
 from kfp_components.components.training.automl.autogluon_leaderboard_evaluation import leaderboard_evaluation
@@ -40,7 +38,7 @@ def autogluon_tabular_training_pipeline(
     task_type: str,
     top_n: int = 3,
     preset: str = "medium_quality",
-    eval_metric: Optional[str] = None,
+    eval_metric: str = "",
 ):
     """AutoGluon Tabular Training Pipeline.
 
@@ -117,7 +115,7 @@ def autogluon_tabular_training_pipeline(
         top_n: Number of top models to select and refit (default: 3); positive integer from range [1, 10].
         preset: AutoGluon quality tier (default: ``"medium_quality"``, 4 vCPU / 16 GiB).
             ``"good_quality"`` trains stronger models at higher resource cost (5 vCPU / 16 GiB).
-        eval_metric: Metric used for model ranking. When None, AutoGluon's task-type default applies ("accuracy" for classification, "r2" for regression).
+        eval_metric: Metric used for model ranking. Empty string (default) lets AutoGluon pick the task-type default ("accuracy" for classification, "r2" for regression).
 
     Returns:
         HTML artifact with leaderboard of refitted models ranked by task_type metric (e.g. accuracy, r2).

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_configs.json
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_configs.json
@@ -5,25 +5,7 @@
     "label_column": "price",
     "problem_type": "regression",
     "task_type": "regression",
-    "automl_settings": { "top_n": 2 },
+    "automl_settings": { "top_n": 2 , "eval_metric": "r2"},
     "tags": ["regression", "smoke"]
-  },
-  {
-    "id": "classification_binary",
-    "dataset_path": "data/classification.csv",
-    "label_column": "target",
-    "problem_type": "classification",
-    "task_type": "binary",
-    "automl_settings": { "top_n": 2 },
-    "tags": ["classification", "binary", "smoke"]
-  },
-  {
-    "id": "classification_multiclass",
-    "dataset_path": "data/multiclass.csv",
-    "label_column": "target",
-    "problem_type": "classification",
-    "task_type": "multiclass",
-    "automl_settings": { "top_n": 2 },
-    "tags": ["classification", "multiclass"]
   }
 ]

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_configs.json
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_configs.json
@@ -5,7 +5,25 @@
     "label_column": "price",
     "problem_type": "regression",
     "task_type": "regression",
-    "automl_settings": { "top_n": 2 , "eval_metric": "r2"},
+    "automl_settings": { "top_n": 2, "eval_metric": "r2" },
     "tags": ["regression", "smoke"]
+  },
+  {
+    "id": "classification_binary",
+    "dataset_path": "data/classification.csv",
+    "label_column": "target",
+    "problem_type": "classification",
+    "task_type": "binary",
+    "automl_settings": { "top_n": 2 },
+    "tags": ["classification", "binary", "smoke"]
+  },
+  {
+    "id": "classification_multiclass",
+    "dataset_path": "data/multiclass.csv",
+    "label_column": "target",
+    "problem_type": "classification",
+    "task_type": "multiclass",
+    "automl_settings": { "top_n": 2 },
+    "tags": ["classification", "multiclass"]
   }
 ]

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_configs.json
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_configs.json
@@ -25,5 +25,23 @@
     "task_type": "multiclass",
     "automl_settings": { "top_n": 2 },
     "tags": ["classification", "multiclass"]
+  },
+  {
+    "id": "regression_good_quality_preset",
+    "dataset_path": "data/regression.csv",
+    "label_column": "price",
+    "problem_type": "regression",
+    "task_type": "regression",
+    "automl_settings": { "top_n": 2, "preset": "good_quality" },
+    "tags": ["regression", "preset"]
+  },
+  {
+    "id": "classification_binary_eval_metric",
+    "dataset_path": "data/classification.csv",
+    "label_column": "target",
+    "problem_type": "classification",
+    "task_type": "binary",
+    "automl_settings": { "top_n": 2, "eval_metric": "f1" },
+    "tags": ["classification", "binary", "eval_metric"]
   }
 ]

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
@@ -13,9 +13,8 @@ from ..pipeline import autogluon_tabular_training_pipeline
 
 # Root DAG task IDs from ``root.dag.tasks`` (fresh compile). Update when the graph changes.
 _EXPECTED_ROOT_DAG_TASK_IDS = (
-    "autogluon-models-training",
     "automl-data-loader",
-    "leaderboard-evaluation",
+    "condition-branches-1",
 )
 
 
@@ -52,11 +51,15 @@ class TestAutogluonTabularTrainingPipelineUnitTests:
             "label_column",
             "task_type",
             "top_n",
+            "preset",
+            "eval_metric",
         }
         inputs = autogluon_tabular_training_pipeline.component_spec.inputs
         params = set(inputs.keys())
         assert params == expected_params, f"Pipeline params {params} != expected {expected_params}"
         assert inputs["top_n"].default == 3
+        assert inputs["preset"].default == "medium_quality"
+        assert inputs["eval_metric"].default is None
 
     def test_compiled_pipeline_has_expected_inputs(self):
         """Test that the compiled pipeline YAML contains expected pipeline inputs."""

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
@@ -59,7 +59,7 @@ class TestAutogluonTabularTrainingPipelineUnitTests:
         assert params == expected_params, f"Pipeline params {params} != expected {expected_params}"
         assert inputs["top_n"].default == 3
         assert inputs["preset"].default == "medium_quality"
-        assert inputs["eval_metric"].default is None
+        assert inputs["eval_metric"].default == ""
 
     def test_compiled_pipeline_has_expected_inputs(self):
         """Test that the compiled pipeline YAML contains expected pipeline inputs."""

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -30,7 +30,7 @@ file (CSV or Parquet). File must include columns for item_id, timestamp, and tar
 column that identifies each time series (e.g. product_id, store_id). Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. timestamp_column: Name of the column containing the timestamp/datetime for each observation. Passed as ``timestamp_column`` when constructing
 TimeSeriesDataFrame; result uses ``timestamp`` as the second index level. known_covariates_names: Optional list of column names known in advance for the forecast horizon (e.g. holidays, promotions). See :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`. prediction_length:
 Number of time steps to forecast (horizon length). Positive integer (default: 1). top_n: Number of top models to select for the leaderboard and output (default: 3). preset: AutoGluon quality tier (default: ``"fast_training"``). ``"medium_quality"`` adds TemporalFusionTransformer at higher resource
-cost (8 vCPU / 32 GiB); Chronos2/Toto are excluded regardless. eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or snake_case form. Normalized to snake_case internally (default: ``"MASE"``).
+cost (8 vCPU / 32 GiB); Chronos2/Toto are excluded regardless. eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or snake_case form. Defaults to ``"MASE"``.
 
 Returns: This pipeline wires task outputs between components; compiled runs expose artifacts from the refit tasks (Model artifacts with predictor, metrics, notebook paths) and the leaderboard evaluation task (HTML leaderboard and aggregated metrics), subject to Kubeflow Pipelines UI and artifact
 configuration.

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -29,7 +29,8 @@ Args: train_data_secret_name: Kubernetes secret name containing S3 credentials (
 file (CSV or Parquet). File must include columns for item_id, timestamp, and target; optional columns for known covariates. target: Name of the column containing the numeric values to forecast. Corresponds to :attr:`~autogluon.timeseries.TimeSeriesDataFrame` target column. id_column: Name of the
 column that identifies each time series (e.g. product_id, store_id). Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. timestamp_column: Name of the column containing the timestamp/datetime for each observation. Passed as ``timestamp_column`` when constructing
 TimeSeriesDataFrame; result uses ``timestamp`` as the second index level. known_covariates_names: Optional list of column names known in advance for the forecast horizon (e.g. holidays, promotions). See :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`. prediction_length:
-Number of time steps to forecast (horizon length). Positive integer (default: 1). top_n: Number of top models to select for the leaderboard and output (default: 3).
+Number of time steps to forecast (horizon length). Positive integer (default: 1). top_n: Number of top models to select for the leaderboard and output (default: 3). preset: AutoGluon quality tier (default: ``"fast_training"``). ``"medium_quality"`` adds TemporalFusionTransformer at higher resource
+cost (8 vCPU / 32 GiB); Chronos2/Toto are excluded regardless. eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or snake_case form. Normalized to snake_case internally (default: ``"MASE"``).
 
 Returns: This pipeline wires task outputs between components; compiled runs expose artifacts from the refit tasks (Model artifacts with predictor, metrics, notebook paths) and the leaderboard evaluation task (HTML leaderboard and aggregated metrics), subject to Kubeflow Pipelines UI and artifact
 configuration.
@@ -52,6 +53,8 @@ prediction_length=14, top_n=3, )
 | `known_covariates_names` | `Optional[List[str]]` | `None` |  |
 | `prediction_length` | `int` | `1` |  |
 | `top_n` | `int` | `3` |  |
+| `preset` | `str` | `fast_training` |  |
+| `eval_metric` | `str` | `MASE` |  |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
@@ -188,8 +188,7 @@ def autogluon_timeseries_training_pipeline(
         # Stage 2: Model Selection
         selection_task_mq = autogluon_timeseries_models_selection(**_selection_kwargs)
         selection_task_mq.set_caching_options(False)
-        # TODO: change to the planned size
-        selection_task_mq.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+        selection_task_mq.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
             MAX_MEMORY
         )
 
@@ -202,7 +201,7 @@ def autogluon_timeseries_training_pipeline(
                 **_refit_base_kwargs,
             )
             refit_task.set_caching_options(False)
-            refit_task.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            refit_task.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
                 MAX_MEMORY
             )
 
@@ -220,7 +219,7 @@ def autogluon_timeseries_training_pipeline(
         # Stage 2: Model Selection
         selection_task_ft = autogluon_timeseries_models_selection(**_selection_kwargs)
         selection_task_ft.set_caching_options(False)
-        selection_task_ft.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+        selection_task_ft.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
             MAX_MEMORY
         )
 
@@ -233,7 +232,7 @@ def autogluon_timeseries_training_pipeline(
                 **_refit_base_kwargs,
             )
             refit_task.set_caching_options(False)
-            refit_task.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            refit_task.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
                 MAX_MEMORY
             )
 

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
@@ -46,6 +46,8 @@ def autogluon_timeseries_training_pipeline(
     known_covariates_names: Optional[List[str]] = None,
     prediction_length: int = 1,
     top_n: int = 3,
+    preset: str = "fast_training",
+    eval_metric: str = "MASE",
 ):
     """AutoGluon time series training pipeline.
 
@@ -101,6 +103,11 @@ def autogluon_timeseries_training_pipeline(
         prediction_length: Number of time steps to forecast (horizon length). Positive integer
             (default: 1).
         top_n: Number of top models to select for the leaderboard and output (default: 3).
+        preset: AutoGluon quality tier (default: ``"fast_training"``). ``"medium_quality"``
+            adds TemporalFusionTransformer at higher resource cost (8 vCPU / 32 GiB);
+            Chronos2/Toto are excluded regardless.
+        eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or
+            snake_case form. Normalized to snake_case internally (default: ``"MASE"``).
 
     Returns:
         This pipeline wires task outputs between components; compiled runs expose artifacts from the
@@ -165,6 +172,8 @@ def autogluon_timeseries_training_pipeline(
         workspace_path=dsl.WORKSPACE_PATH_PLACEHOLDER,
         prediction_length=prediction_length,
         known_covariates_names=known_covariates_names,
+        preset=preset,
+        eval_metric=eval_metric,
     )
     selection_task.set_caching_options(False)
     selection_task.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(MAX_MEMORY)

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
@@ -107,7 +107,7 @@ def autogluon_timeseries_training_pipeline(
             adds TemporalFusionTransformer at higher resource cost (8 vCPU / 32 GiB);
             Chronos2/Toto are excluded regardless.
         eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or
-            snake_case form. Normalized to snake_case internally (default: ``"MASE"``).
+            snake_case form. Defaults to ``"MASE"``.
 
     Returns:
         This pipeline wires task outputs between components; compiled runs expose artifacts from the
@@ -160,9 +160,7 @@ def autogluon_timeseries_training_pipeline(
         optional=True,
     )
 
-    # Stage 2: Model Selection
-    # Train multiple models on selection data and select top N performers
-    selection_task = autogluon_timeseries_models_selection(
+    _selection_kwargs = dict(
         target=target,
         id_column=id_column,
         timestamp_column=timestamp_column,
@@ -175,35 +173,79 @@ def autogluon_timeseries_training_pipeline(
         preset=preset,
         eval_metric=eval_metric,
     )
-    selection_task.set_caching_options(False)
-    selection_task.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(MAX_MEMORY)
-
-    # Stage 3: Model Refitting (parallelism=1: RWO workspace allows only one pod on the volume at a time).
-    with dsl.ParallelFor(items=selection_task.outputs["top_models"], parallelism=1) as model_name:
-        refit_task = autogluon_timeseries_models_full_refit(
-            model_name=model_name,
-            test_dataset=data_loader_task.outputs["sampled_test_dataset"],
-            predictor_path=selection_task.outputs["predictor_path"],
-            sampling_config=data_loader_task.outputs["sample_config"],
-            split_config=data_loader_task.outputs["split_config"],
-            model_config=selection_task.outputs["model_config"],
-            pipeline_name=dsl.PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER,
-            run_id=dsl.PIPELINE_JOB_ID_PLACEHOLDER,
-            models_selection_train_data_path=data_loader_task.outputs["models_selection_train_data_path"],
-            extra_train_data_path=data_loader_task.outputs["extra_train_data_path"],
-            sample_rows=data_loader_task.outputs["sample_rows"],
-        )
-        refit_task.set_caching_options(False)
-        refit_task.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(MAX_MEMORY)
-
-    # Stage 4: Leaderboard Evaluation
-    # Generate leaderboard from all refitted models
-    leaderboard_task = timeseries_leaderboard_evaluation(
-        models=dsl.Collected(refit_task.outputs["model_artifact"]),
-        eval_metric=selection_task.outputs["eval_metric_name"],
+    _refit_base_kwargs = dict(
+        test_dataset=data_loader_task.outputs["sampled_test_dataset"],
+        sampling_config=data_loader_task.outputs["sample_config"],
+        split_config=data_loader_task.outputs["split_config"],
+        pipeline_name=dsl.PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER,
+        run_id=dsl.PIPELINE_JOB_ID_PLACEHOLDER,
+        models_selection_train_data_path=data_loader_task.outputs["models_selection_train_data_path"],
+        extra_train_data_path=data_loader_task.outputs["extra_train_data_path"],
+        sample_rows=data_loader_task.outputs["sample_rows"],
     )
-    leaderboard_task.set_caching_options(False)
-    leaderboard_task.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(MAX_MEMORY)
+    # TODO: when possible, the leaderboard evaluation task should be outside the if/else block
+    with dsl.If(preset == "medium_quality"):
+        # Stage 2: Model Selection
+        selection_task_mq = autogluon_timeseries_models_selection(**_selection_kwargs)
+        selection_task_mq.set_caching_options(False)
+        # TODO: change to the planned size
+        selection_task_mq.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
+
+        # Stage 3: Model Refitting (parallelism=1: RWO workspace allows only one pod on the volume at a time).
+        with dsl.ParallelFor(items=selection_task_mq.outputs["top_models"], parallelism=1) as model_name:
+            refit_task = autogluon_timeseries_models_full_refit(
+                model_name=model_name,
+                predictor_path=selection_task_mq.outputs["predictor_path"],
+                model_config=selection_task_mq.outputs["model_config"],
+                **_refit_base_kwargs,
+            )
+            refit_task.set_caching_options(False)
+            refit_task.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+                MAX_MEMORY
+            )
+
+        # Stage 4: Leaderboard Evaluation
+        leaderboard_task = timeseries_leaderboard_evaluation(
+            models=dsl.Collected(refit_task.outputs["model_artifact"]),
+            eval_metric=selection_task_mq.outputs["eval_metric_name"],
+        )
+        leaderboard_task.set_caching_options(False)
+        leaderboard_task.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
+
+    with dsl.Else():
+        # Stage 2: Model Selection
+        selection_task_ft = autogluon_timeseries_models_selection(**_selection_kwargs)
+        selection_task_ft.set_caching_options(False)
+        selection_task_ft.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
+
+        # Stage 3: Model Refitting (parallelism=1: RWO workspace allows only one pod on the volume at a time).
+        with dsl.ParallelFor(items=selection_task_ft.outputs["top_models"], parallelism=1) as model_name:
+            refit_task = autogluon_timeseries_models_full_refit(
+                model_name=model_name,
+                predictor_path=selection_task_ft.outputs["predictor_path"],
+                model_config=selection_task_ft.outputs["model_config"],
+                **_refit_base_kwargs,
+            )
+            refit_task.set_caching_options(False)
+            refit_task.set_cpu_request("2").set_memory_request("8Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+                MAX_MEMORY
+            )
+
+        # Stage 4: Leaderboard Evaluation
+        leaderboard_task = timeseries_leaderboard_evaluation(
+            models=dsl.Collected(refit_task.outputs["model_artifact"]),
+            eval_metric=selection_task_ft.outputs["eval_metric_name"],
+        )
+        leaderboard_task.set_caching_options(False)
+        leaderboard_task.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
 
 
 if __name__ == "__main__":

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_configs.json
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_configs.json
@@ -19,5 +19,29 @@
     "prediction_length": 10,
     "top_n": 2,
     "tags": ["smoke", "timeseries"]
+  },
+  {
+    "id": "timeseries_medium_quality_preset",
+    "dataset_path": "data/timeseries_sales.csv",
+    "target": "target",
+    "id_column": "item_id",
+    "timestamp_column": "timestamp",
+    "known_covariates_names": ["promo"],
+    "prediction_length": 2,
+    "top_n": 2,
+    "preset": "medium_quality",
+    "tags": ["timeseries", "preset"]
+  },
+  {
+    "id": "timeseries_wql_eval_metric",
+    "dataset_path": "data/timeseries_sales.csv",
+    "target": "target",
+    "id_column": "item_id",
+    "timestamp_column": "timestamp",
+    "known_covariates_names": ["promo"],
+    "prediction_length": 2,
+    "top_n": 2,
+    "eval_metric": "WQL",
+    "tags": ["timeseries", "eval_metric"]
   }
 ]

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_configs.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_configs.py
@@ -30,6 +30,8 @@ class TestConfig:
     prediction_length: int
     top_n: int
     tags: list[str]
+    preset: str = "fast_training"
+    eval_metric: str = "MASE"
 
     def get_pipeline_arguments(
         self,
@@ -48,6 +50,8 @@ class TestConfig:
             "known_covariates_names": self.known_covariates_names,
             "prediction_length": self.prediction_length,
             "top_n": self.top_n,
+            "preset": self.preset,
+            "eval_metric": self.eval_metric,
         }
 
 
@@ -85,6 +89,8 @@ def _load_configs() -> list[TestConfig]:
                     prediction_length=int(item.get("prediction_length", 1)),
                     top_n=int(item.get("top_n", 3)),
                     tags=tags,
+                    preset=str(item.get("preset", "fast_training")),
+                    eval_metric=str(item.get("eval_metric", "MASE")),
                 )
             )
         except KeyError as e:

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
@@ -12,10 +12,8 @@ from kfp_components.utils.pipeline_dag_tasks import (
 from ..pipeline import autogluon_timeseries_training_pipeline
 
 _EXPECTED_ROOT_DAG_TASK_IDS = (
-    "autogluon-timeseries-models-selection",
-    "for-loop-1",
+    "condition-branches-1",
     "timeseries-data-loader",
-    "timeseries-leaderboard-evaluation",
 )
 
 
@@ -54,6 +52,8 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
             "known_covariates_names",
             "prediction_length",
             "top_n",
+            "preset",
+            "eval_metric",
         }
         inputs = autogluon_timeseries_training_pipeline.component_spec.inputs
         params = set(inputs.keys())
@@ -61,6 +61,8 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
         assert inputs["prediction_length"].default == 1
         assert inputs["top_n"].default == 3
         assert inputs["known_covariates_names"].default is None
+        assert inputs["preset"].default == "fast_training"
+        assert inputs["eval_metric"].default == "MASE"
 
     def test_compiled_pipeline_has_expected_inputs(self):
         """Test that compiled pipeline YAML contains expected pipeline input names."""


### PR DESCRIPTION
**Description of your changes:**
Exposes preset and eval_metric as configurable pipeline parameters for both tabular and timeseries AutoML pipelines.

  **Tabular**
  - preset: "medium_quality" (default, 4 vCPU/16 GiB, 30 min) or "good_quality" (8 vCPU/32 GiB, 60 min). Each uses a distinct fit() config;
  good_quality disables AutoGluon's built-in refit so the pipeline controls it explicitly. 
  - eval_metric: defaults to "r2" for regression, "accuracy" for classification.
  - Pipeline branches with dsl.If/Else on preset to set per-tier resource requests.

  **Timeseries**
  - preset: "fast_training" (default, 4 vCPU/16 GiB) or "medium_quality" (8 vCPU/32 GiB).
  - eval_metric: defaults to "MASE"; passed through to AutoGluon as-is (acronym or snake_case).
  - excluded_model_types (Chronos, Toto, Chronos2) enforced on all presets.

  **Both**: unknown preset values are rejected before any IO; eval_metric is stored in model_config metadata for downstream consumers.

  **Test plan**

  - Unit tests: preset/eval_metric forwarding, invalid preset rejection, resource branching, model_config correctness
  - Pipeline unit tests: updated root DAG task IDs, new params asserted on compiled spec
  - Integration test configs: good_quality preset, f1/WQL eval metrics, medium_quality timeseries
  - 
**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `preset` parameter to control AutoGluon quality/resource tier for model training (options include "medium_quality", "good_quality" for tabular; "fast_training", "medium_quality" for timeseries)
  * Added optional `eval_metric` parameter to override the ranking metric for models (auto-resolves to appropriate defaults when not specified)

* **Documentation**
  * Updated training pipeline and component documentation to describe new `preset` and `eval_metric` parameters and their default values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->