### PR TITLE
fix: overriding RELATED_IMAGE in the init-managed-pipelines container

### DIFF
--- a/scripts/generate_managed_pipelines/generate_managed_pipelines.py
+++ b/scripts/generate_managed_pipelines/generate_managed_pipelines.py
@@ -223,10 +223,7 @@ def _module_name_for_compilation(pipeline_py: Path, repo_root: Path) -> str:
 
 def should_recompile_managed_pipelines() -> bool:
     """Return True when DSPO/runtime env provides RELATED_IMAGE overrides for managed runtimes."""
-    return bool(
-        os.getenv(RELATED_IMAGE_AUTOML_ENV, "").strip()
-        or os.getenv(RELATED_IMAGE_AUTORAG_ENV, "").strip()
-    )
+    return bool(os.getenv(RELATED_IMAGE_AUTOML_ENV, "").strip() or os.getenv(RELATED_IMAGE_AUTORAG_ENV, "").strip())
 
 
 def stage_managed_pipelines(repo_root: Path, output_dir: Path) -> int:

--- a/scripts/generate_managed_pipelines/generate_managed_pipelines.py
+++ b/scripts/generate_managed_pipelines/generate_managed_pipelines.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
@@ -23,6 +24,9 @@ from .pipeline_description import extract_pipeline_description_from_file
 OUTPUT_FILENAME = "managed-pipelines.json"
 METADATA_FILENAME = "metadata.yaml"
 PIPELINE_PY = "pipeline.py"
+
+RELATED_IMAGE_AUTOML_ENV = "RELATED_IMAGE_ODH_AUTOML_IMAGE"
+RELATED_IMAGE_AUTORAG_ENV = "RELATED_IMAGE_ODH_AUTORAG_IMAGE"
 
 # Must match values accepted in metadata.yaml (see scripts/validate_metadata).
 METADATA_STABILITY_VALUES = frozenset({"experimental", "alpha", "beta", "stable"})
@@ -217,6 +221,63 @@ def _module_name_for_compilation(pipeline_py: Path, repo_root: Path) -> str:
         return "managed_compile_" + pipeline_py.stem
 
 
+def should_recompile_managed_pipelines() -> bool:
+    """Return True when DSPO/runtime env provides RELATED_IMAGE overrides for managed runtimes."""
+    return bool(
+        os.getenv(RELATED_IMAGE_AUTOML_ENV, "").strip()
+        or os.getenv(RELATED_IMAGE_AUTORAG_ENV, "").strip()
+    )
+
+
+def stage_managed_pipelines(repo_root: Path, output_dir: Path) -> int:
+    """Write ``managed-pipelines.json`` and compiled ``{name}.yaml`` files under ``output_dir``.
+
+    Compiles from ``repo_root`` sources without writing under ``repo_root`` (safe for read-only
+    ``/app`` in the init container).
+
+    Returns:
+        0 on success, 1 on error (messages printed to stderr).
+    """
+    pipelines_root = repo_root / "pipelines"
+    if not pipelines_root.is_dir():
+        print(
+            f"Error: pipelines directory not found or not a directory: {pipelines_root}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        pipelines = collect_managed_pipelines(repo_root)
+    except ManagedPipelineMetadataError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = output_dir / OUTPUT_FILENAME
+    payload = [asdict(entry) for entry in pipelines]
+    manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {len(pipelines)} pipeline(s) to {manifest_path}", file=sys.stderr)
+
+    for entry in pipelines:
+        pipeline_py = repo_root / entry.path
+        output_yaml = output_dir / f"{entry.name}.yaml"
+        try:
+            compile_managed_pipeline(
+                pipeline_py=pipeline_py,
+                output_path=output_yaml,
+                repo_root=repo_root,
+            )
+        except ManagedPipelineCompilationError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+        print(f"Compiled {entry.name} -> {output_yaml}", file=sys.stderr)
+
+    return 0
+
+
 def compile_managed_pipeline(
     *,
     pipeline_py: Path,
@@ -269,16 +330,10 @@ def main() -> int:
     args = parser.parse_args()
 
     repo_root = get_repo_root()
-    output_path = args.output if args.output is not None else repo_root / OUTPUT_FILENAME
+    if args.output is None:
+        return stage_managed_pipelines_for_build(repo_root)
 
-    pipelines_root = repo_root / "pipelines"
-    if not pipelines_root.is_dir():
-        print(
-            f"Error: pipelines directory not found or not a directory: {pipelines_root}",
-            file=sys.stderr,
-        )
-        return 1
-
+    output_path = args.output
     try:
         pipelines = collect_managed_pipelines(repo_root)
     except ManagedPipelineMetadataError as e:
@@ -289,8 +344,42 @@ def main() -> int:
         return 1
 
     payload = [asdict(entry) for entry in pipelines]
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     print(f"Wrote {len(pipelines)} pipeline(s) to {output_path}", file=sys.stderr)
+
+    for entry in pipelines:
+        pipeline_py = repo_root / entry.path
+        output_yaml = pipeline_py.parent / "pipeline.yaml"
+        try:
+            compile_managed_pipeline(
+                pipeline_py=pipeline_py,
+                output_path=output_yaml,
+                repo_root=repo_root,
+            )
+        except ManagedPipelineCompilationError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+        print(f"Compiled {entry.name} -> {output_yaml}", file=sys.stderr)
+
+    return 0
+
+
+def stage_managed_pipelines_for_build(repo_root: Path) -> int:
+    """Build-time default: manifest at repo root, YAML next to each ``pipeline.py``."""
+    try:
+        pipelines = collect_managed_pipelines(repo_root)
+    except ManagedPipelineMetadataError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    manifest_path = repo_root / OUTPUT_FILENAME
+    payload = [asdict(entry) for entry in pipelines]
+    manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {len(pipelines)} pipeline(s) to {manifest_path}", file=sys.stderr)
 
     for entry in pipelines:
         pipeline_py = repo_root / entry.path

--- a/scripts/generate_managed_pipelines/generate_managed_pipelines.py
+++ b/scripts/generate_managed_pipelines/generate_managed_pipelines.py
@@ -6,7 +6,7 @@ import argparse
 import json
 import os
 import sys
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -25,8 +25,7 @@ OUTPUT_FILENAME = "managed-pipelines.json"
 METADATA_FILENAME = "metadata.yaml"
 PIPELINE_PY = "pipeline.py"
 
-RELATED_IMAGE_AUTOML_ENV = "RELATED_IMAGE_ODH_AUTOML_IMAGE"
-RELATED_IMAGE_AUTORAG_ENV = "RELATED_IMAGE_ODH_AUTORAG_IMAGE"
+RELATED_IMAGE_ENV_PREFIX = "RELATED_IMAGE_"
 
 # Must match values accepted in metadata.yaml (see scripts/validate_metadata).
 METADATA_STABILITY_VALUES = frozenset({"experimental", "alpha", "beta", "stable"})
@@ -232,45 +231,47 @@ def staged_pipeline_yaml_path(output_dir: Path, name: str) -> Path:
 
 
 def should_recompile_managed_pipelines() -> bool:
-    """Return True when DSPO/runtime env provides RELATED_IMAGE overrides for managed runtimes."""
-    return bool(os.getenv(RELATED_IMAGE_AUTOML_ENV, "").strip() or os.getenv(RELATED_IMAGE_AUTORAG_ENV, "").strip())
+    """Return True when DSPO/runtime env provides any non-empty ``RELATED_IMAGE_*`` override."""
+    return any(key.startswith(RELATED_IMAGE_ENV_PREFIX) and value.strip() for key, value in os.environ.items())
 
 
-def stage_managed_pipelines(repo_root: Path, output_dir: Path) -> int:
-    """Write ``managed-pipelines.json`` and compiled ``{name}.yaml`` files under ``output_dir``.
+OutputYamlPathFn = Callable[[ManagedPipelineEntry, Path], Path]
 
-    Compiles from ``repo_root`` sources without writing under ``repo_root`` (safe for read-only
-    ``/app`` in the init container).
+
+def _output_yaml_next_to_pipeline_py(_entry: ManagedPipelineEntry, pipeline_py: Path) -> Path:
+    return pipeline_py.parent / "pipeline.yaml"
+
+
+def emit_managed_pipelines(
+    repo_root: Path,
+    manifest_path: Path,
+    *,
+    output_yaml_path: OutputYamlPathFn,
+) -> int:
+    """Collect managed pipelines, write the manifest JSON, and compile each pipeline YAML.
+
+    Args:
+        repo_root: Repository root used to resolve ``pipeline.py`` paths.
+        manifest_path: Destination path for ``managed-pipelines.json`` (or custom ``-o`` path).
+        output_yaml_path: Callback mapping ``(entry, pipeline_py)`` to the compiled YAML path.
 
     Returns:
         0 on success, 1 on error (messages printed to stderr).
     """
-    pipelines_root = repo_root / "pipelines"
-    if not pipelines_root.is_dir():
-        print(
-            f"Error: pipelines directory not found or not a directory: {pipelines_root}",
-            file=sys.stderr,
-        )
-        return 1
-
     try:
         pipelines = collect_managed_pipelines(repo_root)
-    except ManagedPipelineMetadataError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
-    except FileNotFoundError as e:
+    except (ManagedPipelineMetadataError, FileNotFoundError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 
-    output_dir.mkdir(parents=True, exist_ok=True)
-    manifest_path = output_dir / OUTPUT_FILENAME
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
     payload = [asdict(entry) for entry in pipelines]
     manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     print(f"Wrote {len(pipelines)} pipeline(s) to {manifest_path}", file=sys.stderr)
 
     for entry in pipelines:
         pipeline_py = repo_root / entry.path
-        output_yaml = staged_pipeline_yaml_path(output_dir, entry.name)
+        output_yaml = output_yaml_path(entry, pipeline_py)
         try:
             compile_managed_pipeline(
                 pipeline_py=pipeline_py,
@@ -283,6 +284,22 @@ def stage_managed_pipelines(repo_root: Path, output_dir: Path) -> int:
         print(f"Compiled {entry.name} -> {output_yaml}", file=sys.stderr)
 
     return 0
+
+
+def stage_managed_pipelines(repo_root: Path, output_dir: Path) -> int:
+    """Write ``managed-pipelines.json`` and compiled ``{name}.yaml`` files under ``output_dir``.
+
+    Compiles from ``repo_root`` sources without writing under ``repo_root`` (safe for read-only
+    ``/app`` in the init container).
+
+    Returns:
+        0 on success, 1 on error (messages printed to stderr).
+    """
+    return emit_managed_pipelines(
+        repo_root,
+        output_dir / OUTPUT_FILENAME,
+        output_yaml_path=lambda entry, pipeline_py: staged_pipeline_yaml_path(output_dir, entry.name),
+    )
 
 
 def compile_managed_pipeline(
@@ -340,69 +357,20 @@ def main() -> int:
     if args.output is None:
         return stage_managed_pipelines_for_build(repo_root)
 
-    output_path = args.output
-    try:
-        pipelines = collect_managed_pipelines(repo_root)
-    except ManagedPipelineMetadataError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
-    except FileNotFoundError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
-
-    payload = [asdict(entry) for entry in pipelines]
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-    print(f"Wrote {len(pipelines)} pipeline(s) to {output_path}", file=sys.stderr)
-
-    for entry in pipelines:
-        pipeline_py = repo_root / entry.path
-        output_yaml = pipeline_py.parent / "pipeline.yaml"
-        try:
-            compile_managed_pipeline(
-                pipeline_py=pipeline_py,
-                output_path=output_yaml,
-                repo_root=repo_root,
-            )
-        except ManagedPipelineCompilationError as e:
-            print(f"Error: {e}", file=sys.stderr)
-            return 1
-        print(f"Compiled {entry.name} -> {output_yaml}", file=sys.stderr)
-
-    return 0
+    return emit_managed_pipelines(
+        repo_root,
+        args.output,
+        output_yaml_path=_output_yaml_next_to_pipeline_py,
+    )
 
 
 def stage_managed_pipelines_for_build(repo_root: Path) -> int:
     """Build-time default: manifest at repo root, YAML next to each ``pipeline.py``."""
-    try:
-        pipelines = collect_managed_pipelines(repo_root)
-    except ManagedPipelineMetadataError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
-    except FileNotFoundError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        return 1
-
-    manifest_path = repo_root / OUTPUT_FILENAME
-    payload = [asdict(entry) for entry in pipelines]
-    manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-    print(f"Wrote {len(pipelines)} pipeline(s) to {manifest_path}", file=sys.stderr)
-
-    for entry in pipelines:
-        pipeline_py = repo_root / entry.path
-        output_yaml = pipeline_py.parent / "pipeline.yaml"
-        try:
-            compile_managed_pipeline(
-                pipeline_py=pipeline_py,
-                output_path=output_yaml,
-                repo_root=repo_root,
-            )
-        except ManagedPipelineCompilationError as e:
-            print(f"Error: {e}", file=sys.stderr)
-            return 1
-        print(f"Compiled {entry.name} -> {output_yaml}", file=sys.stderr)
-
-    return 0
+    return emit_managed_pipelines(
+        repo_root,
+        repo_root / OUTPUT_FILENAME,
+        output_yaml_path=_output_yaml_next_to_pipeline_py,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/generate_managed_pipelines/generate_managed_pipelines.py
+++ b/scripts/generate_managed_pipelines/generate_managed_pipelines.py
@@ -221,6 +221,16 @@ def _module_name_for_compilation(pipeline_py: Path, repo_root: Path) -> str:
         return "managed_compile_" + pipeline_py.stem
 
 
+def staged_pipeline_yaml_path(output_dir: Path, name: str) -> Path:
+    """Return a resolved ``{name}.yaml`` path confined to ``output_dir``."""
+    if not name or name != Path(name).name or name in (".", ".."):
+        raise ValueError(f"Invalid pipeline name for staging: {name!r}")
+    dest = (output_dir / f"{name}.yaml").resolve()
+    if not dest.is_relative_to(output_dir.resolve()):
+        raise ValueError(f"Staged path escapes output dir: {name!r}")
+    return dest
+
+
 def should_recompile_managed_pipelines() -> bool:
     """Return True when DSPO/runtime env provides RELATED_IMAGE overrides for managed runtimes."""
     return bool(os.getenv(RELATED_IMAGE_AUTOML_ENV, "").strip() or os.getenv(RELATED_IMAGE_AUTORAG_ENV, "").strip())
@@ -260,7 +270,7 @@ def stage_managed_pipelines(repo_root: Path, output_dir: Path) -> int:
 
     for entry in pipelines:
         pipeline_py = repo_root / entry.path
-        output_yaml = output_dir / f"{entry.name}.yaml"
+        output_yaml = staged_pipeline_yaml_path(output_dir, entry.name)
         try:
             compile_managed_pipeline(
                 pipeline_py=pipeline_py,

--- a/scripts/generate_managed_pipelines/tests/test_generate_managed_pipelines.py
+++ b/scripts/generate_managed_pipelines/tests/test_generate_managed_pipelines.py
@@ -9,6 +9,8 @@ import yaml
 
 from ..generate_managed_pipelines import (
     METADATA_STABILITY_VALUES,
+    RELATED_IMAGE_AUTOML_ENV,
+    RELATED_IMAGE_AUTORAG_ENV,
     STABILITY_TO_MANAGED_DISPLAY,
     ManagedPipelineCompilationError,
     ManagedPipelineMetadataError,
@@ -16,6 +18,8 @@ from ..generate_managed_pipelines import (
     compile_managed_pipeline,
     main,
     managed_pipeline_entry_from_dir,
+    should_recompile_managed_pipelines,
+    stage_managed_pipelines,
 )
 
 
@@ -238,6 +242,85 @@ class TestCompileManagedPipeline:
                 output_path=output_yaml,
                 repo_root=tmp_path,
             )
+
+
+# ---------------------------------------------------------------------------
+# should_recompile_managed_pipelines / stage_managed_pipelines (init path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("env",
+    "expected"),
+    [
+        ({}, False),
+        ({RELATED_IMAGE_AUTOML_ENV: ""}, False),
+        ({RELATED_IMAGE_AUTOML_ENV: "   "}, False),
+        ({RELATED_IMAGE_AUTOML_ENV: "quay.io/example/automl-runtime@sha256:aaa"}, True),
+        ({RELATED_IMAGE_AUTORAG_ENV: "quay.io/example/autorag-runtime@sha256:bbb"}, True),
+        (
+            {
+                RELATED_IMAGE_AUTOML_ENV: "quay.io/example/automl-runtime@sha256:aaa",
+                RELATED_IMAGE_AUTORAG_ENV: "quay.io/example/autorag-runtime@sha256:bbb",
+            },
+            True,
+        ),
+    ],
+)
+def test_should_recompile_managed_pipelines(
+    monkeypatch: pytest.MonkeyPatch,
+    env: dict[str, str],
+    expected: bool,
+) -> None:
+    """Init recompiles when either AutoML or AutoRAG RELATED_IMAGE env is non-empty."""
+    monkeypatch.delenv(RELATED_IMAGE_AUTOML_ENV, raising=False)
+    monkeypatch.delenv(RELATED_IMAGE_AUTORAG_ENV, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    assert should_recompile_managed_pipelines() is expected
+
+
+def _write_managed_pipeline_fixture(repo: Path, *, name: str = "my_pipeline") -> Path:
+    """Create a minimal managed pipeline under ``repo/pipelines/``."""
+    pipe_dir = repo / "pipelines" / "training" / "p"
+    pipe_dir.mkdir(parents=True)
+    (pipe_dir / "pipeline.py").write_text(_VALID_PIPELINE_SRC)
+    (pipe_dir / "metadata.yaml").write_text(
+        yaml.dump({"name": name, "stability": "alpha", "managed": True}),
+        encoding="utf-8",
+    )
+    return pipe_dir
+
+
+def test_stage_managed_pipelines_writes_only_to_output_dir(tmp_path: Path) -> None:
+    """Runtime staging writes manifest and YAML under output_dir, not under repo pipelines/."""
+    repo = tmp_path / "app"
+    output_dir = tmp_path / "staging"
+    pipe_dir = _write_managed_pipeline_fixture(repo)
+
+    rc = stage_managed_pipelines(repo, output_dir)
+
+    assert rc == 0
+    manifest = output_dir / "managed-pipelines.json"
+    assert manifest.is_file()
+    entries = json.loads(manifest.read_text())
+    assert entries[0]["name"] == "my_pipeline"
+
+    staged_yaml = output_dir / "my_pipeline.yaml"
+    assert staged_yaml.is_file()
+    assert not (pipe_dir / "pipeline.yaml").exists()
+
+
+def test_stage_managed_pipelines_returns_error_when_pipelines_root_missing(tmp_path: Path) -> None:
+    """Missing pipelines/ under repo_root yields exit code 1."""
+    repo = tmp_path / "empty_app"
+    repo.mkdir()
+    output_dir = tmp_path / "staging"
+
+    rc = stage_managed_pipelines(repo, output_dir)
+
+    assert rc == 1
+    assert not (output_dir / "managed-pipelines.json").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/generate_managed_pipelines/tests/test_generate_managed_pipelines.py
+++ b/scripts/generate_managed_pipelines/tests/test_generate_managed_pipelines.py
@@ -20,6 +20,7 @@ from ..generate_managed_pipelines import (
     managed_pipeline_entry_from_dir,
     should_recompile_managed_pipelines,
     stage_managed_pipelines,
+    staged_pipeline_yaml_path,
 )
 
 
@@ -277,6 +278,15 @@ def test_should_recompile_managed_pipelines(
     for key, value in env.items():
         monkeypatch.setenv(key, value)
     assert should_recompile_managed_pipelines() is expected
+
+
+@pytest.mark.parametrize("bad_name", ["../x", "a/b", "..", "."])
+def test_staged_pipeline_yaml_path_rejects_unsafe_names(tmp_path: Path, bad_name: str) -> None:
+    """Pipeline names must be plain basenames under the staging directory."""
+    output_dir = tmp_path / "staging"
+    output_dir.mkdir()
+    with pytest.raises(ValueError, match="Invalid pipeline name|escapes output dir"):
+        staged_pipeline_yaml_path(output_dir, bad_name)
 
 
 def _write_managed_pipeline_fixture(repo: Path, *, name: str = "my_pipeline") -> Path:

--- a/scripts/generate_managed_pipelines/tests/test_generate_managed_pipelines.py
+++ b/scripts/generate_managed_pipelines/tests/test_generate_managed_pipelines.py
@@ -9,8 +9,7 @@ import yaml
 
 from ..generate_managed_pipelines import (
     METADATA_STABILITY_VALUES,
-    RELATED_IMAGE_AUTOML_ENV,
-    RELATED_IMAGE_AUTORAG_ENV,
+    RELATED_IMAGE_ENV_PREFIX,
     STABILITY_TO_MANAGED_DISPLAY,
     ManagedPipelineCompilationError,
     ManagedPipelineMetadataError,
@@ -19,8 +18,6 @@ from ..generate_managed_pipelines import (
     main,
     managed_pipeline_entry_from_dir,
     should_recompile_managed_pipelines,
-    stage_managed_pipelines,
-    staged_pipeline_yaml_path,
 )
 
 
@@ -246,25 +243,35 @@ class TestCompileManagedPipeline:
 
 
 # ---------------------------------------------------------------------------
-# should_recompile_managed_pipelines / stage_managed_pipelines (init path)
+# should_recompile_managed_pipelines (init path)
 # ---------------------------------------------------------------------------
+
+
+def _clear_related_image_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    import os
+
+    for key in list(os.environ):
+        if key.startswith(RELATED_IMAGE_ENV_PREFIX):
+            monkeypatch.delenv(key, raising=False)
 
 
 @pytest.mark.parametrize(
     ("env", "expected"),
     [
         ({}, False),
-        ({RELATED_IMAGE_AUTOML_ENV: ""}, False),
-        ({RELATED_IMAGE_AUTOML_ENV: "   "}, False),
-        ({RELATED_IMAGE_AUTOML_ENV: "quay.io/example/automl-runtime@sha256:aaa"}, True),
-        ({RELATED_IMAGE_AUTORAG_ENV: "quay.io/example/autorag-runtime@sha256:bbb"}, True),
+        ({"RELATED_IMAGE_ODH_AUTOML_IMAGE": ""}, False),
+        ({"RELATED_IMAGE_ODH_AUTOML_IMAGE": "   "}, False),
+        ({"RELATED_IMAGE_ODH_AUTOML_IMAGE": "quay.io/example/automl-runtime@sha256:aaa"}, True),
+        ({"RELATED_IMAGE_ODH_AUTORAG_IMAGE": "quay.io/example/autorag-runtime@sha256:bbb"}, True),
         (
             {
-                RELATED_IMAGE_AUTOML_ENV: "quay.io/example/automl-runtime@sha256:aaa",
-                RELATED_IMAGE_AUTORAG_ENV: "quay.io/example/autorag-runtime@sha256:bbb",
+                "RELATED_IMAGE_ODH_AUTOML_IMAGE": "quay.io/example/automl-runtime@sha256:aaa",
+                "RELATED_IMAGE_ODH_AUTORAG_IMAGE": "quay.io/example/autorag-runtime@sha256:bbb",
             },
             True,
         ),
+        ({"RELATED_IMAGE_ODH_FUTURE_RUNTIME_IMAGE": "quay.io/example/future@sha256:ccc"}, True),
+        ({"UNRELATED_IMAGE_FOO": "quay.io/example/not-related"}, False),
     ],
 )
 def test_should_recompile_managed_pipelines(
@@ -272,64 +279,11 @@ def test_should_recompile_managed_pipelines(
     env: dict[str, str],
     expected: bool,
 ) -> None:
-    """Init recompiles when either AutoML or AutoRAG RELATED_IMAGE env is non-empty."""
-    monkeypatch.delenv(RELATED_IMAGE_AUTOML_ENV, raising=False)
-    monkeypatch.delenv(RELATED_IMAGE_AUTORAG_ENV, raising=False)
+    """Init recompiles when any non-empty RELATED_IMAGE_* env var is set."""
+    _clear_related_image_env(monkeypatch)
     for key, value in env.items():
         monkeypatch.setenv(key, value)
     assert should_recompile_managed_pipelines() is expected
-
-
-@pytest.mark.parametrize("bad_name", ["../x", "a/b", "..", "."])
-def test_staged_pipeline_yaml_path_rejects_unsafe_names(tmp_path: Path, bad_name: str) -> None:
-    """Pipeline names must be plain basenames under the staging directory."""
-    output_dir = tmp_path / "staging"
-    output_dir.mkdir()
-    with pytest.raises(ValueError, match="Invalid pipeline name|escapes output dir"):
-        staged_pipeline_yaml_path(output_dir, bad_name)
-
-
-def _write_managed_pipeline_fixture(repo: Path, *, name: str = "my_pipeline") -> Path:
-    """Create a minimal managed pipeline under ``repo/pipelines/``."""
-    pipe_dir = repo / "pipelines" / "training" / "p"
-    pipe_dir.mkdir(parents=True)
-    (pipe_dir / "pipeline.py").write_text(_VALID_PIPELINE_SRC)
-    (pipe_dir / "metadata.yaml").write_text(
-        yaml.dump({"name": name, "stability": "alpha", "managed": True}),
-        encoding="utf-8",
-    )
-    return pipe_dir
-
-
-def test_stage_managed_pipelines_writes_only_to_output_dir(tmp_path: Path) -> None:
-    """Runtime staging writes manifest and YAML under output_dir, not under repo pipelines/."""
-    repo = tmp_path / "app"
-    output_dir = tmp_path / "staging"
-    pipe_dir = _write_managed_pipeline_fixture(repo)
-
-    rc = stage_managed_pipelines(repo, output_dir)
-
-    assert rc == 0
-    manifest = output_dir / "managed-pipelines.json"
-    assert manifest.is_file()
-    entries = json.loads(manifest.read_text())
-    assert entries[0]["name"] == "my_pipeline"
-
-    staged_yaml = output_dir / "my_pipeline.yaml"
-    assert staged_yaml.is_file()
-    assert not (pipe_dir / "pipeline.yaml").exists()
-
-
-def test_stage_managed_pipelines_returns_error_when_pipelines_root_missing(tmp_path: Path) -> None:
-    """Missing pipelines/ under repo_root yields exit code 1."""
-    repo = tmp_path / "empty_app"
-    repo.mkdir()
-    output_dir = tmp_path / "staging"
-
-    rc = stage_managed_pipelines(repo, output_dir)
-
-    assert rc == 1
-    assert not (output_dir / "managed-pipelines.json").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/generate_managed_pipelines/tests/test_generate_managed_pipelines.py
+++ b/scripts/generate_managed_pipelines/tests/test_generate_managed_pipelines.py
@@ -250,8 +250,7 @@ class TestCompileManagedPipeline:
 
 
 @pytest.mark.parametrize(
-    ("env",
-    "expected"),
+    ("env", "expected"),
     [
         ({}, False),
         ({RELATED_IMAGE_AUTOML_ENV: ""}, False),

--- a/scripts/init_managed_pipelines/init_managed_pipelines.py
+++ b/scripts/init_managed_pipelines/init_managed_pipelines.py
@@ -5,27 +5,48 @@ import shutil
 import sys
 from pathlib import Path
 
-from scripts.generate_managed_pipelines.generate_managed_pipelines import main as generate_managed_pipelines
+from scripts.generate_managed_pipelines.generate_managed_pipelines import (
+    OUTPUT_FILENAME,
+    should_recompile_managed_pipelines,
+    stage_managed_pipelines,
+)
 
 APP_ROOT = Path("/app")
 OUTPUT_DIR = Path("/config/managed-pipelines")
-MANIFEST = "managed-pipelines.json"
+MANIFEST = OUTPUT_FILENAME
 
-if generate_managed_pipelines() != 0:
-    sys.exit(1)
 
-OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+def _copy_prebuilt_from_image() -> None:
+    """Copy build-time ``managed-pipelines.json`` and YAML from read-only ``/app``."""
+    entries = json.loads((APP_ROOT / MANIFEST).read_text())
 
-entries = json.loads((APP_ROOT / MANIFEST).read_text())
+    for entry in entries:
+        src = (APP_ROOT / entry["path"].replace("pipeline.py", "pipeline.yaml")).resolve()
+        if not src.is_relative_to(APP_ROOT.resolve()):
+            raise ValueError(f"Manifest path escapes app root: {entry['path']}")
+        if not src.is_file():
+            raise FileNotFoundError(f"Pipeline YAML missing for {entry['name']!r}: {src}")
+        shutil.copy2(src, OUTPUT_DIR / f"{entry['name']}.yaml")
 
-for e in entries:
-    src = (APP_ROOT / e["path"].replace("pipeline.py", "pipeline.yaml")).resolve()
-    if not src.is_relative_to(APP_ROOT.resolve()):
-        raise ValueError(f"Manifest path escapes app root: {e['path']}")
-    if not src.is_file():
-        raise FileNotFoundError(f"Pipeline YAML missing for {e['name']!r}: {src}")
-    shutil.copy2(src, OUTPUT_DIR / f"{e['name']}.yaml")
+    shutil.copy2(APP_ROOT / MANIFEST, OUTPUT_DIR / MANIFEST)
+    print(f"Staged {len(entries)} pipeline(s) in {OUTPUT_DIR}")
 
-shutil.copy2(APP_ROOT / MANIFEST, OUTPUT_DIR / MANIFEST)
 
-print(f"Staged {len(entries)} pipeline(s) in {OUTPUT_DIR}")
+def main() -> int:
+    """Stage managed pipelines for the KFP API server init container."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    if should_recompile_managed_pipelines():
+        rc = stage_managed_pipelines(APP_ROOT, OUTPUT_DIR)
+        if rc != 0:
+            return rc
+        entries = json.loads((OUTPUT_DIR / MANIFEST).read_text())
+        print(f"Staged {len(entries)} pipeline(s) in {OUTPUT_DIR} (recompiled with RELATED_IMAGE)")
+        return 0
+
+    _copy_prebuilt_from_image()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/init_managed_pipelines/init_managed_pipelines.py
+++ b/scripts/init_managed_pipelines/init_managed_pipelines.py
@@ -2,11 +2,17 @@
 
 import json
 import shutil
+import sys
 from pathlib import Path
+
+from scripts.generate_managed_pipelines.generate_managed_pipelines import main as generate_managed_pipelines
 
 APP_ROOT = Path("/app")
 OUTPUT_DIR = Path("/config/managed-pipelines")
 MANIFEST = "managed-pipelines.json"
+
+if generate_managed_pipelines() != 0:
+    sys.exit(1)
 
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/init_managed_pipelines/init_managed_pipelines.py
+++ b/scripts/init_managed_pipelines/init_managed_pipelines.py
@@ -9,6 +9,7 @@ from scripts.generate_managed_pipelines.generate_managed_pipelines import (
     OUTPUT_FILENAME,
     should_recompile_managed_pipelines,
     stage_managed_pipelines,
+    staged_pipeline_yaml_path,
 )
 
 APP_ROOT = Path("/app")
@@ -26,7 +27,7 @@ def _copy_prebuilt_from_image() -> None:
             raise ValueError(f"Manifest path escapes app root: {entry['path']}")
         if not src.is_file():
             raise FileNotFoundError(f"Pipeline YAML missing for {entry['name']!r}: {src}")
-        shutil.copy2(src, OUTPUT_DIR / f"{entry['name']}.yaml")
+        shutil.copy2(src, staged_pipeline_yaml_path(OUTPUT_DIR, entry["name"]))
 
     shutil.copy2(APP_ROOT / MANIFEST, OUTPUT_DIR / MANIFEST)
     print(f"Staged {len(entries)} pipeline(s) in {OUTPUT_DIR}")

--- a/scripts/init_managed_pipelines/tests/__init__.py
+++ b/scripts/init_managed_pipelines/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for init_managed_pipelines."""

--- a/scripts/init_managed_pipelines/tests/test_init_managed_pipelines.py
+++ b/scripts/init_managed_pipelines/tests/test_init_managed_pipelines.py
@@ -1,0 +1,109 @@
+"""Unit tests for the init-managed-pipelines container entrypoint."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.generate_managed_pipelines.generate_managed_pipelines import (
+    OUTPUT_FILENAME,
+    RELATED_IMAGE_AUTOML_ENV,
+    RELATED_IMAGE_AUTORAG_ENV,
+)
+
+from .. import init_managed_pipelines as init_mod
+
+
+def _write_image_fixture(app_root: Path) -> None:
+    """Simulate build-time artifacts under ``/app``."""
+    pipe_dir = app_root / "pipelines" / "training" / "p"
+    pipe_dir.mkdir(parents=True)
+    (pipe_dir / "pipeline.py").write_text("from kfp import dsl\n\n@dsl.pipeline\ndef p():\n    pass\n")
+    (pipe_dir / "pipeline.yaml").write_text(
+        "deploymentSpec:\n  executors:\n    exec:\n      container:\n        image: quay.io/build-time:tag\n",
+        encoding="utf-8",
+    )
+    manifest = [
+        {
+            "name": "my_pipeline",
+            "description": "",
+            "path": "pipelines/training/p/pipeline.py",
+            "stability": "Development Preview",
+        },
+    ]
+    (app_root / OUTPUT_FILENAME).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def staging_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Point init module at temporary app root and staging volume."""
+    app_root = tmp_path / "app"
+    output_dir = tmp_path / "config" / "managed-pipelines"
+    app_root.mkdir()
+    monkeypatch.setattr(init_mod, "APP_ROOT", app_root)
+    monkeypatch.setattr(init_mod, "OUTPUT_DIR", output_dir)
+    return app_root, output_dir
+
+
+def test_main_copy_path_without_related_image(
+    staging_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without RELATED_IMAGE env, init copies pre-built YAML from the image."""
+    app_root, output_dir = staging_paths
+    _write_image_fixture(app_root)
+    monkeypatch.delenv(RELATED_IMAGE_AUTOML_ENV, raising=False)
+    monkeypatch.delenv(RELATED_IMAGE_AUTORAG_ENV, raising=False)
+
+    assert init_mod.main() == 0
+
+    staged = output_dir / "my_pipeline.yaml"
+    assert staged.is_file()
+    assert "quay.io/build-time:tag" in staged.read_text()
+    assert (output_dir / OUTPUT_FILENAME).is_file()
+    assert json.loads((output_dir / OUTPUT_FILENAME).read_text())[0]["name"] == "my_pipeline"
+
+
+def test_main_recompile_path_calls_stage_managed_pipelines(
+    staging_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With RELATED_IMAGE env, init stages via stage_managed_pipelines (not image copy)."""
+    app_root, output_dir = staging_paths
+    _write_image_fixture(app_root)
+    monkeypatch.setenv(RELATED_IMAGE_AUTOML_ENV, "quay.io/example/automl-runtime@sha256:aaa")
+
+    calls: list[tuple[Path, Path]] = []
+
+    def fake_stage(repo_root: Path, out_dir: Path) -> int:
+        calls.append((repo_root, out_dir))
+        out_dir.mkdir(parents=True, exist_ok=True)
+        manifest = [{"name": "my_pipeline", "description": "", "path": "p", "stability": "Development Preview"}]
+        (out_dir / OUTPUT_FILENAME).write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+        (out_dir / "my_pipeline.yaml").write_text(
+            "deploymentSpec:\n  executors:\n    exec:\n      container:\n"
+            "        image: quay.io/example/automl-runtime@sha256:aaa\n",
+            encoding="utf-8",
+        )
+        return 0
+
+    monkeypatch.setattr(init_mod, "stage_managed_pipelines", fake_stage)
+
+    assert init_mod.main() == 0
+    assert calls == [(app_root, output_dir)]
+    assert "quay.io/example/automl-runtime@sha256:aaa" in (output_dir / "my_pipeline.yaml").read_text()
+    assert "quay.io/build-time:tag" not in (output_dir / "my_pipeline.yaml").read_text()
+
+
+def test_main_returns_nonzero_when_stage_fails(
+    staging_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Init propagates failure from stage_managed_pipelines."""
+    app_root, output_dir = staging_paths
+    _write_image_fixture(app_root)
+    monkeypatch.setenv(RELATED_IMAGE_AUTOML_ENV, "quay.io/example/automl-runtime@sha256:aaa")
+    monkeypatch.setattr(init_mod, "stage_managed_pipelines", lambda _repo, _out: 1)
+
+    assert init_mod.main() == 1
+    assert not (output_dir / "my_pipeline.yaml").exists()

--- a/scripts/init_managed_pipelines/tests/test_init_managed_pipelines.py
+++ b/scripts/init_managed_pipelines/tests/test_init_managed_pipelines.py
@@ -7,11 +7,19 @@ import pytest
 
 from scripts.generate_managed_pipelines.generate_managed_pipelines import (
     OUTPUT_FILENAME,
-    RELATED_IMAGE_AUTOML_ENV,
-    RELATED_IMAGE_AUTORAG_ENV,
+    RELATED_IMAGE_ENV_PREFIX,
 )
 
 from .. import init_managed_pipelines as init_mod
+
+
+def _clear_related_image_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove all RELATED_IMAGE_* variables from the environment."""
+    import os
+
+    for key in list(os.environ):
+        if key.startswith(RELATED_IMAGE_ENV_PREFIX):
+            monkeypatch.delenv(key, raising=False)
 
 
 def _write_image_fixture(app_root: Path) -> None:
@@ -52,8 +60,7 @@ def test_main_copy_path_without_related_image(
     """Without RELATED_IMAGE env, init copies pre-built YAML from the image."""
     app_root, output_dir = staging_paths
     _write_image_fixture(app_root)
-    monkeypatch.delenv(RELATED_IMAGE_AUTOML_ENV, raising=False)
-    monkeypatch.delenv(RELATED_IMAGE_AUTORAG_ENV, raising=False)
+    _clear_related_image_env(monkeypatch)
 
     assert init_mod.main() == 0
 
@@ -71,7 +78,7 @@ def test_main_recompile_path_calls_stage_managed_pipelines(
     """With RELATED_IMAGE env, init stages via stage_managed_pipelines (not image copy)."""
     app_root, output_dir = staging_paths
     _write_image_fixture(app_root)
-    monkeypatch.setenv(RELATED_IMAGE_AUTOML_ENV, "quay.io/example/automl-runtime@sha256:aaa")
+    monkeypatch.setenv("RELATED_IMAGE_ODH_AUTOML_IMAGE", "quay.io/example/automl-runtime@sha256:aaa")
 
     calls: list[tuple[Path, Path]] = []
 
@@ -102,7 +109,7 @@ def test_main_returns_nonzero_when_stage_fails(
     """Init propagates failure from stage_managed_pipelines."""
     app_root, output_dir = staging_paths
     _write_image_fixture(app_root)
-    monkeypatch.setenv(RELATED_IMAGE_AUTOML_ENV, "quay.io/example/automl-runtime@sha256:aaa")
+    monkeypatch.setenv("RELATED_IMAGE_ODH_AUTOML_IMAGE", "quay.io/example/automl-runtime@sha256:aaa")
     monkeypatch.setattr(init_mod, "stage_managed_pipelines", lambda _repo, _out: 1)
 
     assert init_mod.main() == 1


### PR DESCRIPTION
**Description of your changes:**
Fixes: [RHOAIENG-59436 ](https://redhat.atlassian.net/browse/RHOAIENG-59436)

Before: the init container only copied pipeline YAML baked into the image at build time (without `RELATED_IMAGE_*`), so staged pipelines kept default/runtime images even though DSPO set digest-pinned env vars on the pod.

Now: when RELATED_IMAGE_ODH_AUTOML_IMAGE or RELATED_IMAGE_ODH_AUTORAG_IMAGE is set, init recompiles managed pipelines directly into `/config/managed-pipelines` ( `/app` is read-only). Otherwise, keep `odh-stable` as the image.

**Checklist:**

### Pre-Submission Checklist

- [ ] All tests and CI checks pass
- [ ] Pre-commit hooks pass without errors
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staging can emit compiled pipeline YAMLs and a manifest into configurable output directories.
  * Detection of RELATED_IMAGE_* environment overrides triggers recompilation when set.

* **Refactor**
  * Initialization flow split to either copy prebuilt artifacts or recompile and stage pipelines based on environment.

* **Tests**
  * Added unit tests covering env-var detection, staging, copy-from-image, and success/failure flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->