### PR TITLE
feat(AutoRAG): Add OGX URL to the notebooks during generation time

### DIFF
--- a/components/training/autorag/rag_templates_optimization/component.py
+++ b/components/training/autorag/rag_templates_optimization/component.py
@@ -453,6 +453,7 @@ def rag_templates_optimization(
         mapping["INPUT_DATA_KEY"] = input_data_key
 
         mapping["OGX_SSL_VERIFY"] = ogx_ssl_verify
+        mapping["OGX_CLIENT_BASE_URL"] = (os.environ.get("OGX_CLIENT_BASE_URL") or "").strip()
 
         return mapping
 

--- a/components/training/autorag/rag_templates_optimization/notebook_templates/ogx_indexing_template.ipynb
+++ b/components/training/autorag/rag_templates_optimization/notebook_templates/ogx_indexing_template.ipynb
@@ -294,7 +294,7 @@
     "\n",
     "**Prerequisites:**\n",
     "- `OGX_CLIENT_API_KEY`: Your authentication key for the OGX API\n",
-    "- `OGX_CLIENT_BASE_URL`: The base URL of your OGX instance\n",
+    "- `OGX_CLIENT_BASE_URL`: The base URL of your OGX instance (pre-filled from the experiment run; override via environment variable if needed)\n",
     "\n",
     "&#x1F4A1; **Tip**: In OpenShift AI Workbench, you can add these as environment variables or data connections to avoid entering them manually each time."
    ]
@@ -308,18 +308,19 @@
     "import httpx\n",
     "from ogx_client import OgxClient\n",
     "\n",
-    "if not os.getenv(\"OGX_CLIENT_API_KEY\") or not os.getenv(\"OGX_CLIENT_BASE_URL\"):\n",
-    "    os.environ[\"OGX_CLIENT_API_KEY\"] = getpass.getpass(\"Please enter 'OGX_CLIENT_API_KEY': \")\n",
-    "    os.environ[\"OGX_CLIENT_BASE_URL\"] = getpass.getpass(\"Please enter 'OGX_CLIENT_BASE_URL': \")\n",
+    "OGX_CLIENT_BASE_URL = os.getenv(\"OGX_CLIENT_BASE_URL\", \"{OGX_CLIENT_BASE_URL}\")\n",
+    "OGX_CLIENT_API_KEY = os.getenv(\"OGX_CLIENT_API_KEY\") or getpass.getpass(\"Please enter 'OGX_CLIENT_API_KEY': \")\n",
     "\n",
-    "_ls_kwargs = dict(\n",
-    "    api_key=os.getenv(\"OGX_CLIENT_API_KEY\"),\n",
-    "    base_url=os.getenv(\"OGX_CLIENT_BASE_URL\"),\n",
+    "_ogx_kwargs = dict(\n",
+    "    api_key=OGX_CLIENT_API_KEY,\n",
+    "    base_url=OGX_CLIENT_BASE_URL,\n",
     ")\n",
-    "if not {OGX_SSL_VERIFY}:\n",
-    "    _ls_kwargs[\"http_client\"] = httpx.Client(verify=False)\n",
     "\n",
-    "client = OgxClient(**_ls_kwargs)"
+    "ogx_ssl_verify = {OGX_SSL_VERIFY}\n",
+    "if not ogx_ssl_verify:\n",
+    "    _ogx_kwargs[\"http_client\"] = httpx.Client(verify=False)\n",
+    "\n",
+    "client = OgxClient(**_ogx_kwargs)"
    ]
   },
   {

--- a/components/training/autorag/rag_templates_optimization/notebook_templates/ogx_inference_template.ipynb
+++ b/components/training/autorag/rag_templates_optimization/notebook_templates/ogx_inference_template.ipynb
@@ -76,16 +76,16 @@
     "\n",
     "**Prerequisites:**\n",
     "- `OGX_CLIENT_API_KEY`: Your authentication key for the OGX API\n",
-    "- `OGX_CLIENT_BASE_URL`: The base URL of your OGX instance\n",
+    "- `OGX_CLIENT_BASE_URL`: The base URL of your OGX instance (pre-filled from the experiment run; override via environment variable if needed)\n",
     "\n",
     "&#x1F4A1; **Tip**: In OpenShift AI Workbench, you can add these as environment variables or data connections to avoid entering them manually each time."
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
+   "cell_type": "code",
    "outputs": [],
+   "execution_count": null,
    "source": [
     "import getpass\n",
     "import logging\n",
@@ -98,18 +98,19 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "logging.getLogger(\"httpx\").propagate = False\n",
     "\n",
-    "if not os.getenv(\"OGX_CLIENT_API_KEY\") or not os.getenv(\"OGX_CLIENT_BASE_URL\"):\n",
-    "    os.environ[\"OGX_CLIENT_API_KEY\"] = getpass.getpass(\"Please enter 'OGX_CLIENT_API_KEY': \")\n",
-    "    os.environ[\"OGX_CLIENT_BASE_URL\"] = getpass.getpass(\"Please enter 'OGX_CLIENT_BASE_URL': \")\n",
+    "OGX_CLIENT_BASE_URL = os.getenv(\"OGX_CLIENT_BASE_URL\", \"{OGX_CLIENT_BASE_URL}\")\n",
+    "OGX_CLIENT_API_KEY = os.getenv(\"OGX_CLIENT_API_KEY\") or getpass.getpass(\"Please enter 'OGX_CLIENT_API_KEY': \")\n",
     "\n",
-    "_ls_kwargs = dict(\n",
-    "    api_key=os.getenv(\"OGX_CLIENT_API_KEY\"),\n",
-    "    base_url=os.getenv(\"OGX_CLIENT_BASE_URL\"),\n",
+    "_ogx_kwargs = dict(\n",
+    "    api_key=OGX_CLIENT_API_KEY,\n",
+    "    base_url=OGX_CLIENT_BASE_URL,\n",
     ")\n",
-    "if not {OGX_SSL_VERIFY}:\n",
-    "    _ls_kwargs[\"http_client\"] = httpx.Client(verify=False)\n",
     "\n",
-    "client = OgxClient(**_ls_kwargs)"
+    "ogx_ssl_verify = {OGX_SSL_VERIFY}\n",
+    "if not ogx_ssl_verify:\n",
+    "    _ogx_kwargs[\"http_client\"] = httpx.Client(verify=False)\n",
+    "\n",
+    "client = OgxClient(**_ogx_kwargs)"
    ]
   },
   {


### PR DESCRIPTION
**Description of your changes:**
Introducing dynamic `OGX_BASE_URL` injection to the notebooks during generation. This will simplify running notebooks on the user's env, where no OGX env variables are set by default.

**Checklist:**

### Pre-Submission Checklist

- [ ] All tests and CI checks pass
- [ ] Pre-commit hooks pass without errors
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generated notebook templates now substitute a pre-filled OGX client base URL from the experiment run (can be overridden via environment variables).

* **Documentation**
  * Clarified OGX client setup in generated notebooks, including how the base URL, API key (env or prompt fallback), and SSL verification override are handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->