### PR TITLE
 refactor(automl): Make AutoML timeseries full-refit parameters required

### DIFF
--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -56,6 +56,7 @@ def example_pipeline(
     id_column: str = "item_id",
     timestamp_column: str = "timestamp",
     train_data_path: str = "/tmp/train_data",
+    extra_train_data_path: str = "/tmp/extra_train_data",
     top_n: int = 3,
     workspace_path: str = "/tmp/workspace",
     prediction_length: int = 1,
@@ -69,6 +70,7 @@ def example_pipeline(
         id_column: Name of the ID column.
         timestamp_column: Name of the timestamp column.
         train_data_path: Path to the training data.
+        extra_train_data_path: Path to extra training data for full refit.
         top_n: Number of top models to select.
         workspace_path: Path to the workspace directory.
         prediction_length: Number of time steps to predict.
@@ -89,6 +91,7 @@ def example_pipeline(
         workspace_path=workspace_path,
         pipeline_name=pipeline_name,
         run_id=run_id,
+        extra_train_data_path=extra_train_data_path,
         prediction_length=prediction_length,
     )
 

--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -26,10 +26,10 @@ Refit outputs for all selected models are written under one ``models_artifact`` 
 | `run_id` | `str` | `None` | Pipeline run id used in generated notebook placeholders. |
 | `models_artifact` | `dsl.Output[dsl.Model]` | `None` | Combined output artifact containing all refitted models. |
 | `notebooks` | `dsl.EmbeddedInput[dsl.Dataset]` | `None` | Embedded notebook templates. |
-| `sample_rows` | `str` | `[]` | Optional sample rows JSON string used in generated notebook placeholders. |
+| `extra_train_data_path` | `str` | `None` | Path to extra train split for full refit. |
+| `sample_rows` | `str` | `[]` | Sample rows JSON string used in generated notebook placeholders. |
 | `sampling_config` | `Optional[dict]` | `None` | Optional sampling config stored in artifact metadata. |
 | `split_config` | `Optional[dict]` | `None` | Optional split config stored in artifact metadata. |
-| `extra_train_data_path` | `str` | `""` | Path to extra train split for full refit. |
 | `prediction_length` | `int` | `1` | Forecast horizon (number of timesteps). |
 | `known_covariates_names` | `Optional[List[str]]` | `None` | Optional list of known covariate column names. |
 
@@ -106,7 +106,7 @@ def example_pipeline(
   - timeseries
   - automl
   - model-selection
-- **Last Verified**: 2026-04-10 12:00:00+00:00
+- **Last Verified**: 2026-05-27 12:00:00+00:00
 - **Owners**:
   - Approvers:
     - LukaszCmielowski

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -246,7 +246,10 @@ def autogluon_timeseries_models_training(
             if cell.get("cell_type") != "code":
                 continue
             new_source = []
-            for line in cell.get("source", []):
+            src = cell.get("source", [])
+            if isinstance(src, str):
+                src = [src]
+            for line in src:
                 for placeholder, value in replacements.items():
                     line = line.replace(placeholder, value)
                 new_source.append(line)

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -21,12 +21,12 @@ def autogluon_timeseries_models_training(
     workspace_path: str,
     pipeline_name: str,
     run_id: str,
-    models_artifact: dsl.Output[dsl.Model] = None,
-    notebooks: dsl.EmbeddedInput[dsl.Dataset] = None,
+    models_artifact: dsl.Output[dsl.Model],
+    notebooks: dsl.EmbeddedInput[dsl.Dataset],
+    extra_train_data_path: str,
     sample_rows: str = "[]",
     sampling_config: Optional[dict] = None,
     split_config: Optional[dict] = None,
-    extra_train_data_path: str = "",
     prediction_length: int = 1,
     known_covariates_names: Optional[List[str]] = None,
 ) -> NamedTuple(
@@ -54,14 +54,14 @@ def autogluon_timeseries_models_training(
         test_data: Test dataset artifact for evaluation.
         top_n: Number of top models to select for full refit.
         workspace_path: Workspace directory where predictor will be saved.
-        models_artifact: Combined output artifact containing all refitted models.
-        notebooks: Embedded notebook templates.
         pipeline_name: Pipeline name used in generated notebook placeholders.
         run_id: Pipeline run id used in generated notebook placeholders.
-        sample_rows: Optional sample rows JSON string used in generated notebook placeholders.
+        models_artifact: Combined output artifact containing all refitted models.
+        notebooks: Embedded notebook templates.
+        extra_train_data_path: Path to extra train split for full refit.
+        sample_rows: Sample rows JSON string used in generated notebook placeholders.
         sampling_config: Optional sampling config stored in artifact metadata.
         split_config: Optional split config stored in artifact metadata.
-        extra_train_data_path: Path to extra train split for full refit.
         prediction_length: Forecast horizon (number of timesteps).
         known_covariates_names: Optional list of known covariate column names.
 
@@ -71,7 +71,6 @@ def autogluon_timeseries_models_training(
     import json
     import logging
     import math
-    import os
     from pathlib import Path
 
     import pandas as pd
@@ -112,21 +111,20 @@ def autogluon_timeseries_models_training(
     for param, value in (
         ("pipeline_name", pipeline_name),
         ("run_id", run_id),
+        ("extra_train_data_path", extra_train_data_path),
     ):
         if not isinstance(value, str) or not value.strip():
             raise TypeError(f"{param} must be a non-empty string.")
     if not isinstance(sample_rows, str):
         raise TypeError("sample_rows must be a string.")
-    if models_artifact is not None and not hasattr(models_artifact, "path"):
-        raise TypeError("models_artifact must be a KFP output artifact or None.")
-    if notebooks is not None and not hasattr(notebooks, "path"):
-        raise TypeError("notebooks must be a KFP embedded artifact or None.")
+    if not hasattr(models_artifact, "path"):
+        raise TypeError("models_artifact must be a KFP output artifact.")
+    if not hasattr(notebooks, "path"):
+        raise TypeError("notebooks must be a KFP embedded artifact.")
     if sampling_config is not None and not isinstance(sampling_config, dict):
         raise TypeError("sampling_config must be a dictionary or None.")
     if split_config is not None and not isinstance(split_config, dict):
         raise TypeError("split_config must be a dictionary or None.")
-    if not isinstance(extra_train_data_path, str):
-        raise TypeError("extra_train_data_path must be a string.")
     sampling_config = sampling_config or {}
     split_config = split_config or {}
 
@@ -213,24 +211,6 @@ def autogluon_timeseries_models_training(
     }
 
     # Stage 2: Full refit of selected models on full train data (selection + extra).
-    if models_artifact is None or notebooks is None or not extra_train_data_path.strip():
-        logger.info(
-            "Skipping combined full-refit stage; missing models_artifact/notebooks or extra_train_data_path. "
-            "Returning selection-only outputs for backward compatibility."
-        )
-        outputs = NamedTuple(
-            "outputs",
-            top_models=List[str],
-            predictor_path=str,
-            eval_metric=str,
-            model_config=dict,
-        )
-        return outputs(
-            top_models=top_models,
-            predictor_path=str(predictor_path),
-            eval_metric=eval_metric,
-            model_config=model_config,
-        )
     from autogluon.timeseries.metrics import AVAILABLE_METRICS
     from autogluon.timeseries.models.ensemble import AbstractTimeSeriesEnsembleModel
 
@@ -259,6 +239,7 @@ def autogluon_timeseries_models_training(
     pipeline_name_trimmed = retrieve_pipeline_name(pipeline_name)
     model_names_full = []
     models_metadata = []
+    failed_models = []
 
     def replace_placeholder_in_notebook(notebook, replacements):
         for cell in notebook.get("cells", []):
@@ -274,78 +255,99 @@ def autogluon_timeseries_models_training(
 
     for model_name in top_models:
         model_name_full = f"{model_name}_FULL"
-        model_names_full.append(model_name_full)
-        output_path = Path(models_artifact.path) / model_name_full
-        output_path.mkdir(parents=True, exist_ok=True)
-        predictor_output = output_path / "predictor"
+        try:
+            output_path = Path(models_artifact.path) / model_name_full
+            output_path.mkdir(parents=True, exist_ok=True)
+            predictor_output = output_path / "predictor"
 
-        model_type = predictor._trainer.get_model_attribute(model_name, "type")
-        is_ensemble = issubclass(model_type, AbstractTimeSeriesEnsembleModel)
-        hyperparams_option = "ensemble_hyperparameters" if is_ensemble else "hyperparameters"
-        additional_fit_params = {hyperparams_option: {model_name: model_hyperparams[model_name]}}
+            model_type = predictor._trainer.get_model_attribute(model_name, "type")
+            is_ensemble = issubclass(model_type, AbstractTimeSeriesEnsembleModel)
+            hyperparams_option = "ensemble_hyperparameters" if is_ensemble else "hyperparameters"
+            additional_fit_params = {hyperparams_option: {model_name: model_hyperparams[model_name]}}
 
-        predictor_refit = TimeSeriesPredictor(
-            prediction_length=prediction_length,
-            target=target,
-            eval_metric=eval_metric,
-            path=predictor_output,
-            verbosity=2,
-            known_covariates_names=known_covariates_names,
-        )
-        predictor_refit.fit(
-            train_data=full_train_ts_df,
-            **additional_fit_params,
-            time_limit=DEFAULT_TIME_LIMIT,
-            excluded_model_types=["Chronos", "Chronos2", "Toto"],
-        )
-        predictor_refit.save()
-        metrics = predictor_refit.evaluate(test_ts, metrics=list(AVAILABLE_METRICS.keys()))
+            predictor_refit = TimeSeriesPredictor(
+                prediction_length=prediction_length,
+                target=target,
+                eval_metric=eval_metric,
+                path=predictor_output,
+                verbosity=2,
+                known_covariates_names=known_covariates_names,
+            )
+            # fit() automatically saves the predictor to path specified in constructor
+            predictor_refit.fit(
+                train_data=full_train_ts_df,
+                **additional_fit_params,
+                time_limit=DEFAULT_TIME_LIMIT,
+                excluded_model_types=["Chronos", "Chronos2", "Toto"],
+            )
+            metrics = predictor_refit.evaluate(test_ts, metrics=list(AVAILABLE_METRICS.keys()))
 
-        metrics_dict = {
-            k: float(v) if hasattr(v, "item") else v
-            for k, v in metrics.items()
-            if not (isinstance(v, float) and (math.isnan(v) or math.isinf(v)))
-        }
+            metrics_dict = {
+                k: float(v) if hasattr(v, "item") else v
+                for k, v in metrics.items()
+                if not (isinstance(v, float) and (math.isnan(v) or math.isinf(v)))
+            }
 
-        metrics_path = output_path / "metrics"
-        metrics_path.mkdir(parents=True, exist_ok=True)
-        with (metrics_path / "metrics.json").open("w", encoding="utf-8") as f:
-            json.dump(metrics_dict, f, indent=2)
+            if eval_metric not in metrics_dict:
+                raise ValueError(
+                    f"Eval metric '{eval_metric}' was NaN/Inf for model '{model_name_full}' "
+                    "and was dropped from metrics. Cannot produce a valid leaderboard entry."
+                )
 
-        notebook_file = "timeseries_notebook.ipynb"
-        with open(os.path.join(notebooks.path, notebook_file), "r", encoding="utf-8") as f:
-            notebook = json.load(f)
-        replacements = {
-            "<REPLACE_RUN_ID>": run_id,
-            "<REPLACE_PIPELINE_NAME>": pipeline_name_trimmed,
-            "<REPLACE_MODEL_NAME>": model_name_full,
-            "<REPLACE_SAMPLE_ROW>": str(sample_row_list),
-            "<REPLACE_ID_COLUMN>": id_column,
-            "<REPLACE_TIMESTAMP_COLUMN>": timestamp_column,
-            "<REPLACE_KNOWN_COVARIATES_NAMES>": str(known_covariates_names or []),
-        }
-        notebook = replace_placeholder_in_notebook(notebook, replacements)
+            metrics_path = output_path / "metrics"
+            metrics_path.mkdir(parents=True, exist_ok=True)
+            with (metrics_path / "metrics.json").open("w", encoding="utf-8") as f:
+                json.dump(metrics_dict, f, indent=2)
 
-        notebook_path = output_path / "notebooks"
-        notebook_path.mkdir(parents=True, exist_ok=True)
-        with (notebook_path / "automl_predictor_notebook.ipynb").open("w", encoding="utf-8") as f:
-            json.dump(notebook, f)
+            notebook_file = "timeseries_notebook.ipynb"
+            with (Path(notebooks.path) / notebook_file).open("r", encoding="utf-8") as f:
+                notebook = json.load(f)
+            replacements = {
+                "<REPLACE_RUN_ID>": run_id,
+                "<REPLACE_PIPELINE_NAME>": pipeline_name_trimmed,
+                "<REPLACE_MODEL_NAME>": model_name_full,
+                "<REPLACE_SAMPLE_ROW>": str(sample_row_list),
+                "<REPLACE_ID_COLUMN>": id_column,
+                "<REPLACE_TIMESTAMP_COLUMN>": timestamp_column,
+                "<REPLACE_KNOWN_COVARIATES_NAMES>": str(known_covariates_names or []),
+            }
+            notebook = replace_placeholder_in_notebook(notebook, replacements)
 
-        model_metadata = {
-            "name": model_name_full,
-            "location": {
-                "model_directory": model_name_full,
-                "predictor": str(Path(model_name_full) / "predictor"),
-                "notebook": str(Path(model_name_full) / "notebooks" / "automl_predictor_notebook.ipynb"),
-                "metrics": str(Path(model_name_full) / "metrics"),
-            },
-            "metrics": {
-                "test_data": metrics_dict,
-            },
-        }
-        models_metadata.append(model_metadata)
-        with (output_path / "model.json").open("w", encoding="utf-8") as f:
-            json.dump(model_metadata, f, indent=2)
+            notebook_path = output_path / "notebooks"
+            notebook_path.mkdir(parents=True, exist_ok=True)
+            with (notebook_path / "automl_predictor_notebook.ipynb").open("w", encoding="utf-8") as f:
+                json.dump(notebook, f)
+
+            model_metadata = {
+                "name": model_name_full,
+                "location": {
+                    "model_directory": model_name_full,
+                    "predictor": str(Path(model_name_full) / "predictor"),
+                    "notebook": str(Path(model_name_full) / "notebooks" / "automl_predictor_notebook.ipynb"),
+                    "metrics": str(Path(model_name_full) / "metrics"),
+                },
+                "metrics": {
+                    "test_data": metrics_dict,
+                },
+            }
+            with (output_path / "model.json").open("w", encoding="utf-8") as f:
+                json.dump(model_metadata, f, indent=2)
+
+            # Only append to successful models lists after all operations succeed
+            model_names_full.append(model_name_full)
+            models_metadata.append(model_metadata)
+
+        except Exception as e:
+            logger.error("Refit failed for model '%s': %s", model_name, e)
+            failed_models.append(model_name)
+
+    # Report partial failures
+    if failed_models:
+        logger.warning("The following models failed refit: %s", failed_models)
+
+    # Ensure at least one model succeeded
+    if not model_names_full:
+        raise RuntimeError("All models failed refit. No artifacts written.")
 
     models_artifact.metadata["model_names"] = json.dumps(model_names_full)
     models_artifact.metadata["context"] = {

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -282,11 +282,12 @@ def autogluon_timeseries_models_training(
             )
             metrics = predictor_refit.evaluate(test_ts, metrics=list(AVAILABLE_METRICS.keys()))
 
-            metrics_dict = {
-                k: float(v) if hasattr(v, "item") else v
-                for k, v in metrics.items()
-                if not (isinstance(v, float) and (math.isnan(v) or math.isinf(v)))
-            }
+            metrics_dict = {}
+            for k, v in metrics.items():
+                if hasattr(v, "item"):
+                    v = float(v)
+                if isinstance(v, (int, float)) and math.isfinite(v):
+                    metrics_dict[k] = v
 
             if eval_metric not in metrics_dict:
                 raise ValueError(

--- a/components/training/automl/autogluon_timeseries_models_training/example_pipelines.py
+++ b/components/training/automl/autogluon_timeseries_models_training/example_pipelines.py
@@ -12,6 +12,7 @@ def example_pipeline(
     id_column: str = "item_id",
     timestamp_column: str = "timestamp",
     train_data_path: str = "/tmp/train_data",
+    extra_train_data_path: str = "/tmp/extra_train_data",
     top_n: int = 3,
     workspace_path: str = "/tmp/workspace",
     prediction_length: int = 1,
@@ -25,6 +26,7 @@ def example_pipeline(
         id_column: Name of the ID column.
         timestamp_column: Name of the timestamp column.
         train_data_path: Path to the training data.
+        extra_train_data_path: Path to extra training data for full refit.
         top_n: Number of top models to select.
         workspace_path: Path to the workspace directory.
         prediction_length: Number of time steps to predict.
@@ -45,5 +47,6 @@ def example_pipeline(
         workspace_path=workspace_path,
         pipeline_name=pipeline_name,
         run_id=run_id,
+        extra_train_data_path=extra_train_data_path,
         prediction_length=prediction_length,
     )

--- a/components/training/automl/autogluon_timeseries_models_training/metadata.yaml
+++ b/components/training/automl/autogluon_timeseries_models_training/metadata.yaml
@@ -10,4 +10,4 @@ tags:
   - timeseries
   - automl
   - model-selection
-lastVerified: 2026-04-10T12:00:00Z
+lastVerified: 2026-05-27T12:00:00Z

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -174,6 +174,12 @@ class TestTimeseriesModelsTrainingUnitTests:
         mock_read_csv.assert_any_call("/tmp/test.csv")
         mock_ts_df_cls.from_data_frame.assert_any_call(train_df, id_column="item_id", timestamp_column="timestamp")
         mock_ts_df_cls.from_data_frame.assert_any_call(test_df, id_column="item_id", timestamp_column="timestamp")
+        mock_ts_df_cls.from_path.assert_called_once_with(
+            path=extra_train_path,
+            id_column="item_id",
+            timestamp_column="timestamp",
+        )
+        mock_concat.assert_called_once_with([train_ts, extra_ts], axis=0)
 
         assert result.top_models == ["DeepAR", "TFT"]
         assert result.eval_metric == "MASE"
@@ -239,6 +245,12 @@ class TestTimeseriesModelsTrainingUnitTests:
         # Check that first predictor call (selection) has known_covariates
         assert mock_predictor_cls.call_args_list[0][1]["known_covariates_names"] == covariates
         assert result.model_config["known_covariates_names"] == covariates
+        mock_ts_df_cls.from_path.assert_called_once_with(
+            path=extra_train_path,
+            id_column="item_id",
+            timestamp_column="timestamp",
+        )
+        mock_concat.assert_called_once()
 
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -1,6 +1,8 @@
 """Unit tests for the autogluon_timeseries_models_training component."""
 
+import json
 import sys
+import tempfile
 from pathlib import Path
 from unittest import mock
 
@@ -21,7 +23,62 @@ def isolated_sys_modules():
         _ts = mock.MagicMock()
         _ts.__spec__ = None
         mocked_modules["autogluon.timeseries"] = _ts
+
+        # Mock additional autogluon submodules
+        _metrics = mock.MagicMock()
+        _metrics.AVAILABLE_METRICS = {"MASE": mock.MagicMock(), "MSE": mock.MagicMock()}
+        _metrics.__spec__ = None
+        mocked_modules["autogluon.timeseries.metrics"] = _metrics
+
+        _models = mock.MagicMock()
+        _models.__spec__ = None
+        mocked_modules["autogluon.timeseries.models"] = _models
+
+        _ensemble = mock.MagicMock()
+        _ensemble.AbstractTimeSeriesEnsembleModel = type("AbstractTimeSeriesEnsembleModel", (), {})
+        _ensemble.__spec__ = None
+        mocked_modules["autogluon.timeseries.models.ensemble"] = _ensemble
         yield
+
+
+@pytest.fixture
+def mock_artifacts():
+    """Create mock artifacts for full-refit path."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create mock models_artifact
+        models_artifact = mock.MagicMock()
+        models_artifact.path = str(Path(tmpdir) / "models")
+        models_artifact.metadata = {}
+        Path(models_artifact.path).mkdir(parents=True, exist_ok=True)
+
+        # Create mock notebooks with a template
+        notebooks = mock.MagicMock()
+        notebooks.path = str(Path(tmpdir) / "notebooks")
+        Path(notebooks.path).mkdir(parents=True, exist_ok=True)
+        notebook_template = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "source": [
+                        "# <REPLACE_RUN_ID>\n",
+                        "# <REPLACE_PIPELINE_NAME>\n",
+                        "# <REPLACE_MODEL_NAME>\n",
+                        "# <REPLACE_SAMPLE_ROW>\n",
+                        "# <REPLACE_ID_COLUMN>\n",
+                        "# <REPLACE_TIMESTAMP_COLUMN>\n",
+                        "# <REPLACE_KNOWN_COVARIATES_NAMES>\n",
+                    ],
+                }
+            ]
+        }
+        with open(Path(notebooks.path) / "timeseries_notebook.ipynb", "w") as f:
+            json.dump(notebook_template, f)
+
+        # Create mock extra_train CSV
+        extra_train_path = str(Path(tmpdir) / "extra_train.csv")
+        Path(extra_train_path).touch()
+
+        yield models_artifact, notebooks, extra_train_path
 
 
 def _mock_leaderboard(model_names):
@@ -57,16 +114,40 @@ class TestTimeseriesModelsTrainingUnitTests:
         assert hasattr(autogluon_timeseries_models_training, "python_func")
 
     @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
     @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
     @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
-    def test_basic_flow_returns_expected_outputs(self, mock_predictor_cls, mock_ts_df_cls, mock_read_csv):
-        """Happy path returns top models, config, and predictor path."""
+    def test_basic_flow_returns_expected_outputs(
+        self,
+        mock_predictor_cls,
+        mock_ts_df_cls,
+        mock_concat,
+        mock_read_csv,
+        mock_artifacts,  # noqa: F811
+    ):
+        """Happy path returns top models, config, and predictor path with full refit."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
+
+        # Mock selection predictor
         mock_predictor = mock.MagicMock()
         mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR", "TFT", "AutoARIMA"])
-        mock_predictor_cls.return_value = mock_predictor
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}, "TFT": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        # Mock refit predictor
+        mock_refit_predictor = mock.MagicMock()
+        mock_refit_predictor.evaluate.return_value = {"MASE": 0.5, "MSE": 1.0}
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor, mock_refit_predictor]
 
         train_ts, test_ts = _mock_ts_df(), _mock_ts_df()
+        extra_ts = _mock_ts_df()
+        full_train_ts = _mock_ts_df()
         mock_ts_df_cls.from_data_frame.side_effect = [train_ts, test_ts]
+        mock_ts_df_cls.from_path.return_value = extra_ts
+        mock_ts_df_cls.return_value = full_train_ts
+        mock_concat.return_value = mock.MagicMock()
+
         train_df, test_df = mock.MagicMock(), mock.MagicMock()
         mock_read_csv.side_effect = [train_df, test_df]
 
@@ -83,6 +164,9 @@ class TestTimeseriesModelsTrainingUnitTests:
             workspace_path="/tmp/workspace",
             pipeline_name="ts-pipeline-123",
             run_id="run-123",
+            models_artifact=models_artifact,
+            notebooks=notebooks,
+            extra_train_data_path=extra_train_path,
             prediction_length=24,
         )
 
@@ -90,22 +174,6 @@ class TestTimeseriesModelsTrainingUnitTests:
         mock_read_csv.assert_any_call("/tmp/test.csv")
         mock_ts_df_cls.from_data_frame.assert_any_call(train_df, id_column="item_id", timestamp_column="timestamp")
         mock_ts_df_cls.from_data_frame.assert_any_call(test_df, id_column="item_id", timestamp_column="timestamp")
-
-        mock_predictor_cls.assert_called_once_with(
-            prediction_length=24,
-            target="sales",
-            eval_metric="MASE",
-            path=str(Path("/tmp/workspace") / "timeseries_predictor"),
-            verbosity=2,
-            known_covariates_names=None,
-        )
-        mock_predictor.fit.assert_called_once_with(
-            train_data=train_ts,
-            presets="fast_training",
-            time_limit=600,
-            excluded_model_types=["Chronos", "Toto", "Chronos2"],
-        )
-        mock_predictor.leaderboard.assert_called_once_with(test_ts)
 
         assert result.top_models == ["DeepAR", "TFT"]
         assert result.eval_metric == "MASE"
@@ -115,18 +183,38 @@ class TestTimeseriesModelsTrainingUnitTests:
         assert result.model_config["time_limit"] == 600
         assert result.model_config["known_covariates_names"] == []
         assert result.model_config["num_models_trained"] == 3
+        # Verify full refit happened
+        assert "model_names" in models_artifact.metadata
+        assert "context" in models_artifact.metadata
 
     @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
     @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
     @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
     def test_known_covariates_propagated_to_predictor_and_model_config(
-        self, mock_predictor_cls, mock_ts_df_cls, mock_read_csv
+        self,
+        mock_predictor_cls,
+        mock_ts_df_cls,
+        mock_concat,
+        mock_read_csv,
+        mock_artifacts,  # noqa: F811
     ):
         """Known covariates are passed to predictor ctor and returned in model_config."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
+
         mock_predictor = mock.MagicMock()
         mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
-        mock_predictor_cls.return_value = mock_predictor
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        mock_refit_predictor = mock.MagicMock()
+        mock_refit_predictor.evaluate.return_value = {"MASE": 0.5}
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
         mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df()]
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = _mock_ts_df()
+        mock_concat.return_value = mock.MagicMock()
         mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
         test_data = mock.MagicMock()
         test_data.path = "/tmp/test.csv"
@@ -142,17 +230,29 @@ class TestTimeseriesModelsTrainingUnitTests:
             workspace_path="/tmp/workspace",
             pipeline_name="ts-pipeline-123",
             run_id="run-123",
+            models_artifact=models_artifact,
+            notebooks=notebooks,
+            extra_train_data_path=extra_train_path,
             known_covariates_names=covariates,
         )
 
-        assert mock_predictor_cls.call_args[1]["known_covariates_names"] == covariates
+        # Check that first predictor call (selection) has known_covariates
+        assert mock_predictor_cls.call_args_list[0][1]["known_covariates_names"] == covariates
         assert result.model_config["known_covariates_names"] == covariates
 
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
     @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
-    def test_top_n_greater_than_available_models_raises(self, mock_predictor_cls, mock_ts_df_cls, mock_read_csv):
+    def test_top_n_greater_than_available_models_raises(
+        self,
+        mock_predictor_cls,
+        mock_ts_df_cls,
+        mock_read_csv,
+        mock_artifacts,  # noqa: F811
+    ):
         """top_n exceeding trained model count raises ValueError."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
+
         mock_predictor = mock.MagicMock()
         mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR", "AutoARIMA"])
         mock_predictor_cls.return_value = mock_predictor
@@ -175,10 +275,14 @@ class TestTimeseriesModelsTrainingUnitTests:
                 workspace_path="/tmp/workspace",
                 pipeline_name="ts-pipeline-123",
                 run_id="run-123",
+                models_artifact=models_artifact,
+                notebooks=notebooks,
+                extra_train_data_path=extra_train_path,
             )
 
-    def test_invalid_top_n_zero_raises(self):
+    def test_invalid_top_n_zero_raises(self, mock_artifacts):  # noqa: F811
         """top_n must be in range (0, TOP_N_MAX] (see component TOP_N_MAX)."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
         test_data = mock.MagicMock()
         test_data.path = "/tmp/test.csv"
         with pytest.raises(ValueError, match=r"top_n must be an integer in the range \(0, 7\]; got 0\."):
@@ -192,10 +296,14 @@ class TestTimeseriesModelsTrainingUnitTests:
                 workspace_path="/tmp/workspace",
                 pipeline_name="ts-pipeline-123",
                 run_id="run-123",
+                models_artifact=models_artifact,
+                notebooks=notebooks,
+                extra_train_data_path=extra_train_path,
             )
 
-    def test_invalid_top_n_above_max_raises(self):
+    def test_invalid_top_n_above_max_raises(self, mock_artifacts):  # noqa: F811
         """top_n above TOP_N_MAX is rejected before training."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
         test_data = mock.MagicMock()
         test_data.path = "/tmp/test.csv"
         with pytest.raises(ValueError, match=r"top_n must be an integer in the range \(0, 7\]; got 8\."):
@@ -209,10 +317,14 @@ class TestTimeseriesModelsTrainingUnitTests:
                 workspace_path="/tmp/workspace",
                 pipeline_name="ts-pipeline-123",
                 run_id="run-123",
+                models_artifact=models_artifact,
+                notebooks=notebooks,
+                extra_train_data_path=extra_train_path,
             )
 
-    def test_invalid_prediction_length_raises(self):
+    def test_invalid_prediction_length_raises(self, mock_artifacts):  # noqa: F811
         """prediction_length must be a positive integer."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
         test_data = mock.MagicMock()
         test_data.path = "/tmp/test.csv"
         with pytest.raises(ValueError, match="prediction_length must be greater than 0"):
@@ -226,14 +338,25 @@ class TestTimeseriesModelsTrainingUnitTests:
                 workspace_path="/tmp/workspace",
                 pipeline_name="ts-pipeline-123",
                 run_id="run-123",
+                models_artifact=models_artifact,
+                notebooks=notebooks,
+                extra_train_data_path=extra_train_path,
                 prediction_length=0,
             )
 
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
     @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
-    def test_training_failure_is_wrapped(self, mock_predictor_cls, mock_ts_df_cls, mock_read_csv):
+    def test_training_failure_is_wrapped(
+        self,
+        mock_predictor_cls,
+        mock_ts_df_cls,
+        mock_read_csv,
+        mock_artifacts,  # noqa: F811
+    ):
         """Training errors are wrapped in ValueError with component-specific message."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
+
         mock_predictor = mock.MagicMock()
         mock_predictor.fit.side_effect = RuntimeError("boom")
         mock_predictor_cls.return_value = mock_predictor
@@ -253,13 +376,24 @@ class TestTimeseriesModelsTrainingUnitTests:
                 workspace_path="/tmp/workspace",
                 pipeline_name="ts-pipeline-123",
                 run_id="run-123",
+                models_artifact=models_artifact,
+                notebooks=notebooks,
+                extra_train_data_path=extra_train_path,
             )
 
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
     @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
-    def test_leaderboard_failure_is_wrapped(self, mock_predictor_cls, mock_ts_df_cls, mock_read_csv):
+    def test_leaderboard_failure_is_wrapped(
+        self,
+        mock_predictor_cls,
+        mock_ts_df_cls,
+        mock_read_csv,
+        mock_artifacts,  # noqa: F811
+    ):
         """Leaderboard errors are wrapped in ValueError with component-specific message."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
+
         mock_predictor = mock.MagicMock()
         mock_predictor.leaderboard.side_effect = RuntimeError("no leaderboard")
         mock_predictor_cls.return_value = mock_predictor
@@ -279,4 +413,189 @@ class TestTimeseriesModelsTrainingUnitTests:
                 workspace_path="/tmp/workspace",
                 pipeline_name="ts-pipeline-123",
                 run_id="run-123",
+                models_artifact=models_artifact,
+                notebooks=notebooks,
+                extra_train_data_path=extra_train_path,
+            )
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_nan_eval_metric_caught_and_logged(
+        self,
+        mock_predictor_cls,
+        mock_ts_df_cls,
+        mock_concat,
+        mock_read_csv,
+        mock_artifacts,  # noqa: F811
+        caplog,
+    ):
+        """When eval metric is NaN/Inf, error is caught, logged, and RuntimeError raised if all models fail."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
+
+        # Mock selection predictor
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        # Mock refit predictor with NaN eval metric
+        mock_refit_predictor = mock.MagicMock()
+        # MASE is NaN - should be caught by error isolation
+        mock_refit_predictor.evaluate.return_value = {
+            "MASE": float("nan"),
+            "MSE": 1.0,
+            "MAE": 0.5,
+        }
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
+        mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df()]
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = _mock_ts_df()
+        mock_concat.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        # With error isolation, NaN eval metric error is caught and all models fail
+        with caplog.at_level("ERROR"):
+            with pytest.raises(RuntimeError, match="All models failed refit. No artifacts written."):
+                autogluon_timeseries_models_training.python_func(
+                    target="sales",
+                    id_column="item_id",
+                    timestamp_column="timestamp",
+                    train_data_path="/tmp/train.csv",
+                    test_data=test_data,
+                    top_n=1,
+                    workspace_path="/tmp/workspace",
+                    pipeline_name="ts-pipeline-123",
+                    run_id="run-123",
+                    models_artifact=models_artifact,
+                    notebooks=notebooks,
+                    extra_train_data_path=extra_train_path,
+                )
+
+        # Verify the specific error was logged
+        assert "Eval metric 'MASE' was NaN/Inf for model 'DeepAR_FULL'" in caplog.text
+        assert "Refit failed for model 'DeepAR'" in caplog.text
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_partial_refit_failure_succeeds_with_warnings(
+        self,
+        mock_predictor_cls,
+        mock_ts_df_cls,
+        mock_concat,
+        mock_read_csv,
+        mock_artifacts,  # noqa: F811
+        caplog,
+    ):
+        """When some models fail refit, component succeeds with partial results and warnings."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
+
+        # Mock selection predictor
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR", "TFT", "AutoARIMA"])
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}, "TFT": {}, "AutoARIMA": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        # Mock refit predictors: first succeeds, second fails, third succeeds
+        mock_refit_1 = mock.MagicMock()
+        mock_refit_1.evaluate.return_value = {"MASE": 0.5, "MSE": 1.0}
+
+        mock_refit_2 = mock.MagicMock()
+        mock_refit_2.fit.side_effect = RuntimeError("OOM during refit")
+
+        mock_refit_3 = mock.MagicMock()
+        mock_refit_3.evaluate.return_value = {"MASE": 0.6, "MSE": 1.2}
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_1, mock_refit_2, mock_refit_3]
+        mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df()]
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = _mock_ts_df()
+        mock_concat.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        with caplog.at_level("WARNING"):
+            result = autogluon_timeseries_models_training.python_func(
+                target="sales",
+                id_column="item_id",
+                timestamp_column="timestamp",
+                train_data_path="/tmp/train.csv",
+                test_data=test_data,
+                top_n=3,
+                workspace_path="/tmp/workspace",
+                pipeline_name="ts-pipeline-123",
+                run_id="run-123",
+                models_artifact=models_artifact,
+                notebooks=notebooks,
+                extra_train_data_path=extra_train_path,
+            )
+
+        # Verify partial success: DeepAR and AutoARIMA succeeded, TFT failed
+        assert result.top_models == ["DeepAR", "TFT", "AutoARIMA"]  # Original top models unchanged
+        assert "model_names" in models_artifact.metadata
+        model_names = json.loads(models_artifact.metadata["model_names"])
+        assert model_names == ["DeepAR_FULL", "AutoARIMA_FULL"]  # Only successful models
+        assert len(models_artifact.metadata["context"]["models"]) == 2
+
+        # Verify warning was logged
+        assert "The following models failed refit: ['TFT']" in caplog.text
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_all_models_fail_refit_raises(
+        self,
+        mock_predictor_cls,
+        mock_ts_df_cls,
+        mock_concat,
+        mock_read_csv,
+        mock_artifacts,  # noqa: F811
+    ):
+        """When all models fail refit, component raises RuntimeError."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
+
+        # Mock selection predictor
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR", "TFT"])
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}, "TFT": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        # Mock refit predictors: all fail
+        mock_refit_1 = mock.MagicMock()
+        mock_refit_1.fit.side_effect = RuntimeError("OOM")
+
+        mock_refit_2 = mock.MagicMock()
+        mock_refit_2.fit.side_effect = RuntimeError("CUDA error")
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_1, mock_refit_2]
+        mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df()]
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = _mock_ts_df()
+        mock_concat.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        with pytest.raises(RuntimeError, match="All models failed refit. No artifacts written."):
+            autogluon_timeseries_models_training.python_func(
+                target="sales",
+                id_column="item_id",
+                timestamp_column="timestamp",
+                train_data_path="/tmp/train.csv",
+                test_data=test_data,
+                top_n=2,
+                workspace_path="/tmp/workspace",
+                pipeline_name="ts-pipeline-123",
+                run_id="run-123",
+                models_artifact=models_artifact,
+                notebooks=notebooks,
+                extra_train_data_path=extra_train_path,
             )


### PR DESCRIPTION
Assisted by Claude Code

**Description of your changes:**

  Apply changes requested in code review to remove backward compatibility
  and enforce required parameters for full model refit workflow.

  ## Breaking Changes
  - `models_artifact`, `notebooks`, and `extra_train_data_path` are now
    required parameters (previously optional with defaults)
  - Component always performs both model selection and full refit stages
  - Removed early-return "selection-only" mode for backward compatibility

  ## Improvements
  - Enhanced test coverage for full-refit path with comprehensive mocking
  - Added mock fixtures for autogluon metrics and ensemble models
  - Improved parameter validation and error messages
  - Updated documentation to reflect new parameter requirements

  ## Technical Details
  - Parameter order changed: extra_train_data_path moved to required position
  - Removed unused import os
  - Added pandas.concat mocking in tests
  - Updated lastVerified metadata timestamp

  This aligns the timeseries training component with the expected two-stage
  pipeline architecture without optional fallback modes.


**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Example pipeline accepts and forwards an extra training data path for full-refit runs.

* **Bug Fixes**
  * Stronger input validation: several inputs are now required and validated.
  * Improved error handling: per-model refit failures are captured so successful models persist; component errors if all refits fail.
  * Stricter metric checks: missing or non-finite evaluation metrics now trigger errors.

* **Documentation**
  * Updated component parameter docs and verification timestamp.

* **Tests**
  * Expanded/refactored unit tests to cover extra-data and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->