### PR TITLE
feat(piplines, components)[AutoML]: add new param eval_metric

### DIFF
--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -31,6 +31,7 @@ mutates predictor state. All artifacts are written under a single output artifac
 | `split_config` | `Optional[dict]` | `None` | Data split config stored in artifact metadata. |
 | `extra_train_data_path` | `str` | `""` | Optional path to extra training CSV passed to ``refit_full``. |
 | `positive_class` | `Optional[str]` | `None` | Optional label value for the positive class in **binary** classification (``int`` or ``str``, e.g. ``"1"`` or ``"yes"``). Passed to ``TabularPredictor`` when set. If ``None`` or empty, AutoGluon infers the positive class when ``fit`` runs (see note below). Ignored for ``multiclass`` and ``regression``. |
+| `eval_metric` | `str` | `""` | Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults to ``"r2"`` for regression and ``"accuracy"`` otherwise. |
 
 ## Outputs 📤
 

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -179,8 +179,8 @@ def autogluon_models_training(
             )
         if test_data_df.empty:
             raise ValueError("Test CSV is empty. Ensure the data loader produced valid test data.")
-    if not eval_metric:
-        eval_metric = "r2" if task_type == "regression" else "accuracy"
+        if not eval_metric:
+            eval_metric = "r2" if task_type == "regression" else "accuracy"
 
         extra_train_df = None
         if extra_train_data_path.strip():
@@ -200,8 +200,6 @@ def autogluon_models_training(
             train_rows=len(train_data_df),
             test_rows=len(test_data_df),
         )
-
-        eval_metric = "r2" if task_type == "regression" else "accuracy"
 
         coerced_positive_class = _coerce_positive_class(positive_class)
         if coerced_positive_class is not None and task_type != "binary":

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -81,7 +81,10 @@ def autogluon_models_training(
     import shutil
     from concurrent.futures import ThreadPoolExecutor
     from pathlib import Path
-    from typing import Any, NamedTuple
+    from typing import (
+        Any,
+        NamedTuple,
+    )  # NamedTuple must be imported inside the function body for KFP container execution
 
     import numpy as np
     import pandas as pd
@@ -114,6 +117,8 @@ def autogluon_models_training(
         raise TypeError("split_config must be a dictionary or None.")
     if positive_class is not None and not isinstance(positive_class, str):
         raise TypeError("positive_class must be a string or None.")
+    if eval_metric and not eval_metric.strip():
+        raise TypeError("eval_metric must be a non-empty string (or empty string '' to use the task-type default).")
 
     sampling_config = sampling_config or {}
     split_config = split_config or {}

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -88,6 +88,7 @@ def autogluon_models_training(
 
     import numpy as np
     import pandas as pd
+    from autogluon.core.metrics import METRICS
     from autogluon.tabular import TabularPredictor
 
     VALID_TASK_TYPES = {"binary", "multiclass", "regression"}
@@ -119,6 +120,11 @@ def autogluon_models_training(
         raise TypeError("positive_class must be a string or None.")
     if eval_metric and not eval_metric.strip():
         raise TypeError("eval_metric must be a non-empty string (or empty string '' to use the task-type default).")
+    if eval_metric and eval_metric not in METRICS.get(task_type, {}):
+        raise ValueError(
+            f"eval_metric {eval_metric!r} is not valid for task_type={task_type!r}. "
+            f"Valid options: {sorted(METRICS.get(task_type, {}))}."
+        )
 
     sampling_config = sampling_config or {}
     split_config = split_config or {}

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -83,8 +83,8 @@ def autogluon_models_training(
     from pathlib import Path
     from typing import (
         Any,
-        NamedTuple,
-    )  # NamedTuple must be imported inside the function body for KFP container execution
+        NamedTuple,  # NamedTuple must be imported inside the function body for KFP container execution
+    )
 
     import numpy as np
     import pandas as pd

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -23,6 +23,7 @@ def autogluon_models_training(
     split_config: Optional[dict] = None,
     extra_train_data_path: str = "",
     positive_class: Optional[str] = None,
+    eval_metric: str = "",
 ) -> NamedTuple("outputs", eval_metric=str):
     """Train AutoGluon models, select the top N, and refit each on the full dataset.
 
@@ -61,6 +62,8 @@ def autogluon_models_training(
             (``int`` or ``str``, e.g. ``"1"`` or ``"yes"``). Passed to ``TabularPredictor`` when set.
             If ``None`` or empty, AutoGluon infers the positive class when ``fit`` runs (see note below).
             Ignored for ``multiclass`` and ``regression``.
+        eval_metric: Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults
+            to ``"r2"`` for regression and ``"accuracy"`` otherwise.
 
     Returns:
         NamedTuple with ``eval_metric`` (the metric used for ranking, e.g. ``"r2"`` or ``"accuracy"``).
@@ -78,7 +81,7 @@ def autogluon_models_training(
     import shutil
     from concurrent.futures import ThreadPoolExecutor
     from pathlib import Path
-    from typing import Any
+    from typing import Any, NamedTuple
 
     import numpy as np
     import pandas as pd
@@ -165,6 +168,8 @@ def autogluon_models_training(
             )
         if test_data_df.empty:
             raise ValueError("Test CSV is empty. Ensure the data loader produced valid test data.")
+    if not eval_metric:
+        eval_metric = "r2" if task_type == "regression" else "accuracy"
 
         extra_train_df = None
         if extra_train_data_path.strip():
@@ -639,7 +644,7 @@ def autogluon_models_training(
         status.record("evaluate_models", "completed", eval_metric=str(predictor.eval_metric))
         component_status.metadata["display_name"] = "Models Training Status"
 
-    return NamedTuple("outputs", eval_metric=str)(eval_metric=str(predictor.eval_metric))
+    return NamedTuple("outputs", eval_metric=str)(eval_metric=eval_metric)
 
 
 if __name__ == "__main__":

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -1312,7 +1312,7 @@ class TestAutogluonModelsTrainingUnitTests:
                 split_config=[],
             )
 
-    def test_rejects_whitespace_eval_metric(self, mock_notebooks):
+    def test_rejects_whitespace_eval_metric(self):
         """Whitespace-only eval_metric must raise TypeError, not be forwarded to AutoGluon."""
         with pytest.raises(TypeError, match="eval_metric must be a non-empty string"):
             autogluon_models_training.python_func(
@@ -1326,11 +1326,10 @@ class TestAutogluonModelsTrainingUnitTests:
                 run_id=RUN_ID,
                 sample_row=SAMPLE_ROW,
                 models_artifact=self._minimal_artifact(),
-                notebooks=mock_notebooks,
                 eval_metric="   ",
             )
 
-    def test_invalid_eval_metric_for_task_type_raises(self, mock_notebooks):
+    def test_invalid_eval_metric_for_task_type_raises(self):
         """eval_metric unknown for the given task_type raises ValueError before training."""
         with pytest.raises(ValueError, match="is not valid for task_type="):
             autogluon_models_training.python_func(
@@ -1344,7 +1343,6 @@ class TestAutogluonModelsTrainingUnitTests:
                 run_id=RUN_ID,
                 sample_row=SAMPLE_ROW,
                 models_artifact=self._minimal_artifact(),
-                notebooks=mock_notebooks,
                 eval_metric="accuracy",  # valid for binary/multiclass, not regression
             )
 
@@ -1352,9 +1350,7 @@ class TestAutogluonModelsTrainingUnitTests:
 
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.tabular.TabularPredictor")
-    def test_eval_metric_explicit_forwarded_to_predictor(
-        self, mock_predictor_class, mock_read_csv, mock_notebooks, tmp_path
-    ):
+    def test_eval_metric_explicit_forwarded_to_predictor(self, mock_predictor_class, mock_read_csv, tmp_path):
         """Explicit eval_metric is passed through to TabularPredictor constructor and returned."""
         mock_predictor = mock.MagicMock()
         mock_predictor_clone = mock.MagicMock()
@@ -1387,7 +1383,6 @@ class TestAutogluonModelsTrainingUnitTests:
             run_id=RUN_ID,
             sample_row=SAMPLE_ROW,
             models_artifact=mock_models_artifact,
-            notebooks=mock_notebooks,
             eval_metric="r2",
         )
 
@@ -1402,9 +1397,7 @@ class TestAutogluonModelsTrainingUnitTests:
 
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.tabular.TabularPredictor")
-    def test_eval_metric_none_regression_resolves_to_r2(
-        self, mock_predictor_class, mock_read_csv, mock_notebooks, tmp_path
-    ):
+    def test_eval_metric_none_regression_resolves_to_r2(self, mock_predictor_class, mock_read_csv, tmp_path):
         """eval_metric=None with regression resolves to 'r2'."""
         mock_predictor = mock.MagicMock()
         mock_predictor_clone = mock.MagicMock()
@@ -1437,7 +1430,6 @@ class TestAutogluonModelsTrainingUnitTests:
             run_id=RUN_ID,
             sample_row=SAMPLE_ROW,
             models_artifact=mock_models_artifact,
-            notebooks=mock_notebooks,
             eval_metric=None,
         )
 
@@ -1449,7 +1441,7 @@ class TestAutogluonModelsTrainingUnitTests:
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.tabular.TabularPredictor")
     def test_eval_metric_none_binary_resolves_to_accuracy(
-        self, mock_predictor_class, mock_read_csv, mock_confusion_matrix, mock_notebooks, tmp_path
+        self, mock_predictor_class, mock_read_csv, mock_confusion_matrix, tmp_path
     ):
         """eval_metric=None with binary resolves to 'accuracy'."""
         mock_predictor = mock.MagicMock()
@@ -1484,7 +1476,6 @@ class TestAutogluonModelsTrainingUnitTests:
             run_id=RUN_ID,
             sample_row=SAMPLE_ROW,
             models_artifact=mock_models_artifact,
-            notebooks=mock_notebooks,
         )
 
         assert mock_predictor_class.call_args[1]["eval_metric"] == "accuracy"
@@ -1494,7 +1485,7 @@ class TestAutogluonModelsTrainingUnitTests:
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.tabular.TabularPredictor")
     def test_eval_metric_none_multiclass_resolves_to_accuracy(
-        self, mock_predictor_class, mock_read_csv, mock_confusion_matrix, mock_notebooks, tmp_path
+        self, mock_predictor_class, mock_read_csv, mock_confusion_matrix, tmp_path
     ):
         """eval_metric=None with multiclass resolves to 'accuracy'."""
         mock_predictor = mock.MagicMock()
@@ -1529,7 +1520,6 @@ class TestAutogluonModelsTrainingUnitTests:
             run_id=RUN_ID,
             sample_row=SAMPLE_ROW,
             models_artifact=mock_models_artifact,
-            notebooks=mock_notebooks,
         )
 
         assert mock_predictor_class.call_args[1]["eval_metric"] == "accuracy"

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -1261,6 +1261,24 @@ class TestAutogluonModelsTrainingUnitTests:
                 split_config=[],
             )
 
+    def test_rejects_whitespace_eval_metric(self, mock_notebooks):
+        """Whitespace-only eval_metric must raise TypeError, not be forwarded to AutoGluon."""
+        with pytest.raises(TypeError, match="eval_metric must be a non-empty string"):
+            autogluon_models_training.python_func(
+                label_column="target",
+                task_type="regression",
+                top_n=1,
+                train_data_path="/tmp/train.csv",
+                test_data=mock.MagicMock(path="/tmp/test.csv"),
+                workspace_path="/tmp/ws",
+                pipeline_name=PIPELINE_NAME,
+                run_id=RUN_ID,
+                sample_row=SAMPLE_ROW,
+                models_artifact=self._minimal_artifact(),
+                notebooks=mock_notebooks,
+                eval_metric="   ",
+            )
+
     # ── eval_metric parameter ─────────────────────────────────────────────────
 
     @mock.patch("pandas.read_csv")

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -28,6 +28,57 @@ def isolated_sys_modules():
             _m.__spec__ = None
             if sub == "autogluon.core":
                 _m.__path__ = []
+            if sub == "autogluon.core.metrics":
+                _m.METRICS = {
+                    "binary": {
+                        k: mock.MagicMock()
+                        for k in (
+                            "accuracy",
+                            "balanced_accuracy",
+                            "f1",
+                            "f1_macro",
+                            "f1_micro",
+                            "f1_weighted",
+                            "log_loss",
+                            "mcc",
+                            "roc_auc",
+                            "average_precision",
+                            "precision",
+                            "recall",
+                        )
+                    },
+                    "multiclass": {
+                        k: mock.MagicMock()
+                        for k in (
+                            "accuracy",
+                            "balanced_accuracy",
+                            "f1_macro",
+                            "f1_micro",
+                            "f1_weighted",
+                            "log_loss",
+                            "mcc",
+                            "roc_auc_ovo",
+                            "roc_auc_ovr",
+                        )
+                    },
+                    "regression": {
+                        k: mock.MagicMock()
+                        for k in (
+                            "r2",
+                            "mean_squared_error",
+                            "mse",
+                            "root_mean_squared_error",
+                            "rmse",
+                            "mean_absolute_error",
+                            "mae",
+                            "median_absolute_error",
+                            "mape",
+                            "smape",
+                            "spearmanr",
+                            "pearsonr",
+                        )
+                    },
+                }
             mocked_modules[sub] = _m
 
         def _roc_auc_score_side_effect(y_true, y_score):
@@ -1277,6 +1328,24 @@ class TestAutogluonModelsTrainingUnitTests:
                 models_artifact=self._minimal_artifact(),
                 notebooks=mock_notebooks,
                 eval_metric="   ",
+            )
+
+    def test_invalid_eval_metric_for_task_type_raises(self, mock_notebooks):
+        """eval_metric unknown for the given task_type raises ValueError before training."""
+        with pytest.raises(ValueError, match="is not valid for task_type="):
+            autogluon_models_training.python_func(
+                label_column="target",
+                task_type="regression",
+                top_n=1,
+                train_data_path="/tmp/train.csv",
+                test_data=mock.MagicMock(path="/tmp/test.csv"),
+                workspace_path="/tmp/ws",
+                pipeline_name=PIPELINE_NAME,
+                run_id=RUN_ID,
+                sample_row=SAMPLE_ROW,
+                models_artifact=self._minimal_artifact(),
+                notebooks=mock_notebooks,
+                eval_metric="accuracy",  # valid for binary/multiclass, not regression
             )
 
     # ── eval_metric parameter ─────────────────────────────────────────────────

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -1260,3 +1260,190 @@ class TestAutogluonModelsTrainingUnitTests:
                 models_artifact=self._minimal_artifact(),
                 split_config=[],
             )
+
+    # ── eval_metric parameter ─────────────────────────────────────────────────
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_eval_metric_explicit_forwarded_to_predictor(
+        self, mock_predictor_class, mock_read_csv, mock_notebooks, tmp_path
+    ):
+        """Explicit eval_metric is passed through to TabularPredictor constructor and returned."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"r2": 0.9}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        result = autogluon_models_training.python_func(
+            label_column="target",
+            task_type="regression",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            notebooks=mock_notebooks,
+            eval_metric="r2",
+        )
+
+        mock_predictor_class.assert_called_once_with(
+            problem_type="regression",
+            label="target",
+            eval_metric="r2",
+            path=Path(workspace_path) / "autogluon_predictor",
+            verbosity=2,
+        )
+        assert result.eval_metric == "r2"
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_eval_metric_none_regression_resolves_to_r2(
+        self, mock_predictor_class, mock_read_csv, mock_notebooks, tmp_path
+    ):
+        """eval_metric=None with regression resolves to 'r2'."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"r2": 0.9}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        result = autogluon_models_training.python_func(
+            label_column="target",
+            task_type="regression",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            notebooks=mock_notebooks,
+            eval_metric=None,
+        )
+
+        ctor_kwargs = mock_predictor_class.call_args[1]
+        assert ctor_kwargs["eval_metric"] == "r2"
+        assert result.eval_metric == "r2"
+
+    @mock.patch("autogluon.core.metrics.confusion_matrix")
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_eval_metric_none_binary_resolves_to_accuracy(
+        self, mock_predictor_class, mock_read_csv, mock_confusion_matrix, mock_notebooks, tmp_path
+    ):
+        """eval_metric=None with binary resolves to 'accuracy'."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "binary"
+        mock_predictor.label = "target"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"accuracy": 0.9}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_confusion_matrix.return_value = mock.MagicMock(to_dict=lambda: {"0": {"0": 5}})
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        result = autogluon_models_training.python_func(
+            label_column="target",
+            task_type="binary",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            notebooks=mock_notebooks,
+        )
+
+        assert mock_predictor_class.call_args[1]["eval_metric"] == "accuracy"
+        assert result.eval_metric == "accuracy"
+
+    @mock.patch("autogluon.core.metrics.confusion_matrix")
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_eval_metric_none_multiclass_resolves_to_accuracy(
+        self, mock_predictor_class, mock_read_csv, mock_confusion_matrix, mock_notebooks, tmp_path
+    ):
+        """eval_metric=None with multiclass resolves to 'accuracy'."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "multiclass"
+        mock_predictor.label = "target"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"accuracy": 0.88}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_confusion_matrix.return_value = mock.MagicMock(to_dict=lambda: {"0": {"0": 5}})
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        result = autogluon_models_training.python_func(
+            label_column="target",
+            task_type="multiclass",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            notebooks=mock_notebooks,
+        )
+
+        assert mock_predictor_class.call_args[1]["eval_metric"] == "accuracy"
+        assert result.eval_metric == "accuracy"

--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -32,6 +32,7 @@ Refit outputs for all selected models are written under one ``models_artifact`` 
 | `split_config` | `Optional[dict]` | `None` | Optional split config stored in artifact metadata. |
 | `prediction_length` | `int` | `1` | Forecast horizon (number of timesteps). |
 | `known_covariates_names` | `Optional[List[str]]` | `None` | Optional list of known covariate column names. |
+| `eval_metric` | `str` | `MASE` | Metric for model ranking (e.g. ``"MASE"``, ``"WQL"``). Defaults to ``"MASE"``. |
 
 ## Outputs 📤
 

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -99,6 +99,7 @@ def autogluon_timeseries_models_training(
             ("timestamp_column", timestamp_column),
             ("train_data_path", train_data_path),
             ("workspace_path", workspace_path),
+            ("eval_metric", eval_metric),
         ):
             if not isinstance(value, str) or not value.strip():
                 raise TypeError(f"{param} must be a non-empty string.")
@@ -134,8 +135,6 @@ def autogluon_timeseries_models_training(
             raise TypeError("sampling_config must be a dictionary or None.")
         if split_config is not None and not isinstance(split_config, dict):
             raise TypeError("split_config must be a dictionary or None.")
-        if not isinstance(eval_metric, str) or not eval_metric.strip():
-            raise TypeError("eval_metric must be a non-empty string.")
         sampling_config = sampling_config or {}
         split_config = split_config or {}
 

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -74,6 +74,8 @@ def autogluon_timeseries_models_training(
     import pandas as pd
     from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesPredictor
     from autogluon.timeseries.metrics import AVAILABLE_METRICS
+    from kfp_components.components.training.automl.shared.component_status import ComponentStatusTracker
+    from kfp_components.components.training.automl.shared.run_status import shared_automl_dir
 
     logger = logging.getLogger(__name__)
 
@@ -86,11 +88,6 @@ def autogluon_timeseries_models_training(
 
     status = ComponentStatusTracker(component_status.path, "autogluon_timeseries_models_training")
     with status:
-        # Set constants
-        DEFAULT_PRESETS = "fast_training"
-        DEFAULT_EVAL_METRIC = "MASE"
-        DEFAULT_TIME_LIMIT = 600  # 10 minutes
-
         TOP_N_MAX = 7
 
         # Input validation
@@ -104,6 +101,8 @@ def autogluon_timeseries_models_training(
         ):
             if not isinstance(value, str) or not value.strip():
                 raise TypeError(f"{param} must be a non-empty string.")
+        if eval_metric not in AVAILABLE_METRICS:
+            raise ValueError(f"eval_metric must be one of {sorted(AVAILABLE_METRICS)}; got {eval_metric!r}.")
         if not isinstance(top_n, int):
             raise TypeError("top_n must be an integer.")
         if top_n <= 0 or top_n > TOP_N_MAX:

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -80,8 +80,6 @@ def autogluon_timeseries_models_training(
     logger = logging.getLogger(__name__)
 
     from kfp_components.components.training.automl.shared.back_testing import build_back_testing_json
-    from kfp_components.components.training.automl.shared.component_status import ComponentStatusTracker
-    from kfp_components.components.training.automl.shared.run_status import shared_automl_dir
     from kfp_components.components.training.automl.shared.timeseries_notebook_utils import (
         build_predict_sample_artifact,
     )
@@ -89,6 +87,8 @@ def autogluon_timeseries_models_training(
     status = ComponentStatusTracker(component_status.path, "autogluon_timeseries_models_training")
     with status:
         TOP_N_MAX = 7
+        DEFAULT_PRESETS = "fast_training"
+        DEFAULT_TIME_LIMIT = 600  # 10 minutes
 
         # Input validation
         for param, value in (

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -73,6 +73,7 @@ def autogluon_timeseries_models_training(
 
     import pandas as pd
     from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesPredictor
+    from autogluon.timeseries.metrics import AVAILABLE_METRICS
 
     logger = logging.getLogger(__name__)
 

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -25,6 +25,7 @@ def autogluon_timeseries_models_training(
     split_config: Optional[dict] = None,
     prediction_length: int = 1,
     known_covariates_names: Optional[List[str]] = None,
+    eval_metric: str = "MASE",
 ) -> NamedTuple(
     "outputs",
     top_models=List[str],
@@ -60,6 +61,7 @@ def autogluon_timeseries_models_training(
         prediction_length: Forecast horizon (number of timesteps).
         known_covariates_names: Optional list of known covariate column names.
         component_status: Output artifact containing stage-level progress tracking for this component.
+        eval_metric: Metric for model ranking (e.g. ``"MASE"``, ``"WQL"``). Defaults to ``"MASE"``.
 
     Returns:
         NamedTuple: top_models list, predictor_path, eval_metric, model_config.
@@ -132,6 +134,8 @@ def autogluon_timeseries_models_training(
             raise TypeError("sampling_config must be a dictionary or None.")
         if split_config is not None and not isinstance(split_config, dict):
             raise TypeError("split_config must be a dictionary or None.")
+        if not isinstance(eval_metric, str) or not eval_metric.strip():
+            raise TypeError("eval_metric must be a non-empty string.")
         sampling_config = sampling_config or {}
         split_config = split_config or {}
 
@@ -167,7 +171,6 @@ def autogluon_timeseries_models_training(
         # Create predictor path in workspace
         predictor_path = Path(workspace_path) / "timeseries_predictor"
 
-        eval_metric = DEFAULT_EVAL_METRIC
         # Create TimeSeriesPredictor
         predictor = TimeSeriesPredictor(
             prediction_length=prediction_length,

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -586,7 +586,7 @@ class TestTimeseriesModelsTrainingUnitTests:
 
     def test_empty_eval_metric_raises(self, mock_artifacts):  # noqa: F811
         """eval_metric must be a non-empty string."""
-        models_artifact, notebooks, extra_train_path = mock_artifacts
+        models_artifact, extra_train_path = mock_artifacts
         test_data = mock.MagicMock()
         test_data.path = "/tmp/test.csv"
         with pytest.raises(TypeError, match="eval_metric must be a non-empty string"):
@@ -601,14 +601,13 @@ class TestTimeseriesModelsTrainingUnitTests:
                 pipeline_name="ts-pipeline-123",
                 run_id="run-123",
                 models_artifact=models_artifact,
-                notebooks=notebooks,
                 extra_train_data_path=extra_train_path,
                 eval_metric="",
             )
 
     def test_unsupported_eval_metric_raises(self, mock_artifacts):  # noqa: F811
         """eval_metric not in AVAILABLE_METRICS raises ValueError before training."""
-        models_artifact, notebooks, extra_train_path = mock_artifacts
+        models_artifact, extra_train_path = mock_artifacts
         test_data = mock.MagicMock()
         test_data.path = "/tmp/test.csv"
         with pytest.raises(ValueError, match="eval_metric must be one of"):
@@ -623,7 +622,6 @@ class TestTimeseriesModelsTrainingUnitTests:
                 pipeline_name="ts-pipeline-123",
                 run_id="run-123",
                 models_artifact=models_artifact,
-                notebooks=notebooks,
                 extra_train_data_path=extra_train_path,
                 eval_metric="BADMETRIC",
             )
@@ -641,7 +639,7 @@ class TestTimeseriesModelsTrainingUnitTests:
         mock_artifacts,  # noqa: F811
     ):
         """Custom eval_metric is passed to both TimeSeriesPredictor constructors, stored in model_config, and returned."""  # noqa: E501
-        models_artifact, notebooks, extra_train_path = mock_artifacts
+        models_artifact, extra_train_path = mock_artifacts
 
         mock_predictor = mock.MagicMock()
         mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
@@ -671,7 +669,6 @@ class TestTimeseriesModelsTrainingUnitTests:
             pipeline_name="ts-pipeline-123",
             run_id="run-123",
             models_artifact=models_artifact,
-            notebooks=notebooks,
             extra_train_data_path=extra_train_path,
             eval_metric="WQL",
         )

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -580,6 +580,85 @@ class TestTimeseriesModelsTrainingUnitTests:
                 extra_train_data_path=extra_train_path,
             )
 
+    # ── eval_metric parameter ─────────────────────────────────────────────────
+
+    def test_empty_eval_metric_raises(self, mock_artifacts):  # noqa: F811
+        """eval_metric must be a non-empty string."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+        with pytest.raises(TypeError, match="eval_metric must be a non-empty string"):
+            autogluon_timeseries_models_training.python_func(
+                target="sales",
+                id_column="item_id",
+                timestamp_column="timestamp",
+                train_data_path="/tmp/train.csv",
+                test_data=test_data,
+                top_n=1,
+                workspace_path="/tmp/workspace",
+                pipeline_name="ts-pipeline-123",
+                run_id="run-123",
+                models_artifact=models_artifact,
+                notebooks=notebooks,
+                extra_train_data_path=extra_train_path,
+                eval_metric="",
+            )
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_custom_eval_metric_passed_to_predictors_and_returned(
+        self,
+        mock_predictor_cls,
+        mock_ts_df_cls,
+        mock_concat,
+        mock_read_csv,
+        mock_artifacts,  # noqa: F811
+    ):
+        """Custom eval_metric is passed to both TimeSeriesPredictor constructors, stored in model_config, and returned."""  # noqa: E501
+        models_artifact, notebooks, extra_train_path = mock_artifacts
+
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        mock_refit_predictor = mock.MagicMock()
+        mock_refit_predictor.evaluate.return_value = {"WQL": 0.3, "MASE": 0.5}
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
+        mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df()]
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = _mock_ts_df()
+        mock_concat.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        result = autogluon_timeseries_models_training.python_func(
+            target="sales",
+            id_column="item_id",
+            timestamp_column="timestamp",
+            train_data_path="/tmp/train.csv",
+            test_data=test_data,
+            top_n=1,
+            workspace_path="/tmp/workspace",
+            pipeline_name="ts-pipeline-123",
+            run_id="run-123",
+            models_artifact=models_artifact,
+            notebooks=notebooks,
+            extra_train_data_path=extra_train_path,
+            eval_metric="WQL",
+        )
+
+        for call in mock_predictor_cls.call_args_list:
+            assert call.kwargs["eval_metric"] == "WQL"
+
+        assert result.eval_metric == "WQL"
+        assert result.model_config["eval_metric"] == "WQL"
+        assert models_artifact.metadata["context"]["model_config"]["eval_metric"] == "WQL"
+
 
 class TestMetricsJsonSignConvention:
     """Tests for metrics.json sign convention (raw AutoGluon, leaderboard-compatible)."""

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -26,7 +26,9 @@ def isolated_sys_modules():
 
         # Mock additional autogluon submodules
         _metrics = mock.MagicMock()
-        _metrics.AVAILABLE_METRICS = {"MASE": mock.MagicMock(), "MSE": mock.MagicMock()}
+        _metrics.AVAILABLE_METRICS = {
+            k: mock.MagicMock() for k in ("MASE", "MSE", "WQL", "RMSSE", "MAE", "RMSE", "SQL")
+        }
         _metrics.__spec__ = None
         mocked_modules["autogluon.timeseries.metrics"] = _metrics
 
@@ -602,6 +604,28 @@ class TestTimeseriesModelsTrainingUnitTests:
                 notebooks=notebooks,
                 extra_train_data_path=extra_train_path,
                 eval_metric="",
+            )
+
+    def test_unsupported_eval_metric_raises(self, mock_artifacts):  # noqa: F811
+        """eval_metric not in AVAILABLE_METRICS raises ValueError before training."""
+        models_artifact, notebooks, extra_train_path = mock_artifacts
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+        with pytest.raises(ValueError, match="eval_metric must be one of"):
+            autogluon_timeseries_models_training.python_func(
+                target="sales",
+                id_column="item_id",
+                timestamp_column="timestamp",
+                train_data_path="/tmp/train.csv",
+                test_data=test_data,
+                top_n=1,
+                workspace_path="/tmp/workspace",
+                pipeline_name="ts-pipeline-123",
+                run_id="run-123",
+                models_artifact=models_artifact,
+                notebooks=notebooks,
+                extra_train_data_path=extra_train_path,
+                eval_metric="BADMETRIC",
             )
 
     @mock.patch("pandas.read_csv")

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -650,7 +650,8 @@ class TestTimeseriesModelsTrainingUnitTests:
         mock_refit_predictor.evaluate.return_value = {"WQL": 0.3, "MASE": 0.5}
 
         mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
-        mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df()]
+        # from_data_frame: train, test, and once per model in build_predict_sample_artifact (1 model)
+        mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df(), _mock_ts_df()]
         mock_ts_df_cls.from_path.return_value = _mock_ts_df()
         mock_ts_df_cls.return_value = _mock_ts_df()
         mock_concat.return_value = mock.MagicMock()

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
@@ -59,7 +59,7 @@ The pipeline leverages AutoGluon's unique ensembling strategy that combines mult
 | `task_type` | `str` | `None` | "binary", "multiclass", or "regression"; drives metrics and model types. |
 | `top_n` | `int` | `3` | Number of top models to select and refit (default: 3); positive integer from range [1, 10]. |
 | `positive_class` | `Optional[str]` | `None` | Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values. |
-| `eval_metric` | `str` | `""` | Metric used for model ranking. Empty string (default) lets AutoGluon pick the task-type default ("accuracy" for binary and multiclass classification, "r2" for regression). |
+| `eval_metric` | `str` | `""` | Metric used for model ranking. Empty string (default) is resolved by the component to "r2" for regression and "accuracy" for binary and multiclass classification. |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
@@ -59,6 +59,7 @@ The pipeline leverages AutoGluon's unique ensembling strategy that combines mult
 | `task_type` | `str` | `None` | "binary", "multiclass", or "regression"; drives metrics and model types. |
 | `top_n` | `int` | `3` | Number of top models to select and refit (default: 3); positive integer from range [1, 10]. |
 | `positive_class` | `Optional[str]` | `None` | Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values. |
+| `eval_metric` | `str` | `""` | Metric used for model ranking. Empty string (default) lets AutoGluon pick the task-type default ("accuracy" for binary and multiclass classification, "r2" for regression). |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
@@ -125,7 +125,7 @@ def autogluon_tabular_training_pipeline(
         task_type: "binary", "multiclass", or "regression"; drives metrics and model types.
         top_n: Number of top models to select and refit (default: 3); positive integer from range [1, 10].
         positive_class: Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values.
-        eval_metric: Metric used for model ranking. Empty string (default) lets AutoGluon pick the task-type default ("accuracy" for binary and multiclass classification, "r2" for regression).
+        eval_metric: Metric used for model ranking. Empty string (default) is resolved by the component to "r2" for regression and "accuracy" for binary and multiclass classification.
 
     Returns:
         HTML artifact with leaderboard of refitted models ranked by task_type metric (e.g. accuracy, r2).

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
@@ -42,6 +42,7 @@ def autogluon_tabular_training_pipeline(
     task_type: str,
     top_n: int = 3,
     positive_class: Optional[str] = None,
+    eval_metric: str = "",
 ):
     """AutoGluon Tabular Training Pipeline.
 
@@ -124,6 +125,7 @@ def autogluon_tabular_training_pipeline(
         task_type: "binary", "multiclass", or "regression"; drives metrics and model types.
         top_n: Number of top models to select and refit (default: 3); positive integer from range [1, 10].
         positive_class: Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values.
+        eval_metric: Metric used for model ranking. Empty string (default) lets AutoGluon pick the task-type default ("accuracy" for binary and multiclass classification, "r2" for regression).
 
     Returns:
         HTML artifact with leaderboard of refitted models ranked by task_type metric (e.g. accuracy, r2).
@@ -199,6 +201,7 @@ def autogluon_tabular_training_pipeline(
         sampling_config=data_loader_task.outputs["sample_config"],
         split_config=data_loader_task.outputs["split_config"],
         extra_train_data_path=data_loader_task.outputs["extra_train_data_path"],
+        eval_metric=eval_metric,
     )
     training_task.set_caching_options(False)
     training_task.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(MAX_MEMORY)

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_configs.json
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_configs.json
@@ -5,7 +5,7 @@
     "label_column": "price",
     "problem_type": "regression",
     "task_type": "regression",
-    "automl_settings": { "top_n": 2 },
+    "automl_settings": { "top_n": 2, "eval_metric": "r2" },
     "tags": ["regression", "smoke"]
   },
   {
@@ -25,5 +25,14 @@
     "task_type": "multiclass",
     "automl_settings": { "top_n": 2 },
     "tags": ["classification", "multiclass"]
+  },
+  {
+    "id": "classification_binary_eval_metric",
+    "dataset_path": "data/classification.csv",
+    "label_column": "target",
+    "problem_type": "classification",
+    "task_type": "binary",
+    "automl_settings": { "top_n": 2, "eval_metric": "f1" },
+    "tags": ["classification", "binary", "eval_metric"]
   }
 ]

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
@@ -81,6 +81,7 @@ class TestAutogluonTabularTrainingPipelineUnitTests:
                 "task_type",
                 "top_n",
                 "positive_class",
+                "eval_metric",
             ):
                 assert name in content, f"Expected pipeline input '{name}' in compiled YAML"
         except Exception as e:
@@ -136,6 +137,22 @@ class TestAutogluonTabularTrainingPipelineUnitTests:
         assert "outputParameterKey: sample_config" in content
         assert "outputParameterKey: extra_train_data_path" in content
         assert "positive_class" in content
+
+    def test_compiled_pipeline_wires_eval_metric_to_training_task(self):
+        """eval_metric pipeline input is forwarded into the training task and its output wired to the leaderboard."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp_file:
+            tmp_path = tmp_file.name
+        try:
+            compiler.Compiler().compile(
+                pipeline_func=autogluon_tabular_training_pipeline,
+                package_path=tmp_path,
+            )
+            content = Path(tmp_path).read_text(encoding="utf-8")
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+        assert "componentInputParameter: eval_metric" in content
+        assert "outputParameterKey: eval_metric" in content
 
     def test_compiled_pipeline_data_loader_declares_task_type_and_label(self):
         """Tabular data loader component exposes task_type and label_column inputs."""

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
@@ -54,11 +54,13 @@ class TestAutogluonTabularTrainingPipelineUnitTests:
             "task_type",
             "top_n",
             "positive_class",
+            "eval_metric",
         }
         inputs = autogluon_tabular_training_pipeline.component_spec.inputs
         params = set(inputs.keys())
         assert params == expected_params, f"Pipeline params {params} != expected {expected_params}"
         assert inputs["top_n"].default == 3
+        assert inputs["eval_metric"].default == ""
 
     def test_compiled_pipeline_has_expected_inputs(self):
         """Test that the compiled pipeline YAML contains expected pipeline inputs."""

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -32,7 +32,7 @@ Args: train_data_secret_name: Kubernetes secret name containing S3 credentials (
 file (CSV or Parquet). File must include columns for item_id, timestamp, and target; optional columns for known covariates. target: Name of the column containing the numeric values to forecast. Corresponds to :attr:`~autogluon.timeseries.TimeSeriesDataFrame` target column. id_column: Name of the
 column that identifies each time series (e.g. product_id, store_id). Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. timestamp_column: Name of the column containing the timestamp/datetime for each observation. Passed as ``timestamp_column`` when constructing
 TimeSeriesDataFrame; result uses ``timestamp`` as the second index level. known_covariates_names: Optional list of column names known in advance for the forecast horizon (e.g. holidays, promotions). See :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`. prediction_length:
-Number of time steps to forecast (horizon length). Positive integer (default: 1). top_n: Number of top models to select for the leaderboard and output (default: 3).
+Number of time steps to forecast (horizon length). Positive integer (default: 1). top_n: Number of top models to select for the leaderboard and output (default: 3). eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or snake_case form. Defaults to ``"MASE"``.
 
 Returns: This pipeline wires task outputs between components; compiled runs expose the combined models artifact (per-model predictor, metrics, notebook paths) and leaderboard evaluation artifact (HTML + aggregated metrics), subject to Kubeflow Pipelines UI and artifact configuration.
 
@@ -54,6 +54,7 @@ prediction_length=14, top_n=3, )
 | `known_covariates_names` | `Optional[List[str]]` | `None` |  |
 | `prediction_length` | `int` | `1` |  |
 | `top_n` | `int` | `3` |  |
+| `eval_metric` | `str` | `MASE` |  |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
@@ -44,6 +44,7 @@ def autogluon_timeseries_training_pipeline(
     known_covariates_names: Optional[List[str]] = None,
     prediction_length: int = 1,
     top_n: int = 3,
+    eval_metric: str = "MASE",
 ):
     """AutoGluon time series training pipeline.
 
@@ -102,6 +103,8 @@ def autogluon_timeseries_training_pipeline(
         prediction_length: Number of time steps to forecast (horizon length). Positive integer
             (default: 1).
         top_n: Number of top models to select for the leaderboard and output (default: 3).
+        eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or
+            snake_case form. Defaults to ``"MASE"``.
 
     Returns:
         This pipeline wires task outputs between components; compiled runs expose the combined models artifact
@@ -181,6 +184,7 @@ def autogluon_timeseries_training_pipeline(
         sampling_config=data_loader_task.outputs["sample_config"],
         split_config=data_loader_task.outputs["split_config"],
         extra_train_data_path=data_loader_task.outputs["extra_train_data_path"],
+        eval_metric=eval_metric,
     )
     training_task.set_caching_options(False)
     training_task.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(MAX_MEMORY)

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_configs.json
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_configs.json
@@ -19,5 +19,17 @@
     "prediction_length": 10,
     "top_n": 2,
     "tags": ["smoke", "timeseries"]
+  },
+  {
+    "id": "timeseries_wql_eval_metric",
+    "dataset_path": "data/timeseries_sales.csv",
+    "target": "target",
+    "id_column": "item_id",
+    "timestamp_column": "timestamp",
+    "known_covariates_names": ["promo"],
+    "prediction_length": 2,
+    "top_n": 2,
+    "eval_metric": "WQL",
+    "tags": ["timeseries", "eval_metric"]
   }
 ]

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
@@ -85,6 +85,7 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
                 "known_covariates_names",
                 "prediction_length",
                 "top_n",
+                "eval_metric",
             ):
                 assert name in content, f"Expected pipeline input '{name}' in compiled YAML"
         except Exception as e:
@@ -116,3 +117,5 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
                 pytest.fail(f"Compiled pipeline YAML must be ASCII-only: {exc}")
         finally:
             Path(tmp_path).unlink(missing_ok=True)
+        assert "componentInputParameter: eval_metric" in content
+        assert "outputParameterKey: eval_metric" in content

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
@@ -110,9 +110,9 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
                 pipeline_func=autogluon_timeseries_training_pipeline,
                 package_path=tmp_path,
             )
-            content = Path(tmp_path).read_bytes()
+            content_bytes = Path(tmp_path).read_bytes()
             try:
-                content.decode("ascii")
+                content = content_bytes.decode("ascii")
             except UnicodeDecodeError as exc:
                 pytest.fail(f"Compiled pipeline YAML must be ASCII-only: {exc}")
         finally:

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
@@ -54,6 +54,7 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
             "known_covariates_names",
             "prediction_length",
             "top_n",
+            "eval_metric",
         }
         inputs = autogluon_timeseries_training_pipeline.component_spec.inputs
         params = set(inputs.keys())
@@ -61,6 +62,7 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
         assert inputs["prediction_length"].default == 1
         assert inputs["top_n"].default == 3
         assert inputs["known_covariates_names"].default is None
+        assert inputs["eval_metric"].default == "MASE"
 
     def test_compiled_pipeline_has_expected_inputs(self):
         """Test that compiled pipeline YAML contains expected pipeline input names."""


### PR DESCRIPTION
Assisted-by: Claude Code

**Description of your changes:**
Adds an eval_metric parameter to both the tabular and timeseries AutoML training components and their corresponding pipelines, allowing callers to control the metric used for model ranking without forking the pipeline.

  Tabular (autogluon_models_training + pipeline)

  - autogluon_models_training: adds eval_metric: str = "" input parameter. When empty (default), the component resolves to "r2" for regression and "accuracy" for classification — preserving existing behaviour. The resolved metric is passed to TabularPredictor constructor
   and returned directly (previously read from predictor.eval_metric after fit).
  - Pipeline (autogluon_tabular_training_pipeline): exposes eval_metric: str = "" and forwards it to the training component.
  - Tests: 4 new unit tests covering explicit metric forwarding and per-task-type default resolution (r2 / accuracy). Pipeline signature test updated. Regression smoke config gains "eval_metric": "r2"; new classification_binary_eval_metric integration config added.

  Timeseries (autogluon_timeseries_models_training + pipeline)

  - autogluon_timeseries_models_training: adds eval_metric: str = "MASE" input parameter (previously hardcoded as DEFAULT_EVAL_METRIC). Validates that the value is a non-empty string. Metric is passed to both the selection TimeSeriesPredictor and each refit predictor,
  stored in model_config, and returned as a component output.
  - Pipeline (autogluon_timeseries_training_pipeline): exposes eval_metric: str = "MASE" and forwards it to the training component.
  - Tests: 2 new unit tests — test_empty_eval_metric_raises and test_custom_eval_metric_passed_to_predictors_and_returned. Pipeline signature test updated. New timeseries_wql_eval_metric integration config added.

  Documentation

  README inputs tables for both components and both pipelines updated with the new eval_metric parameter.
**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added eval_metric input across tabular and timeseries training pipelines/components; tabular accepts empty to resolve to task-type default (e.g., r2 for regression, accuracy for classification), timeseries defaults to "MASE" and requires a valid metric. The chosen metric is exposed as a component output.

* **Documentation**
  * Updated READMEs and pipeline docs to describe eval_metric, defaults, and allowed values.

* **Tests**
  * Added unit tests for validation, default resolution, propagation to trainers, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->