### PR TITLE
feat(components): Add multilingual language detection and explicit language instructions to AutoRAG pipeline.

### DIFF
--- a/components/deployment/autorag/build_responses_request_bodies/component.py
+++ b/components/deployment/autorag/build_responses_request_bodies/component.py
@@ -232,74 +232,12 @@ def prepare_responses_api_requests(
 import copy
 import json
 import os
-from collections import Counter
 from getpass import getpass
 from pathlib import Path
 from urllib import request
 from urllib.error import HTTPError, URLError
 import ssl
 import sys
-
-try:
-    from langdetect import detect as _langdetect_detect, LangDetectException
-    _HAS_LANGDETECT = True
-except ImportError:
-    _HAS_LANGDETECT = False
-
-_LANG_MAP = {{
-    "ja": "Japanese", "ko": "Korean", "zh-cn": "Chinese", "zh-tw": "Chinese",
-    "de": "German", "fr": "French", "es": "Spanish", "pt": "Portuguese",
-    "it": "Italian", "ru": "Russian", "ar": "Arabic", "hi": "Hindi",
-    "th": "Thai", "vi": "Vietnamese", "pl": "Polish", "nl": "Dutch",
-    "sv": "Swedish", "cs": "Czech", "tr": "Turkish",
-}}
-
-_SCRIPT_RANGES = [
-    ("ja", [(0x3040, 0x309F), (0x30A0, 0x30FF), (0x31F0, 0x31FF)]),
-    ("ko", [(0xAC00, 0xD7AF), (0x1100, 0x11FF), (0x3130, 0x318F)]),
-    ("zh-cn", [(0x4E00, 0x9FFF), (0x3400, 0x4DBF), (0x20000, 0x2A6DF)]),
-    ("ar", [(0x0600, 0x06FF), (0x0750, 0x077F), (0x08A0, 0x08FF)]),
-    ("th", [(0x0E00, 0x0E7F)]),
-    ("hi", [(0x0900, 0x097F)]),
-    ("ru", [(0x0400, 0x04FF), (0x0500, 0x052F)]),
-]
-
-
-def _detect_language_by_script(text):
-    script_counts = {{}}
-    for ch in text:
-        cp = ord(ch)
-        for lang_code, ranges in _SCRIPT_RANGES:
-            if any(lo <= cp <= hi for lo, hi in ranges):
-                script_counts[lang_code] = script_counts.get(lang_code, 0) + 1
-                break
-    if not script_counts:
-        return None
-    best = max(script_counts, key=script_counts.get)
-    if best == "zh-cn" and script_counts.get("ja", 0) > 0:
-        return "ja"
-    return best
-
-
-def _detect_language_instruction(question: str) -> str:
-    """Detect question language and return explicit instruction, or empty for English."""
-    if not question.strip():
-        return ""
-    if _HAS_LANGDETECT:
-        try:
-            code = _langdetect_detect(question)
-        except (LangDetectException, Exception):
-            code = None
-        if code and code != "en":
-            name = _LANG_MAP.get(code)
-            if name:
-                return f"You MUST respond in {{name}}."
-    code = _detect_language_by_script(question)
-    if code:
-        name = _LANG_MAP.get(code)
-        if name:
-            return f"You MUST respond in {{name}}."
-    return ""
 
 
 OGX_BASE_URL = "{base_url.rstrip("/")}"
@@ -419,9 +357,6 @@ def main() -> int:
             return 0
         body = copy.deepcopy(template)
         _set_question(body, question)
-        lang_instr = _detect_language_instruction(question)
-        if lang_instr and "instructions" in body and lang_instr not in body["instructions"]:
-            body["instructions"] = f"{{lang_instr}} {{body['instructions']}}"
         rc = _post_responses(body, api_key, ssl_context)
         if rc != 0:
             return rc

--- a/components/deployment/autorag/build_responses_request_bodies/component.py
+++ b/components/deployment/autorag/build_responses_request_bodies/component.py
@@ -125,6 +125,8 @@ def prepare_responses_api_requests(
         """Build explicit language instruction from detected_language metadata."""
         if not isinstance(detected_language, dict):
             return ""
+        if detected_language.get("code") == "en":
+            return ""
         name = detected_language.get("name", "")
         if not name:
             return ""

--- a/components/deployment/autorag/build_responses_request_bodies/component.py
+++ b/components/deployment/autorag/build_responses_request_bodies/component.py
@@ -121,6 +121,15 @@ def prepare_responses_api_requests(
         """Placeholder user message in the JSON; interactive script overwrites at runtime."""
         return RESPONSES_BODY_DEFAULT_QUESTION
 
+    def _explicit_language_instruction(detected_language: object) -> str:
+        """Build explicit language instruction from detected_language metadata."""
+        if not isinstance(detected_language, dict):
+            return ""
+        name = detected_language.get("name", "")
+        if not name:
+            return ""
+        return f"You MUST respond in {name}."
+
     def _language_instruction_from_user_message(user_message_text: object) -> str:
         """Extract language guidance from generation.user_message_text when present."""
         if not isinstance(user_message_text, str):
@@ -162,15 +171,20 @@ def prepare_responses_api_requests(
     def _compose_instructions(generation: dict) -> str:
         """Compose Responses API instructions from system/user generation fields."""
         system_text = _normalize_system_message_for_file_search(generation.get("system_message_text"))
-        language_hint = _language_instruction_from_user_message(generation.get("user_message_text"))
+        explicit_lang = _explicit_language_instruction(generation.get("detected_language"))
+        language_hint = explicit_lang or _language_instruction_from_user_message(generation.get("user_message_text"))
         if not system_text:
+            if explicit_lang:
+                return f"{grounding_instruction} {explicit_lang}"
             return default_instructions
 
         parts = [system_text]
         lowered = system_text.lower()
         if "file_search" not in lowered and "retriev" not in lowered:
             parts.append(grounding_instruction)
-        if language_hint:
+        if "you must respond in" in lowered:
+            pass
+        elif language_hint:
             if "same language as the user question" not in lowered and "language of the question" not in lowered:
                 parts.append(language_hint)
         elif "same language as the user question" not in lowered and "language of the question" not in lowered:
@@ -218,12 +232,74 @@ def prepare_responses_api_requests(
 import copy
 import json
 import os
+from collections import Counter
 from getpass import getpass
 from pathlib import Path
 from urllib import request
 from urllib.error import HTTPError, URLError
 import ssl
 import sys
+
+try:
+    from langdetect import detect as _langdetect_detect, LangDetectException
+    _HAS_LANGDETECT = True
+except ImportError:
+    _HAS_LANGDETECT = False
+
+_LANG_MAP = {{
+    "ja": "Japanese", "ko": "Korean", "zh-cn": "Chinese", "zh-tw": "Chinese",
+    "de": "German", "fr": "French", "es": "Spanish", "pt": "Portuguese",
+    "it": "Italian", "ru": "Russian", "ar": "Arabic", "hi": "Hindi",
+    "th": "Thai", "vi": "Vietnamese", "pl": "Polish", "nl": "Dutch",
+    "sv": "Swedish", "cs": "Czech", "tr": "Turkish",
+}}
+
+_SCRIPT_RANGES = [
+    ("ja", [(0x3040, 0x309F), (0x30A0, 0x30FF), (0x31F0, 0x31FF)]),
+    ("ko", [(0xAC00, 0xD7AF), (0x1100, 0x11FF), (0x3130, 0x318F)]),
+    ("zh-cn", [(0x4E00, 0x9FFF), (0x3400, 0x4DBF), (0x20000, 0x2A6DF)]),
+    ("ar", [(0x0600, 0x06FF), (0x0750, 0x077F), (0x08A0, 0x08FF)]),
+    ("th", [(0x0E00, 0x0E7F)]),
+    ("hi", [(0x0900, 0x097F)]),
+    ("ru", [(0x0400, 0x04FF), (0x0500, 0x052F)]),
+]
+
+
+def _detect_language_by_script(text):
+    script_counts = {{}}
+    for ch in text:
+        cp = ord(ch)
+        for lang_code, ranges in _SCRIPT_RANGES:
+            if any(lo <= cp <= hi for lo, hi in ranges):
+                script_counts[lang_code] = script_counts.get(lang_code, 0) + 1
+                break
+    if not script_counts:
+        return None
+    best = max(script_counts, key=script_counts.get)
+    if best == "zh-cn" and script_counts.get("ja", 0) > 0:
+        return "ja"
+    return best
+
+
+def _detect_language_instruction(question: str) -> str:
+    """Detect question language and return explicit instruction, or empty for English."""
+    if not question.strip():
+        return ""
+    if _HAS_LANGDETECT:
+        try:
+            code = _langdetect_detect(question)
+        except (LangDetectException, Exception):
+            code = None
+        if code and code != "en":
+            name = _LANG_MAP.get(code)
+            if name:
+                return f"You MUST respond in {{name}}."
+    code = _detect_language_by_script(question)
+    if code:
+        name = _LANG_MAP.get(code)
+        if name:
+            return f"You MUST respond in {{name}}."
+    return ""
 
 
 OGX_BASE_URL = "{base_url.rstrip("/")}"
@@ -343,6 +419,9 @@ def main() -> int:
             return 0
         body = copy.deepcopy(template)
         _set_question(body, question)
+        lang_instr = _detect_language_instruction(question)
+        if lang_instr and "instructions" in body and lang_instr not in body["instructions"]:
+            body["instructions"] = f"{{lang_instr}} {{body['instructions']}}"
         rc = _post_responses(body, api_key, ssl_context)
         if rc != 0:
             return rc

--- a/components/deployment/autorag/build_responses_request_bodies/tests/test_component_unit.py
+++ b/components/deployment/autorag/build_responses_request_bodies/tests/test_component_unit.py
@@ -183,6 +183,18 @@ class TestBuildOgxV1ResponsesBody:
         body = json.loads((out / "p1" / OUTPUT_FILENAME).read_text(encoding="utf-8"))
         assert "Respond in the same language as the user question." in body["instructions"]
 
+    def test_english_detected_language_does_not_add_explicit_instruction(self, tmp_path):
+        """English detected_language should not produce 'You MUST respond in English.'."""
+        pattern = _minimal_pattern()
+        pattern["settings"]["generation"]["detected_language"] = {
+            "code": "en",
+            "name": "English",
+        }
+        out, _ = _run_python_func(tmp_path, [("p1", pattern)])
+        body = json.loads((out / "p1" / OUTPUT_FILENAME).read_text(encoding="utf-8"))
+        assert "You MUST respond in English." not in body["instructions"]
+        assert "Respond in the same language as the user question." in body["instructions"]
+
     def test_input_uses_placeholder_not_generation_template(self, tmp_path):
         """``input`` uses the fixed placeholder, not ``user_message_text`` template expansion."""
         pattern = _minimal_pattern()

--- a/components/deployment/autorag/build_responses_request_bodies/tests/test_component_unit.py
+++ b/components/deployment/autorag/build_responses_request_bodies/tests/test_component_unit.py
@@ -205,13 +205,25 @@ class TestBuildOgxV1ResponsesBody:
         assert "file_search results" in body["instructions"]
         assert "Respond in the same language as the user question." in body["instructions"]
 
-    def test_script_includes_language_detection(self, tmp_path):
-        """Generated helper script includes langdetect-based language detection."""
+    def test_script_has_no_langdetect_dependency(self, tmp_path):
+        """Generated helper script must not depend on langdetect."""
         out, _ = _run_python_func(tmp_path, [("p1", _minimal_pattern())])
         script = (out / "p1" / SCRIPT_FILENAME).read_text(encoding="utf-8")
-        assert "_detect_language_instruction" in script
-        assert "langdetect" in script
-        assert "_LANG_MAP" in script
+        assert "langdetect" not in script
+        assert "_detect_language_instruction" not in script
+        assert "_LANG_MAP" not in script
+
+    def test_detected_language_instruction_not_duplicated(self, tmp_path):
+        """When system_message_text already has 'You MUST respond in X.', instructions don't double it."""
+        pattern = _minimal_pattern()
+        pattern["settings"]["generation"]["detected_language"] = {"code": "ja", "name": "Japanese"}
+        pattern["settings"]["generation"]["system_message_text"] = (
+            "You MUST respond in Japanese. Answer based on context only."
+        )
+        out, _ = _run_python_func(tmp_path, [("p1", pattern)])
+        body = json.loads((out / "p1" / OUTPUT_FILENAME).read_text(encoding="utf-8"))
+        count = body["instructions"].count("You MUST respond in Japanese.")
+        assert count == 1, f"Expected 1 occurrence, got {count}: {body['instructions']}"
 
     def test_script_supports_custom_ca_bundle_and_insecure_tls(self, tmp_path):
         """Generated helper exposes CA-bundle env vars and a dev-only insecure flag.

--- a/components/deployment/autorag/build_responses_request_bodies/tests/test_component_unit.py
+++ b/components/deployment/autorag/build_responses_request_bodies/tests/test_component_unit.py
@@ -165,6 +165,24 @@ class TestBuildOgxV1ResponsesBody:
         body = json.loads((out / "p1" / OUTPUT_FILENAME).read_text(encoding="utf-8"))
         assert "ranking_options" not in body["tools"][0]
 
+    def test_detected_language_produces_explicit_instruction(self, tmp_path):
+        """When detected_language is in the pattern, instructions use explicit language name."""
+        pattern = _minimal_pattern()
+        pattern["settings"]["generation"]["detected_language"] = {
+            "code": "ja",
+            "name": "Japanese",
+        }
+        out, _ = _run_python_func(tmp_path, [("p1", pattern)])
+        body = json.loads((out / "p1" / OUTPUT_FILENAME).read_text(encoding="utf-8"))
+        assert "You MUST respond in Japanese." in body["instructions"]
+        assert "Respond in the same language as the user question." not in body["instructions"]
+
+    def test_no_detected_language_falls_back_to_generic(self, tmp_path):
+        """Without detected_language, instructions use generic language hint."""
+        out, _ = _run_python_func(tmp_path, [("p1", _minimal_pattern())])
+        body = json.loads((out / "p1" / OUTPUT_FILENAME).read_text(encoding="utf-8"))
+        assert "Respond in the same language as the user question." in body["instructions"]
+
     def test_input_uses_placeholder_not_generation_template(self, tmp_path):
         """``input`` uses the fixed placeholder, not ``user_message_text`` template expansion."""
         pattern = _minimal_pattern()
@@ -186,6 +204,14 @@ class TestBuildOgxV1ResponsesBody:
         assert "Context section" not in body["instructions"]
         assert "file_search results" in body["instructions"]
         assert "Respond in the same language as the user question." in body["instructions"]
+
+    def test_script_includes_language_detection(self, tmp_path):
+        """Generated helper script includes langdetect-based language detection."""
+        out, _ = _run_python_func(tmp_path, [("p1", _minimal_pattern())])
+        script = (out / "p1" / SCRIPT_FILENAME).read_text(encoding="utf-8")
+        assert "_detect_language_instruction" in script
+        assert "langdetect" in script
+        assert "_LANG_MAP" in script
 
     def test_script_supports_custom_ca_bundle_and_insecure_tls(self, tmp_path):
         """Generated helper exposes CA-bundle env vars and a dev-only insecure flag.

--- a/components/deployment/autorag/build_responses_request_bodies/tests/test_component_unit.py
+++ b/components/deployment/autorag/build_responses_request_bodies/tests/test_component_unit.py
@@ -205,14 +205,6 @@ class TestBuildOgxV1ResponsesBody:
         assert "file_search results" in body["instructions"]
         assert "Respond in the same language as the user question." in body["instructions"]
 
-    def test_script_has_no_langdetect_dependency(self, tmp_path):
-        """Generated helper script must not depend on langdetect."""
-        out, _ = _run_python_func(tmp_path, [("p1", _minimal_pattern())])
-        script = (out / "p1" / SCRIPT_FILENAME).read_text(encoding="utf-8")
-        assert "langdetect" not in script
-        assert "_detect_language_instruction" not in script
-        assert "_LANG_MAP" not in script
-
     def test_detected_language_instruction_not_duplicated(self, tmp_path):
         """When system_message_text already has 'You MUST respond in X.', instructions don't double it."""
         pattern = _minimal_pattern()

--- a/components/training/autorag/rag_templates_optimization/component.py
+++ b/components/training/autorag/rag_templates_optimization/component.py
@@ -580,6 +580,8 @@ def rag_templates_optimization(
     with open(search_space_prep_report, "r") as f:
         search_space = yml.safe_load(f)
 
+    detected_language = search_space.pop("detected_language", None)
+
     search_space = AI4RAGSearchSpace(
         params=[Parameter(param, "C", values=values) for param, values in search_space.items()]
     )
@@ -602,6 +604,32 @@ def rag_templates_optimization(
         raise ValueError("vector_io_provider_id must be a non-empty string.")
     vector_io_provider_id = vector_io_provider_id.strip()
 
+    _DEFAULT_SYSTEM_MSG = (
+        "Please answer the question I provide in the Question section below, "
+        "based solely on the information I provide in the Context section. "
+        "If the question is unanswerable, please say you cannot answer."
+    )
+    _DEFAULT_USER_MSG = (
+        "\n\nContext:\n{reference_documents}:\n\nQuestion: {question}. \n"
+        "Again, please answer the question based on the context provided only. "
+        "If the context is not related to the question, just say you cannot answer. "
+    )
+
+    if detected_language:
+        lang_name = detected_language.get("name", "")
+        if lang_name:
+            explicit_instruction = f"You MUST respond in {lang_name}."
+            sys_msg = f"{explicit_instruction} {_DEFAULT_SYSTEM_MSG}"
+            usr_msg = f"{_DEFAULT_USER_MSG}{explicit_instruction}"
+            for fm in search_space["foundation_model"].values:
+                fm.system_message_text = sys_msg
+                fm.user_message_text = usr_msg
+            _ssl_logger.info(
+                "Set explicit language instruction on %d foundation model(s): %s",
+                len(search_space["foundation_model"].values),
+                explicit_instruction,
+            )
+
     rag_exp = AI4RAGExperiment(
         client=client,
         event_handler=event_handler,
@@ -612,7 +640,6 @@ def rag_templates_optimization(
         documents=documents,
         optimization_metric=optimization_metric,
         ogx_vector_io_provider_id=vector_io_provider_id,
-        # TODO some necessary kwargs (if any at all)
     )
 
     # retrieve documents && run optimisation loop
@@ -643,6 +670,19 @@ def rag_templates_optimization(
 
     rag_patterns_dir = Path(rag_patterns.path)
     evaluation_data_list = getattr(rag_exp.results, "evaluation_data", [])
+
+    def _build_system_message(custom_text: str | None, lang: dict | None) -> str:
+        """Build system message with explicit language instruction when detected."""
+        base = custom_text if custom_text else _DEFAULT_SYSTEM_MSG
+        if not lang:
+            return base
+        lang_name = lang.get("name", "")
+        if not lang_name:
+            return base
+        instruction = f"You MUST respond in {lang_name}."
+        if instruction in base:
+            return base
+        return f"{instruction} {base}"
 
     def _build_pattern_json(evaluation_result, iteration: int, max_combinations: int) -> dict:
         """Build pattern.json with flat schema (name, iteration, settings, scores, final_score)."""
@@ -728,13 +768,11 @@ def rag_templates_optimization(
                             "the question."
                         ),
                     ),
-                    "system_message_text": generation.get(
-                        "system_message_text",
-                        (
-                            "Please answer the question I provide in the Question section below, based solely "
-                            "on the information I provide in the Context section. If unanswerable, say so."
-                        ),
+                    "system_message_text": _build_system_message(
+                        generation.get("system_message_text"),
+                        detected_language,
                     ),
+                    **({"detected_language": detected_language} if detected_language else {}),
                 },
             },
         }

--- a/components/training/autorag/rag_templates_optimization/component.py
+++ b/components/training/autorag/rag_templates_optimization/component.py
@@ -616,14 +616,15 @@ def rag_templates_optimization(
     )
 
     if detected_language:
+        lang_code = detected_language.get("code", "")
         lang_name = detected_language.get("name", "")
-        if lang_name:
+        if lang_name and lang_code != "en":
             explicit_instruction = f"You MUST respond in {lang_name}."
-            sys_msg = f"{explicit_instruction} {_DEFAULT_SYSTEM_MSG}"
-            usr_msg = f"{_DEFAULT_USER_MSG}{explicit_instruction}"
             for fm in search_space["foundation_model"].values:
-                fm.system_message_text = sys_msg
-                fm.user_message_text = usr_msg
+                existing_sys = fm.system_message_text if fm.system_message_text else _DEFAULT_SYSTEM_MSG
+                existing_usr = str(fm.user_message_text) if fm.user_message_text else _DEFAULT_USER_MSG
+                fm.system_message_text = f"{explicit_instruction} {existing_sys}"
+                fm.user_message_text = f"{existing_usr}{explicit_instruction}"
             _ssl_logger.info(
                 "Set explicit language instruction on %d foundation model(s): %s",
                 len(search_space["foundation_model"].values),

--- a/components/training/autorag/rag_templates_optimization/tests/test_component_unit.py
+++ b/components/training/autorag/rag_templates_optimization/tests/test_component_unit.py
@@ -522,3 +522,99 @@ class TestSSLFallbackRagTemplatesOptimization:
                     test_data_key="small-dataset/benchmark.json",
                     vector_io_provider_id="milvus",
                 )
+
+
+class TestMultilingualPromptOverrides:
+    """Tests for detected_language prompt override and _build_system_message dedup."""
+
+    def _setup_with_language(self, tmp_path, detected_language=None):
+        """Set up mocks with detected_language in search space YAML."""
+        mocks = _make_all_mocks()
+        ogx_mod = _make_ogx_client_module()
+        mock_ogx = mock.MagicMock()
+        mock_ogx.models.list.return_value = []
+        ogx_mod.OgxClient.return_value = mock_ogx
+        mocks["ogx_client"] = ogx_mod
+        mocks["ai4rag.core.experiment.experiment"].AI4RAGExperiment.side_effect = _SentinelAbort
+
+        search_space_data = {}
+        if detected_language:
+            search_space_data["detected_language"] = detected_language
+
+        mock_yaml = mock.MagicMock()
+        mock_yaml.safe_load.return_value = search_space_data
+        mocks["yaml"] = mock_yaml
+
+        report = tmp_path / "report.yml"
+        report.write_text("{}")
+        test_data = tmp_path / "test_data.json"
+        test_data.write_text("[]")
+
+        return mocks, str(tmp_path / "extracted"), str(test_data), str(report)
+
+    def _run(self, mocks, extracted_text, test_data, report, **kwargs):
+        with (
+            mock.patch.dict(sys.modules, mocks),
+            mock.patch.dict(os.environ, {
+                "OGX_CLIENT_BASE_URL": "https://ogx.example.com",
+                "OGX_CLIENT_API_KEY": "test-api-key",
+            }),
+        ):
+            rag_templates_optimization.python_func(
+                extracted_text=extracted_text,
+                test_data=test_data,
+                search_space_prep_report=report,
+                rag_patterns=mock.MagicMock(path="/tmp/rag_patterns", metadata={}, uri=""),
+                embedded_artifact=mock.MagicMock(path="/tmp/embedded"),
+                test_data_key="small-dataset/benchmark.json",
+                vector_io_provider_id="milvus",
+                optimization_settings={"metric": "faithfulness", "max_number_of_rag_patterns": 8},
+                **kwargs,
+            )
+
+    def test_detected_language_sets_prompts_on_foundation_models(self, tmp_path):
+        """When detected_language is present, foundation models get explicit language instruction."""
+        mocks, ext, td, report = self._setup_with_language(
+            tmp_path, detected_language={"code": "de", "name": "German"}
+        )
+        mock_fm = mock.MagicMock()
+        mock_search_space = mock.MagicMock()
+        mock_search_space.__getitem__ = mock.MagicMock(
+            return_value=mock.MagicMock(values=[mock_fm])
+        )
+        mocks["ai4rag.search_space.src.search_space"].AI4RAGSearchSpace.return_value = mock_search_space
+
+        with pytest.raises(_SentinelAbort):
+            self._run(mocks, ext, td, report)
+
+        assert "You MUST respond in German." in mock_fm.system_message_text
+        assert "You MUST respond in German." in mock_fm.user_message_text
+
+    def test_no_detected_language_preserves_defaults(self, tmp_path):
+        """Without detected_language, foundation model prompts are untouched."""
+        mocks, ext, td, report = self._setup_with_language(tmp_path)
+        mock_fm = mock.MagicMock()
+        original_sys = mock_fm.system_message_text
+        mock_search_space = mock.MagicMock()
+        mock_search_space.__getitem__ = mock.MagicMock(
+            return_value=mock.MagicMock(values=[mock_fm])
+        )
+        mocks["ai4rag.search_space.src.search_space"].AI4RAGSearchSpace.return_value = mock_search_space
+
+        with pytest.raises(_SentinelAbort):
+            self._run(mocks, ext, td, report)
+
+        assert mock_fm.system_message_text == original_sys
+
+    def test_detected_language_popped_before_search_space_construction(self, tmp_path):
+        """detected_language must not leak into AI4RAGSearchSpace as a parameter."""
+        mocks, ext, td, report = self._setup_with_language(
+            tmp_path, detected_language={"code": "ja", "name": "Japanese"}
+        )
+
+        with pytest.raises(_SentinelAbort):
+            self._run(mocks, ext, td, report)
+
+        param_calls = mocks["ai4rag.search_space.src.parameter"].Parameter.call_args_list
+        param_names = [c.args[0] if c.args else c.kwargs.get("name", "") for c in param_calls]
+        assert "detected_language" not in param_names

--- a/components/training/autorag/rag_templates_optimization/tests/test_component_unit.py
+++ b/components/training/autorag/rag_templates_optimization/tests/test_component_unit.py
@@ -555,10 +555,13 @@ class TestMultilingualPromptOverrides:
     def _run(self, mocks, extracted_text, test_data, report, **kwargs):
         with (
             mock.patch.dict(sys.modules, mocks),
-            mock.patch.dict(os.environ, {
-                "OGX_CLIENT_BASE_URL": "https://ogx.example.com",
-                "OGX_CLIENT_API_KEY": "test-api-key",
-            }),
+            mock.patch.dict(
+                os.environ,
+                {
+                    "OGX_CLIENT_BASE_URL": "https://ogx.example.com",
+                    "OGX_CLIENT_API_KEY": "test-api-key",
+                },
+            ),
         ):
             rag_templates_optimization.python_func(
                 extracted_text=extracted_text,
@@ -574,14 +577,10 @@ class TestMultilingualPromptOverrides:
 
     def test_detected_language_sets_prompts_on_foundation_models(self, tmp_path):
         """When detected_language is present, foundation models get explicit language instruction."""
-        mocks, ext, td, report = self._setup_with_language(
-            tmp_path, detected_language={"code": "de", "name": "German"}
-        )
+        mocks, ext, td, report = self._setup_with_language(tmp_path, detected_language={"code": "de", "name": "German"})
         mock_fm = mock.MagicMock()
         mock_search_space = mock.MagicMock()
-        mock_search_space.__getitem__ = mock.MagicMock(
-            return_value=mock.MagicMock(values=[mock_fm])
-        )
+        mock_search_space.__getitem__ = mock.MagicMock(return_value=mock.MagicMock(values=[mock_fm]))
         mocks["ai4rag.search_space.src.search_space"].AI4RAGSearchSpace.return_value = mock_search_space
 
         with pytest.raises(_SentinelAbort):
@@ -596,9 +595,7 @@ class TestMultilingualPromptOverrides:
         mock_fm = mock.MagicMock()
         original_sys = mock_fm.system_message_text
         mock_search_space = mock.MagicMock()
-        mock_search_space.__getitem__ = mock.MagicMock(
-            return_value=mock.MagicMock(values=[mock_fm])
-        )
+        mock_search_space.__getitem__ = mock.MagicMock(return_value=mock.MagicMock(values=[mock_fm]))
         mocks["ai4rag.search_space.src.search_space"].AI4RAGSearchSpace.return_value = mock_search_space
 
         with pytest.raises(_SentinelAbort):

--- a/components/training/autorag/search_space_preparation/component.py
+++ b/components/training/autorag/search_space_preparation/component.py
@@ -136,11 +136,16 @@ def search_space_preparation(
         "tr": "Turkish",
     }
 
-    def _detect_language_via_llm(questions: list[str], llm_client: OgxClient) -> dict[str, str] | None:
+    def _detect_language_via_llm(
+        questions: list[str],
+        llm_client: OgxClient,
+        allowed_generation_models: list[str] | None = None,
+    ) -> dict[str, str] | None:
         """Detect the dominant language by asking an LLM.
 
-        Sends a few sample questions to the first available generation model and asks
-        it to identify the language. Returns a dict with code/name, or None for English.
+        Sends a few sample questions to a generation model and asks for the ISO 639-1 code.
+        Prefers models from allowed_generation_models when provided.
+        Returns a dict with code/name, or None for English.
         """
         sample_text = "\n".join(f"- {q}" for q in questions[:5])
         valid_codes = ", ".join(sorted(LANGUAGE_MAP.keys()))
@@ -148,15 +153,19 @@ def search_space_preparation(
         try:
             models_response = llm_client.models.list()
             models_list = models_response.data if hasattr(models_response, "data") else list(models_response)
+            registered_ids = {(m.identifier if hasattr(m, "identifier") else str(m.id)) for m in models_list}
+
             model_id = None
-            for m in models_list:
-                if hasattr(m, "model_type") and getattr(m, "model_type", "") == "llm":
-                    model_id = m.identifier if hasattr(m, "identifier") else str(m.id)
-                    break
-            if not model_id and models_list:
-                model_id = (
-                    models_list[0].identifier if hasattr(models_list[0], "identifier") else str(models_list[0].id)
-                )
+            if allowed_generation_models:
+                for gm in allowed_generation_models:
+                    if gm in registered_ids:
+                        model_id = gm
+                        break
+            if not model_id:
+                for m in models_list:
+                    if hasattr(m, "model_type") and getattr(m, "model_type", "") == "llm":
+                        model_id = m.identifier if hasattr(m, "identifier") else str(m.id)
+                        break
             if not model_id:
                 _ssl_logger.warning("No models available for LLM language detection.")
                 return None
@@ -187,7 +196,7 @@ def search_space_preparation(
             if not detected_code:
                 return None
             if detected_code == "en":
-                return None
+                return {"code": "en", "name": "English"}
 
             name = LANGUAGE_MAP.get(detected_code)
             if not name:
@@ -211,7 +220,7 @@ def search_space_preparation(
             return None
 
         sample = questions[:LANGUAGE_DETECTION_SAMPLE_SIZE]
-        return _detect_language_via_llm(sample, llm_client)
+        return _detect_language_via_llm(sample, llm_client, allowed_generation_models=generation_models)
 
     supported_metrics = ["faithfulness", "answer_correctness", "context_correctness"]
 

--- a/components/training/autorag/search_space_preparation/component.py
+++ b/components/training/autorag/search_space_preparation/component.py
@@ -109,6 +109,107 @@ def search_space_preparation(
     METRIC = "faithfulness"
     SAMPLE_SIZE = 5
     SEED = 17
+    LANGUAGE_DETECTION_SAMPLE_SIZE = 10
+
+    # English-only names: KFP's MySQL backend rejects multi-byte UTF-8 in
+    # PipelineRuntimeManifest, so no non-ASCII literals in component source.
+    LANGUAGE_MAP: dict[str, str] = {
+        "ja": "Japanese",
+        "ko": "Korean",
+        "zh-cn": "Chinese",
+        "zh-tw": "Chinese",
+        "en": "English",
+        "de": "German",
+        "fr": "French",
+        "es": "Spanish",
+        "pt": "Portuguese",
+        "it": "Italian",
+        "ru": "Russian",
+        "ar": "Arabic",
+        "hi": "Hindi",
+        "th": "Thai",
+        "vi": "Vietnamese",
+        "pl": "Polish",
+        "nl": "Dutch",
+        "sv": "Swedish",
+        "cs": "Czech",
+        "tr": "Turkish",
+    }
+
+    def _detect_language_via_llm(questions: list[str], llm_client: OgxClient) -> dict[str, str] | None:
+        """Detect the dominant language by asking an LLM.
+
+        Sends a few sample questions to the first available generation model and asks
+        it to identify the language. Returns a dict with code/name, or None for English.
+        """
+        sample_text = "\n".join(f"- {q}" for q in questions[:5])
+        valid_codes = ", ".join(sorted(LANGUAGE_MAP.keys()))
+
+        try:
+            models_response = llm_client.models.list()
+            models_list = models_response.data if hasattr(models_response, "data") else list(models_response)
+            model_id = None
+            for m in models_list:
+                if hasattr(m, "model_type") and getattr(m, "model_type", "") == "llm":
+                    model_id = m.identifier if hasattr(m, "identifier") else str(m.id)
+                    break
+            if not model_id and models_list:
+                model_id = models_list[0].identifier if hasattr(models_list[0], "identifier") else str(models_list[0].id)
+            if not model_id:
+                _ssl_logger.warning("No models available for LLM language detection.")
+                return None
+
+            response = llm_client.chat.completions.create(
+                model=model_id,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a language detection assistant. "
+                            "Given text samples, respond with ONLY the ISO 639-1 language code "
+                            f"(one of: {valid_codes}). "
+                            "Nothing else — just the code."
+                        ),
+                    },
+                    {
+                        "role": "user",
+                        "content": f"What language are these questions written in?\n{sample_text}",
+                    },
+                ],
+                max_completion_tokens=10,
+                temperature=0.0,
+            )
+            raw = response.choices[0].message.content.strip().lower().replace('"', "").replace("'", "")
+            detected_code = raw.split()[0] if raw else None
+
+            if not detected_code:
+                return None
+            if detected_code == "en":
+                return None
+
+            name = LANGUAGE_MAP.get(detected_code)
+            if not name:
+                _ssl_logger.warning("LLM returned unsupported language code: %s", detected_code)
+                return None
+            _ssl_logger.info("Language detected via LLM: %s (%s)", detected_code, name)
+            return {"code": detected_code, "name": name}
+
+        except Exception as exc:
+            _ssl_logger.warning("LLM language detection failed: %s", exc)
+            return None
+
+    def _detect_benchmark_language(df: pd.DataFrame, llm_client: OgxClient) -> dict[str, str] | None:
+        """Detect the dominant language from benchmark questions.
+
+        Uses LLM via OGX for accurate detection across all languages.
+        Returns a dict with code/name, or None for English / on failure.
+        """
+        questions = df["question"].dropna().astype(str).tolist()
+        if not questions:
+            return None
+
+        sample = questions[:LANGUAGE_DETECTION_SAMPLE_SIZE]
+        return _detect_language_via_llm(sample, llm_client)
 
     supported_metrics = ["faithfulness", "answer_correctness", "context_correctness"]
 
@@ -212,7 +313,9 @@ def search_space_preparation(
 
     search_space = prepare_ai4rag_search_space()
 
-    benchmark_data = BenchmarkData(pd.read_json(Path(test_data.path)))
+    benchmark_df = pd.read_json(Path(test_data.path))
+    detected_language = _detect_benchmark_language(benchmark_df, llm_client=client)
+    benchmark_data = BenchmarkData(benchmark_df)
     documents = load_as_langchain_doc(extracted_text.path)
 
     if (
@@ -248,6 +351,9 @@ def search_space_preparation(
         if k not in ("foundation_model", "embedding_model")
     }
     verbose_search_space_repr |= selected_models_names
+
+    if detected_language:
+        verbose_search_space_repr["detected_language"] = detected_language
 
     with open(search_space_prep_report.path, "w") as report_file:
         yml.safe_dump(verbose_search_space_repr, report_file)

--- a/components/training/autorag/search_space_preparation/component.py
+++ b/components/training/autorag/search_space_preparation/component.py
@@ -154,7 +154,9 @@ def search_space_preparation(
                     model_id = m.identifier if hasattr(m, "identifier") else str(m.id)
                     break
             if not model_id and models_list:
-                model_id = models_list[0].identifier if hasattr(models_list[0], "identifier") else str(models_list[0].id)
+                model_id = (
+                    models_list[0].identifier if hasattr(models_list[0], "identifier") else str(models_list[0].id)
+                )
             if not model_id:
                 _ssl_logger.warning("No models available for LLM language detection.")
                 return None

--- a/components/training/autorag/search_space_preparation/tests/test_component_unit.py
+++ b/components/training/autorag/search_space_preparation/tests/test_component_unit.py
@@ -256,6 +256,143 @@ class TestSearchSpacePreparationUnitTests:
                     )
 
 
+class _SentinelAfterLanguageDetection(Exception):
+    """Raised to abort after language detection completes."""
+
+
+class TestLanguageDetection:
+    """Tests for LLM-based language detection in search_space_preparation."""
+
+    def _make_ogx_with_chat(self, llm_response_text):
+        """Build OGX mock that returns a chat completion with given text."""
+        ogx_mod = _make_ogx_client_module()
+
+        mock_model = mock.MagicMock()
+        mock_model.identifier = "test-llm"
+        mock_model.model_type = "llm"
+
+        mock_models_response = mock.MagicMock()
+        mock_models_response.data = [mock_model]
+
+        mock_choice = mock.MagicMock()
+        mock_choice.message.content = llm_response_text
+        mock_chat_response = mock.MagicMock()
+        mock_chat_response.choices = [mock_choice]
+
+        mock_client = mock.MagicMock()
+        mock_client.models.list.return_value = mock_models_response
+        mock_client.chat.completions.create.return_value = mock_chat_response
+        ogx_mod.OgxClient.return_value = mock_client
+
+        return ogx_mod, mock_client
+
+    def _setup_mocks(self, tmp_path, llm_response_text, ogx_mod=None, mock_client=None):
+        """Set up mocks that let the component flow reach language detection.
+
+        Raises _SentinelAfterLanguageDetection from BenchmarkData (called right after detection).
+        """
+        import json
+
+        mocks = _make_all_mocks()
+
+        mock_pd = mock.MagicMock()
+        import pandas as pd
+
+        mock_pd.read_json = pd.read_json
+        mocks["pandas"] = mock_pd
+
+        if ogx_mod is None:
+            ogx_mod, mock_client = self._make_ogx_with_chat(llm_response_text)
+        mocks["ogx_client"] = ogx_mod
+
+        mocks["ai4rag.core.experiment.benchmark_data"].BenchmarkData.side_effect = _SentinelAfterLanguageDetection
+
+        benchmark = [
+            {"question": "Was ist das?", "correct_answers": [["etwas"]], "correct_answer_document_ids": [["d"]]}
+        ]
+        test_data = tmp_path / "test_data.json"
+        test_data.write_text(json.dumps(benchmark))
+
+        test_data_art = mock.MagicMock(path=str(test_data))
+        extracted_art = mock.MagicMock(path=str(tmp_path / "ext"))
+        report_art = mock.MagicMock(path=str(tmp_path / "report.yml"))
+
+        return mocks, mock_client, test_data_art, extracted_art, report_art
+
+    def _run(self, mocks, test_data_art, extracted_art, report_art, **kwargs):
+        with (
+            mock.patch.dict(sys.modules, mocks),
+            mock.patch.dict(
+                "os.environ", {"OGX_CLIENT_BASE_URL": "https://ogx.example.com", "OGX_CLIENT_API_KEY": "key"}
+            ),
+        ):
+            with pytest.raises(_SentinelAfterLanguageDetection):
+                search_space_preparation.python_func(
+                    test_data=test_data_art,
+                    extracted_text=extracted_art,
+                    search_space_prep_report=report_art,
+                    **kwargs,
+                )
+
+    def test_detects_german(self, tmp_path):
+        """LLM returns 'de' → chat.completions.create is called for detection."""
+        mocks, mock_client, td, ext, rep = self._setup_mocks(tmp_path, "de")
+        self._run(mocks, td, ext, rep)
+        mock_client.chat.completions.create.assert_called_once()
+
+    def test_english_returns_english_dict(self, tmp_path):
+        """LLM returns 'en' → detection completes without error (English is recorded)."""
+        mocks, _, td, ext, rep = self._setup_mocks(tmp_path, "en")
+        self._run(mocks, td, ext, rep)
+
+    def test_unsupported_code_returns_none(self, tmp_path):
+        """LLM returns unsupported code 'fi' → detection completes gracefully."""
+        mocks, _, td, ext, rep = self._setup_mocks(tmp_path, "fi")
+        self._run(mocks, td, ext, rep)
+
+    def test_llm_failure_returns_none(self, tmp_path):
+        """When LLM call fails, detection returns None gracefully."""
+        ogx_mod = _make_ogx_client_module()
+        mock_model = mock.MagicMock()
+        mock_model.identifier = "test-llm"
+        mock_model.model_type = "llm"
+        mock_models_response = mock.MagicMock()
+        mock_models_response.data = [mock_model]
+        mock_client = mock.MagicMock()
+        mock_client.models.list.return_value = mock_models_response
+        mock_client.chat.completions.create.side_effect = RuntimeError("LLM unavailable")
+        ogx_mod.OgxClient.return_value = mock_client
+
+        mocks, _, td, ext, rep = self._setup_mocks(tmp_path, "", ogx_mod=ogx_mod, mock_client=mock_client)
+        self._run(mocks, td, ext, rep)
+
+    def test_prefers_allowed_generation_models(self, tmp_path):
+        """When generation_models is provided, uses that model for detection."""
+        ogx_mod = _make_ogx_client_module()
+        mock_embed = mock.MagicMock()
+        mock_embed.identifier = "embed-model"
+        mock_embed.model_type = "embedding"
+        mock_llm = mock.MagicMock()
+        mock_llm.identifier = "preferred-llm"
+        mock_llm.model_type = "llm"
+        mock_models_response = mock.MagicMock()
+        mock_models_response.data = [mock_embed, mock_llm]
+        mock_choice = mock.MagicMock()
+        mock_choice.message.content = "de"
+        mock_chat_response = mock.MagicMock()
+        mock_chat_response.choices = [mock_choice]
+        mock_client = mock.MagicMock()
+        mock_client.models.list.return_value = mock_models_response
+        mock_client.chat.completions.create.return_value = mock_chat_response
+        ogx_mod.OgxClient.return_value = mock_client
+
+        mocks, _, td, ext, rep = self._setup_mocks(tmp_path, "de", ogx_mod=ogx_mod, mock_client=mock_client)
+        self._run(mocks, td, ext, rep, generation_models=["preferred-llm"])
+
+        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert call_kwargs["model"] == "preferred-llm"
+
+
 class TestSSLFallbackSearchSpacePreparation:
     """Tests for SSL retry logic in _create_ogx_client."""
 

--- a/components/training/autorag/search_space_preparation/tests/test_component_unit.py
+++ b/components/training/autorag/search_space_preparation/tests/test_component_unit.py
@@ -256,12 +256,12 @@ class TestSearchSpacePreparationUnitTests:
                     )
 
 
-class _SentinelAfterLanguageDetection(Exception):
-    """Raised to abort after language detection completes."""
-
-
 class TestLanguageDetection:
-    """Tests for LLM-based language detection in search_space_preparation."""
+    """Tests for LLM-based language detection in search_space_preparation.
+
+    The component runs to completion (writing the YAML report) so we can read
+    back detected_language from the output and assert its value.
+    """
 
     def _make_ogx_with_chat(self, llm_response_text):
         """Build OGX mock that returns a chat completion with given text."""
@@ -286,12 +286,15 @@ class TestLanguageDetection:
 
         return ogx_mod, mock_client
 
-    def _setup_mocks(self, tmp_path, llm_response_text, ogx_mod=None, mock_client=None):
-        """Set up mocks that let the component flow reach language detection.
+    def _setup_and_run(self, tmp_path, llm_response_text, ogx_mod=None, mock_client=None, **run_kwargs):
+        """Run the component to completion and return (detected_language, mock_client).
 
-        Raises _SentinelAfterLanguageDetection from BenchmarkData (called right after detection).
+        Lets prepare_search_space_with_ogx return a minimal mock search space,
+        then the component writes the YAML report. We read it back to get detected_language.
         """
         import json
+
+        import yaml
 
         mocks = _make_all_mocks()
 
@@ -305,7 +308,22 @@ class TestLanguageDetection:
             ogx_mod, mock_client = self._make_ogx_with_chat(llm_response_text)
         mocks["ogx_client"] = ogx_mod
 
-        mocks["ai4rag.core.experiment.benchmark_data"].BenchmarkData.side_effect = _SentinelAfterLanguageDetection
+        mock_search_space = mock.MagicMock()
+        mock_search_space.__getitem__ = mock.MagicMock(return_value=mock.MagicMock(values=[]))
+        mock_search_space._search_space = {}
+        mocks[
+            "ai4rag.search_space.prepare.prepare_search_space"
+        ].prepare_search_space_with_ogx.return_value = mock_search_space
+
+        mock_yaml = mock.MagicMock()
+        captured = {}
+
+        def fake_safe_dump(data, stream):
+            captured.update(data)
+
+        mock_yaml.safe_dump = fake_safe_dump
+        mock_yaml.safe_load = mock.MagicMock(return_value={})
+        mocks["yaml"] = mock_yaml
 
         benchmark = [
             {"question": "Was ist das?", "correct_answers": [["etwas"]], "correct_answer_document_ids": [["d"]]}
@@ -315,43 +333,42 @@ class TestLanguageDetection:
 
         test_data_art = mock.MagicMock(path=str(test_data))
         extracted_art = mock.MagicMock(path=str(tmp_path / "ext"))
-        report_art = mock.MagicMock(path=str(tmp_path / "report.yml"))
+        report_path = tmp_path / "report.yml"
+        report_art = mock.MagicMock(path=str(report_path))
 
-        return mocks, mock_client, test_data_art, extracted_art, report_art
-
-    def _run(self, mocks, test_data_art, extracted_art, report_art, **kwargs):
         with (
             mock.patch.dict(sys.modules, mocks),
             mock.patch.dict(
                 "os.environ", {"OGX_CLIENT_BASE_URL": "https://ogx.example.com", "OGX_CLIENT_API_KEY": "key"}
             ),
         ):
-            with pytest.raises(_SentinelAfterLanguageDetection):
-                search_space_preparation.python_func(
-                    test_data=test_data_art,
-                    extracted_text=extracted_art,
-                    search_space_prep_report=report_art,
-                    **kwargs,
-                )
+            search_space_preparation.python_func(
+                test_data=test_data_art,
+                extracted_text=extracted_art,
+                search_space_prep_report=report_art,
+                **run_kwargs,
+            )
+
+        return captured.get("detected_language"), mock_client
 
     def test_detects_german(self, tmp_path):
-        """LLM returns 'de' → chat.completions.create is called for detection."""
-        mocks, mock_client, td, ext, rep = self._setup_mocks(tmp_path, "de")
-        self._run(mocks, td, ext, rep)
+        """LLM returns 'de' → detected_language is {code: de, name: German}."""
+        detected, mock_client = self._setup_and_run(tmp_path, "de")
+        assert detected == {"code": "de", "name": "German"}
         mock_client.chat.completions.create.assert_called_once()
 
     def test_english_returns_english_dict(self, tmp_path):
-        """LLM returns 'en' → detection completes without error (English is recorded)."""
-        mocks, _, td, ext, rep = self._setup_mocks(tmp_path, "en")
-        self._run(mocks, td, ext, rep)
+        """LLM returns 'en' → detected_language is {code: en, name: English}."""
+        detected, _ = self._setup_and_run(tmp_path, "en")
+        assert detected == {"code": "en", "name": "English"}
 
     def test_unsupported_code_returns_none(self, tmp_path):
-        """LLM returns unsupported code 'fi' → detection completes gracefully."""
-        mocks, _, td, ext, rep = self._setup_mocks(tmp_path, "fi")
-        self._run(mocks, td, ext, rep)
+        """LLM returns unsupported code 'fi' → detected_language is None (not written)."""
+        detected, _ = self._setup_and_run(tmp_path, "fi")
+        assert detected is None
 
     def test_llm_failure_returns_none(self, tmp_path):
-        """When LLM call fails, detection returns None gracefully."""
+        """When LLM call fails, detected_language is None."""
         ogx_mod = _make_ogx_client_module()
         mock_model = mock.MagicMock()
         mock_model.identifier = "test-llm"
@@ -363,8 +380,8 @@ class TestLanguageDetection:
         mock_client.chat.completions.create.side_effect = RuntimeError("LLM unavailable")
         ogx_mod.OgxClient.return_value = mock_client
 
-        mocks, _, td, ext, rep = self._setup_mocks(tmp_path, "", ogx_mod=ogx_mod, mock_client=mock_client)
-        self._run(mocks, td, ext, rep)
+        detected, _ = self._setup_and_run(tmp_path, "", ogx_mod=ogx_mod, mock_client=mock_client)
+        assert detected is None
 
     def test_prefers_allowed_generation_models(self, tmp_path):
         """When generation_models is provided, uses that model for detection."""
@@ -386,9 +403,10 @@ class TestLanguageDetection:
         mock_client.chat.completions.create.return_value = mock_chat_response
         ogx_mod.OgxClient.return_value = mock_client
 
-        mocks, _, td, ext, rep = self._setup_mocks(tmp_path, "de", ogx_mod=ogx_mod, mock_client=mock_client)
-        self._run(mocks, td, ext, rep, generation_models=["preferred-llm"])
-
+        detected, _ = self._setup_and_run(
+            tmp_path, "de", ogx_mod=ogx_mod, mock_client=mock_client, generation_models=["preferred-llm"]
+        )
+        assert detected == {"code": "de", "name": "German"}
         call_kwargs = mock_client.chat.completions.create.call_args.kwargs
         assert call_kwargs["model"] == "preferred-llm"
 

--- a/components/training/autorag/search_space_preparation/tests/test_component_unit.py
+++ b/components/training/autorag/search_space_preparation/tests/test_component_unit.py
@@ -292,16 +292,16 @@ class TestLanguageDetection:
         Lets prepare_search_space_with_ogx return a minimal mock search space,
         then the component writes the YAML report. We read it back to get detected_language.
         """
-        import json
-
-        import yaml
+        import pandas as pd
 
         mocks = _make_all_mocks()
 
+        benchmark_df = pd.DataFrame(
+            [{"question": "Was ist das?", "correct_answers": [["etwas"]], "correct_answer_document_ids": [["d"]]}]
+        )
         mock_pd = mock.MagicMock()
-        import pandas as pd
-
-        mock_pd.read_json = pd.read_json
+        mock_pd.read_json.return_value = benchmark_df
+        mock_pd.DataFrame = pd.DataFrame
         mocks["pandas"] = mock_pd
 
         if ogx_mod is None:
@@ -325,13 +325,7 @@ class TestLanguageDetection:
         mock_yaml.safe_load = mock.MagicMock(return_value={})
         mocks["yaml"] = mock_yaml
 
-        benchmark = [
-            {"question": "Was ist das?", "correct_answers": [["etwas"]], "correct_answer_document_ids": [["d"]]}
-        ]
-        test_data = tmp_path / "test_data.json"
-        test_data.write_text(json.dumps(benchmark))
-
-        test_data_art = mock.MagicMock(path=str(test_data))
+        test_data_art = mock.MagicMock(path=str(tmp_path / "test_data.json"))
         extracted_art = mock.MagicMock(path=str(tmp_path / "ext"))
         report_path = tmp_path / "report.yml"
         report_art = mock.MagicMock(path=str(report_path))


### PR DESCRIPTION
**Description of your changes:**

## Summary

  Adds automatic language detection to the AutoRAG optimization pipeline so that non-English benchmarks receive explicit language instructions (e.g. `"You MUST
  respond in German."`) in both the system and user prompts, replacing the generic `"Respond exclusively in the language of the question"` which models frequently
  ignore.
  
  ### Changes by component

  **`search_space_preparation`**
  - Adds LLM-based language detection via OGX: sends 5 sample benchmark questions to the first available generation model and asks for the ISO 639-1 code
  - Supports 20 languages (Japanese, Korean, Chinese, German, French, Spanish, etc.)
  - Writes `detected_language: {code, name}` to the search space YAML report

  **`rag_templates_optimization`**
  - Reads `detected_language` from the search space report
  - When present, sets explicit `system_message_text` and `user_message_text` on all foundation model instances before creating the experiment
  - Adds `_build_system_message()` with dedup guard to prevent double-prepending the language instruction in `pattern.json`
  - Stores `detected_language` in `pattern.json` at `settings.generation.detected_language`

  **`build_responses_request_bodies`**
  - Adds `_explicit_language_instruction()` to build instructions from `detected_language` metadata in `pattern.json`
  - Updates `_compose_instructions()` to prefer explicit language instruction over generic hint, with dedup guard when system message already contains the 
  instruction

  ### Tests

  - `test_detected_language_produces_explicit_instruction` — explicit instruction appears when `detected_language` is set
  - `test_no_detected_language_falls_back_to_generic` — generic hint used without detection
  - `test_detected_language_instruction_not_duplicated` — instruction appears exactly once when system message already contains it
  - `test_detected_language_sets_prompts_on_foundation_models` — German detected → prompts updated on all models
  - `test_no_detected_language_preserves_defaults` — no language → prompts untouched
  - `test_detected_language_popped_before_search_space_construction` — `detected_language` not leaked as a search space parameter

**Checklist:**

### Pre-Submission Checklist

- [ ] All tests and CI checks pass
- [ ] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic language detection for questions/benchmarks; detected non-English languages add an explicit “You MUST respond in <language>.” instruction where appropriate, avoiding duplication and preferring this explicit hint over generic fallbacks. English detection does not add the explicit directive.
  * Detection is applied to RAG prompt generation and emitted configuration when available.

* **Tests**
  * Added tests covering detected-language behavior, fallbacks, non-duplication, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->