### PR TITLE
chore[AutoML]: improve kfp compoennts installation and add kfp-kubernetes 

### DIFF
--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
@@ -7,7 +7,8 @@ COPY pyproject.toml __init__.py /tmp/kfp-src/
 COPY components/ /tmp/kfp-src/components/
 COPY pipelines/ /tmp/kfp-src/pipelines/
 COPY utils/ /tmp/kfp-src/utils/
-RUN pip wheel --no-deps --index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple -w /tmp/dist /tmp/kfp-src/
+RUN pip install --no-cache-dir setuptools && \
+    pip wheel --no-deps --no-build-isolation --index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple -w /tmp/dist /tmp/kfp-src/
 
 FROM ${BASE_IMAGE}
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
@@ -8,7 +8,7 @@ COPY components/ /tmp/kfp-src/components/
 COPY pipelines/ /tmp/kfp-src/pipelines/
 COPY utils/ /tmp/kfp-src/utils/
 RUN pip install --no-cache-dir --index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple setuptools==80.10.2 && \
-    pip wheel --no-deps --no-build-isolation --index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple -w /tmp/dist /tmp/kfp-src/
+    pip wheel --no-deps --no-build-isolation -w /tmp/dist /tmp/kfp-src/
 
 FROM ${BASE_IMAGE}
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
@@ -7,7 +7,7 @@ COPY pyproject.toml __init__.py /tmp/kfp-src/
 COPY components/ /tmp/kfp-src/components/
 COPY pipelines/ /tmp/kfp-src/pipelines/
 COPY utils/ /tmp/kfp-src/utils/
-RUN pip install --no-cache-dir setuptools && \
+RUN pip install --no-cache-dir --index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple setuptools==80.10.2 && \
     pip wheel --no-deps --no-build-isolation --index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.4/cpu-ubi9/simple -w /tmp/dist /tmp/kfp-src/
 
 FROM ${BASE_IMAGE}

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
@@ -84,6 +84,7 @@ joblib==1.5.3
 kfp==2.16.1
 kfp-pipeline-spec==2.16.1
 kfp-server-api==2.16.1
+kfp-kubernetes==2.16.1
 kiwisolver==1.5.0
 kubernetes==35.0.0
 lightgbm==4.6.0


### PR DESCRIPTION
**Description of your changes:**

Align Containerfile with https://github.com/red-hat-data-services/pipelines-components/blob/main/Dockerfile.konflux.automl and add kfp-kubernetes since it is a kfp-components dependency.

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies and process for the AutoGluon tabular training pipeline.
  * Added `kfp-kubernetes` version 2.16.1 as a required dependency for the training pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->