### PR TITLE
chore: add efazal to OWNERS for finetuning, model registry, and dataset download

### DIFF
--- a/components/data_processing/dataset_download/OWNERS
+++ b/components/data_processing/dataset_download/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/components/data_processing/dataset_download/README.md
+++ b/components/data_processing/dataset_download/README.md
@@ -40,6 +40,7 @@ Validates that datasets follow chat template format (messages/conversations with
 - **Owners**:
   - Approvers:
     - briangallagher
+    - efazal
     - Fiona-Waters
     - kramaranya
     - MStokluska

--- a/components/deployment/kubeflow_model_registry/OWNERS
+++ b/components/deployment/kubeflow_model_registry/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/components/deployment/kubeflow_model_registry/README.md
+++ b/components/deployment/kubeflow_model_registry/README.md
@@ -55,6 +55,7 @@ Uses the upstream model artifact (input_model) produced by training, or falls ba
 - **Owners**:
   - Approvers:
     - briangallagher
+    - efazal
     - Fiona-Waters
     - kramaranya
     - MStokluska

--- a/components/evaluation/evalhub/OWNERS
+++ b/components/evaluation/evalhub/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/components/evaluation/evalhub/kserve/OWNERS
+++ b/components/evaluation/evalhub/kserve/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/components/evaluation/evalhub/kserve/README.md
+++ b/components/evaluation/evalhub/kserve/README.md
@@ -60,6 +60,7 @@ Creates a KServe ServingRuntime + InferenceService (matching the RHOAI dashboard
 - **Owners**:
   - Approvers:
     - briangallagher
+    - efazal
     - Fiona-Waters
     - kramaranya
     - MStokluska

--- a/components/training/finetuning/OWNERS
+++ b/components/training/finetuning/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/pipelines/training/finetuning/OWNERS
+++ b/pipelines/training/finetuning/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/pipelines/training/finetuning_evalhub/OWNERS
+++ b/pipelines/training/finetuning_evalhub/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/pipelines/training/finetuning_evalhub/lora/OWNERS
+++ b/pipelines/training/finetuning_evalhub/lora/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/pipelines/training/finetuning_evalhub/lora/README.md
+++ b/pipelines/training/finetuning_evalhub/lora/README.md
@@ -114,6 +114,7 @@ The base_model_name parameter is needed for tokenizer resolution since the serve
 - **Owners**:
   - Approvers:
     - briangallagher
+    - efazal
     - Fiona-Waters
     - kramaranya
     - MStokluska

--- a/pipelines/training/finetuning_evalhub/lora_minimal/OWNERS
+++ b/pipelines/training/finetuning_evalhub/lora_minimal/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/pipelines/training/finetuning_evalhub/lora_minimal/README.md
+++ b/pipelines/training/finetuning_evalhub/lora_minimal/README.md
@@ -70,6 +70,7 @@ Prerequisites: Eval Hub and KServe must be installed on the cluster. The pipelin
 - **Owners**:
   - Approvers:
     - briangallagher
+    - efazal
     - Fiona-Waters
     - kramaranya
     - MStokluska

--- a/pipelines/training/finetuning_evalhub/osft/OWNERS
+++ b/pipelines/training/finetuning_evalhub/osft/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/pipelines/training/finetuning_evalhub/osft/README.md
+++ b/pipelines/training/finetuning_evalhub/osft/README.md
@@ -91,6 +91,7 @@ The base_model_name parameter is needed for tokenizer resolution since the serve
 - **Owners**:
   - Approvers:
     - briangallagher
+    - efazal
     - Fiona-Waters
     - kramaranya
     - MStokluska

--- a/pipelines/training/finetuning_evalhub/osft_minimal/OWNERS
+++ b/pipelines/training/finetuning_evalhub/osft_minimal/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/pipelines/training/finetuning_evalhub/osft_minimal/README.md
+++ b/pipelines/training/finetuning_evalhub/osft_minimal/README.md
@@ -68,6 +68,7 @@ Prerequisites: Eval Hub and KServe must be installed on the cluster. The pipelin
 - **Owners**:
   - Approvers:
     - briangallagher
+    - efazal
     - Fiona-Waters
     - kramaranya
     - MStokluska

--- a/pipelines/training/finetuning_evalhub/sft/OWNERS
+++ b/pipelines/training/finetuning_evalhub/sft/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/pipelines/training/finetuning_evalhub/sft/README.md
+++ b/pipelines/training/finetuning_evalhub/sft/README.md
@@ -88,6 +88,7 @@ The base_model_name parameter is needed for tokenizer resolution since the serve
 - **Owners**:
   - Approvers:
     - briangallagher
+    - efazal
     - Fiona-Waters
     - kramaranya
     - MStokluska

--- a/pipelines/training/finetuning_evalhub/sft_minimal/OWNERS
+++ b/pipelines/training/finetuning_evalhub/sft_minimal/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - briangallagher
+  - efazal
   - Fiona-Waters
   - kramaranya
   - MStokluska

--- a/pipelines/training/finetuning_evalhub/sft_minimal/README.md
+++ b/pipelines/training/finetuning_evalhub/sft_minimal/README.md
@@ -66,6 +66,7 @@ Prerequisites: Eval Hub and KServe must be installed on the cluster. The pipelin
 - **Owners**:
   - Approvers:
     - briangallagher
+    - efazal
     - Fiona-Waters
     - kramaranya
     - MStokluska


### PR DESCRIPTION
## Summary
Grants owner/approver access to @efazal for the following directories:
- `components/training/finetuning`
- `components/deployment/kubeflow_model_registry`
- `pipelines/training/finetuning`
- `components/data_processing/dataset_download`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new approver entry across multiple component and pipeline owner lists.
  * Updated corresponding Owners/Approvers sections in related README files to reflect the new approver.
  * No functional code or public API changes; metadata/ownership updates only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->