### PR TITLE
fix: cleanup and improve initial pipeline components (RHOAIENG-52443)

### DIFF
--- a/components/evaluation/lm_eval/component.py
+++ b/components/evaluation/lm_eval/component.py
@@ -79,11 +79,10 @@ def universal_llm_evaluator(
     import torch
 
     # Delayed imports for lm-eval
-    from lm_eval import tasks
     from lm_eval.api.instance import Instance
     from lm_eval.api.metrics import mean
     from lm_eval.api.registry import get_model
-    from lm_eval.api.task import TaskConfig
+    from lm_eval.api.task import Task, TaskConfig
     from lm_eval.evaluator import evaluate
     from lm_eval.tasks import get_task_dict
 
@@ -167,7 +166,7 @@ def universal_llm_evaluator(
     # =========================================================================
     # Custom Chat Holdout Task
     # =========================================================================
-    class ChatHoldoutTask(tasks.Task):
+    class ChatHoldoutTask(Task):
         """A custom lm-eval task for evaluating on chat-format holdout data."""
 
         VERSION = 0
@@ -300,13 +299,12 @@ def universal_llm_evaluator(
                             "prediction": prediction,
                         }
                     )
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"Failed to log prompt for doc: {e}")
 
             exact_match = 1.0 if prediction.lower() == target.lower() else 0.0
 
-            target_start = target.lower()[:50] if len(target) > 50 else target.lower()
-            contains_match = 1.0 if target_start in prediction.lower() else 0.0
+            contains_match = 1.0 if target and target.lower() in prediction.lower() else 0.0
 
             try:
                 bleu = sacrebleu.sentence_bleu(prediction, [target]).score / 100.0

--- a/components/training/finetuning/README.md
+++ b/components/training/finetuning/README.md
@@ -3,5 +3,5 @@
 This subcategory contains components in the **Finetuning** group:
 
 - [Lora](./lora/README.md): Train model using LoRA (Low-Rank Adaptation). Outputs model artifact and metrics.
-- [Osft](./osft/README.md): Train model using OSFT (Orthogonal Subspace Fine-Tuning). Outputs model artifact and metrics.
-- [Sft](./sft/README.md): Train model using SFT (Supervised Fine-Tuning). Outputs model artifact and metrics.
+- [Osft](./osft/README.md): Train using OSFT (Orthogonal Subspace Fine-Tuning).
+- [Sft](./sft/README.md): Train using SFT (Supervised Fine-Tuning).

--- a/components/training/finetuning/lora/tests/test_component_unit.py
+++ b/components/training/finetuning/lora/tests/test_component_unit.py
@@ -146,10 +146,8 @@ class TestLoRAComponentUnitTests:
         """Test that the component docstring describes LoRA training."""
         docstring = train_model.python_func.__doc__
 
-        # Should mention LoRA
         assert "LoRA" in docstring or "Low-Rank Adaptation" in docstring
-        # Should NOT mention SFT or OSFT
-        assert "SFT" not in docstring or "Supervised Fine-Tuning" not in docstring
+        assert "SFT" not in docstring
         assert "OSFT" not in docstring
 
     @mock.patch.dict("sys.modules", {"kubeflow.trainer": mock.MagicMock()})

--- a/components/training/finetuning/osft/README.md
+++ b/components/training/finetuning/osft/README.md
@@ -4,7 +4,9 @@
 
 ## Overview 🧾
 
-Train model using OSFT (Orthogonal Subspace Fine-Tuning). Outputs model artifact and metrics.
+Train using OSFT (Orthogonal Subspace Fine-Tuning).
+
+Uses mini-trainer backend. Outputs model artifact and metrics.
 
 ## Inputs 📥
 

--- a/components/training/finetuning/osft/component.py
+++ b/components/training/finetuning/osft/component.py
@@ -71,7 +71,9 @@ def train_model(
     training_runtime: str = "training-hub",
     kubernetes_config: dsl.TaskConfig = None,
 ) -> str:
-    """Train model using OSFT (Orthogonal Subspace Fine-Tuning). Uses mini-trainer backend. Outputs model artifact and metrics.
+    """Train using OSFT (Orthogonal Subspace Fine-Tuning).
+
+    Uses mini-trainer backend. Outputs model artifact and metrics.
 
     Args:
         pvc_path: Workspace PVC root path (use dsl.WORKSPACE_PATH_PLACEHOLDER).

--- a/components/training/finetuning/osft/component.py
+++ b/components/training/finetuning/osft/component.py
@@ -71,7 +71,7 @@ def train_model(
     training_runtime: str = "training-hub",
     kubernetes_config: dsl.TaskConfig = None,
 ) -> str:
-    """Train model using OSFT (Orthogonal Subspace Fine-Tuning). Outputs model artifact and metrics.
+    """Train model using OSFT (Orthogonal Subspace Fine-Tuning). Uses mini-trainer backend. Outputs model artifact and metrics.
 
     Args:
         pvc_path: Workspace PVC root path (use dsl.WORKSPACE_PATH_PLACEHOLDER).

--- a/components/training/finetuning/osft/tests/test_component_unit.py
+++ b/components/training/finetuning/osft/tests/test_component_unit.py
@@ -116,12 +116,9 @@ class TestOSFTComponentUnitTests:
         """Test that the component docstring describes OSFT training."""
         docstring = train_model.python_func.__doc__
 
-        # Should mention OSFT
         assert "OSFT" in docstring or "Orthogonal Subspace" in docstring
-        # Should NOT mention SFT or instructlab
-        assert "SFT" not in docstring or "OSFT" in docstring  # Allow OSFT mention
-        # Should mention mini-trainer backend
-        assert "mini-trainer" not in docstring or True  # Backend is hardcoded in implementation
+        assert "SFT" not in docstring.replace("OSFT", "")
+        assert "mini-trainer" in docstring
 
     @mock.patch.dict("sys.modules", {"kubeflow.trainer": mock.MagicMock()})
     def test_component_with_mocked_trainer(self):

--- a/components/training/finetuning/sft/README.md
+++ b/components/training/finetuning/sft/README.md
@@ -4,7 +4,9 @@
 
 ## Overview 🧾
 
-Train model using SFT (Supervised Fine-Tuning). Outputs model artifact and metrics.
+Train using SFT (Supervised Fine-Tuning).
+
+Uses instructlab-training backend. Outputs model artifact and metrics.
 
 ## Inputs 📥
 

--- a/components/training/finetuning/sft/component.py
+++ b/components/training/finetuning/sft/component.py
@@ -66,7 +66,9 @@ def train_model(
     training_runtime: str = "training-hub",
     kubernetes_config: dsl.TaskConfig = None,
 ) -> str:
-    """Train model using SFT (Supervised Fine-Tuning). Uses instructlab-training backend. Outputs model artifact and metrics.
+    """Train using SFT (Supervised Fine-Tuning).
+
+    Uses instructlab-training backend. Outputs model artifact and metrics.
 
     Args:
         pvc_path: Workspace PVC root path (use dsl.WORKSPACE_PATH_PLACEHOLDER).

--- a/components/training/finetuning/sft/component.py
+++ b/components/training/finetuning/sft/component.py
@@ -66,7 +66,7 @@ def train_model(
     training_runtime: str = "training-hub",
     kubernetes_config: dsl.TaskConfig = None,
 ) -> str:
-    """Train model using SFT (Supervised Fine-Tuning). Outputs model artifact and metrics.
+    """Train model using SFT (Supervised Fine-Tuning). Uses instructlab-training backend. Outputs model artifact and metrics.
 
     Args:
         pvc_path: Workspace PVC root path (use dsl.WORKSPACE_PATH_PLACEHOLDER).

--- a/components/training/finetuning/sft/tests/test_component_unit.py
+++ b/components/training/finetuning/sft/tests/test_component_unit.py
@@ -120,7 +120,7 @@ class TestSFTComponentUnitTests:
         # Should NOT mention OSFT
         assert "OSFT" not in docstring
         # Should mention instructlab-training backend
-        assert "instructlab" not in docstring or True  # Backend is hardcoded in implementation
+        assert "instructlab" in docstring  # Backend is hardcoded in implementation
 
     @mock.patch.dict("sys.modules", {"kubeflow.trainer": mock.MagicMock()})
     def test_component_with_mocked_trainer(self):

--- a/components/training/finetuning/shared/data.py
+++ b/components/training/finetuning/shared/data.py
@@ -130,6 +130,7 @@ def _skopeo_copy(ref: str, dest: str, auth: Optional[str], log: logging.Logger) 
         if af:
             os.unlink(af)
 
+
 def _extract_tar(img_dir: str, out: str, log: logging.Logger) -> List[str]:
     """Extract model files from OCI image layers.
 

--- a/components/training/finetuning/shared/data.py
+++ b/components/training/finetuning/shared/data.py
@@ -5,6 +5,7 @@ import logging
 import os
 import shutil
 import subprocess
+import tempfile
 from typing import List, Optional
 
 
@@ -111,19 +112,23 @@ def _skopeo_copy(ref: str, dest: str, auth: Optional[str], log: logging.Logger) 
     os.makedirs(dest, exist_ok=True)
     af = None
     if auth:
-        af = "/tmp/skopeo-auth.json"
-        with open(af, "w") as f:
-            f.write(auth)
-    cmd = ["skopeo", "copy"]
-    if af:
-        cmd.extend(["--authfile", af])
-    cmd.extend([f"docker://{ref}", f"dir:{dest}"])
-    log.info(f"Run: {' '.join(cmd)}")
-    r = subprocess.run(cmd, text=True, capture_output=True)
-    if r.returncode != 0:
-        log.error(f"skopeo fail: {r.stderr}")
-        r.check_returncode()
-
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+            os.chmod(tmp.name, 0o600)
+            tmp.write(auth)
+            af = tmp.name
+    try:
+        cmd = ["skopeo", "copy"]
+        if af:
+            cmd.extend(["--authfile", af])
+        cmd.extend([f"docker://{ref}", f"dir:{dest}"])
+        log.info(f"Run: {' '.join(cmd)}")
+        r = subprocess.run(cmd, text=True, capture_output=True)
+        if r.returncode != 0:
+            log.error(f"skopeo fail: {r.stderr}")
+            r.check_returncode()
+    finally:
+        if af:
+            os.unlink(af)
 
 def _extract_tar(img_dir: str, out: str, log: logging.Logger) -> List[str]:
     """Extract model files from OCI image layers.

--- a/components/training/finetuning/shared/output.py
+++ b/components/training/finetuning/shared/output.py
@@ -6,6 +6,8 @@ import os
 import shutil
 from typing import Dict, List, Optional
 
+log = logging.getLogger(__name__)
+
 
 def find_model_dir(root: str) -> Optional[str]:
     """Find the most recent model checkpoint directory.
@@ -113,8 +115,8 @@ def extract_metrics_from_jsonl(metrics_file: str) -> tuple[Dict, List[float]]:
                             loss.append(float(lv))
                         except (ValueError, TypeError):
                             pass
-                except Exception:
-                    pass
+                except Exception as e:
+                    log.warning(f"Failed to parse metrics line: {e}")
     if loss:
         met["final_loss"], met["min_loss"] = loss[-1], min(loss)
         met["final_perplexity"] = __import__("math").exp(min(loss[-1], 10))

--- a/components/training/finetuning/shared/setup.py
+++ b/components/training/finetuning/shared/setup.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import sys
-import tempfile
 from typing import Dict, Optional
 
 

--- a/components/training/finetuning/shared/setup.py
+++ b/components/training/finetuning/shared/setup.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import sys
+import tempfile
 from typing import Dict, Optional
 
 

--- a/components/training/finetuning/shared/tests/test_data.py
+++ b/components/training/finetuning/shared/tests/test_data.py
@@ -149,6 +149,7 @@ class TestFindHfModel:
     """Tests for _find_hf_model."""
 
     def test_finds_valid_hf_model_dir(self, tmp_path):
+        """Directory with config.json, weights, and tokenizer is found."""
         model_dir = tmp_path / "models" / "my_model"
         model_dir.mkdir(parents=True)
         (model_dir / "config.json").write_text("{}")
@@ -159,15 +160,16 @@ class TestFindHfModel:
         assert result == str(model_dir)
 
     def test_returns_none_when_no_model(self, tmp_path):
+        """Returns None when no HF model structure exists."""
         (tmp_path / "random.txt").write_text("nothing")
         assert _find_hf_model(str(tmp_path)) is None
 
     def test_requires_config_and_weights_and_tokenizer(self, tmp_path):
+        """Returns None when tokenizer is missing."""
         model_dir = tmp_path / "model"
         model_dir.mkdir()
         (model_dir / "config.json").write_text("{}")
         (model_dir / "model.safetensors").write_bytes(b"")
-        # Missing tokenizer
         assert _find_hf_model(str(tmp_path)) is None
 
 
@@ -175,26 +177,31 @@ class TestGetOciAuth:
     """Tests for _get_oci_auth."""
 
     def test_returns_none_when_unset(self, log):
+        """Returns None when env var is not set."""
         with mock.patch.dict(os.environ, {}, clear=True):
             assert _get_oci_auth(log) is None
 
     def test_returns_raw_json_when_valid(self, log):
+        """Returns raw JSON string when valid Docker config is provided."""
         auth = json.dumps({"auths": {"registry.io": {"auth": "abc"}}})
         with mock.patch.dict(os.environ, {"OCI_PULL_SECRET_MODEL_DOWNLOAD": auth}):
             result = _get_oci_auth(log)
         assert result == auth
 
     def test_raises_on_invalid_json(self, log):
+        """Raises ValueError for non-JSON content."""
         with mock.patch.dict(os.environ, {"OCI_PULL_SECRET_MODEL_DOWNLOAD": "not-json"}):
             with pytest.raises(ValueError, match="not valid JSON"):
                 _get_oci_auth(log)
 
     def test_raises_on_missing_auths(self, log):
+        """Raises ValueError when 'auths' key is absent."""
         with mock.patch.dict(os.environ, {"OCI_PULL_SECRET_MODEL_DOWNLOAD": "{}"}):
             with pytest.raises(ValueError, match="non-empty 'auths' field"):
                 _get_oci_auth(log)
 
     def test_raises_on_empty_auths(self, log):
+        """Raises ValueError when 'auths' dict is empty."""
         auth = json.dumps({"auths": {}})
         with mock.patch.dict(os.environ, {"OCI_PULL_SECRET_MODEL_DOWNLOAD": auth}):
             with pytest.raises(ValueError, match="non-empty 'auths' field"):
@@ -205,6 +212,7 @@ class TestSkopeoCopy:
     """Tests for _skopeo_copy."""
 
     def test_runs_skopeo_without_auth(self, log, tmp_path):
+        """Skopeo is invoked without --authfile when no auth is provided."""
         dest = str(tmp_path / "dest")
         with mock.patch("subprocess.run") as mock_run:
             mock_run.return_value = mock.MagicMock(returncode=0)
@@ -212,9 +220,10 @@ class TestSkopeoCopy:
         args = mock_run.call_args[0][0]
         assert args[:2] == ["skopeo", "copy"]
         assert "--authfile" not in args
-        assert f"docker://registry.io/model:latest" in args
+        assert "docker://registry.io/model:latest" in args
 
     def test_runs_skopeo_with_auth(self, log, tmp_path):
+        """Skopeo is invoked with --authfile when auth is provided."""
         dest = str(tmp_path / "dest")
         with mock.patch("subprocess.run") as mock_run:
             mock_run.return_value = mock.MagicMock(returncode=0)
@@ -223,6 +232,7 @@ class TestSkopeoCopy:
         assert "--authfile" in args
 
     def test_raises_on_failure(self, log, tmp_path):
+        """RuntimeError is raised when skopeo exits with non-zero code."""
         dest = str(tmp_path / "dest")
         with mock.patch("subprocess.run") as mock_run:
             proc = mock.MagicMock(returncode=1, stderr="pull denied")
@@ -232,6 +242,7 @@ class TestSkopeoCopy:
                 _skopeo_copy("registry.io/model:latest", dest, None, log)
 
     def test_cleans_up_authfile(self, log, tmp_path):
+        """Temporary auth file is cleaned up after skopeo run."""
         dest = str(tmp_path / "dest")
         created_files = []
 
@@ -261,6 +272,7 @@ class TestResolveDataset:
     """Tests for resolve_dataset."""
 
     def test_existing_dir_is_reused(self, log, tmp_path, mock_datasets):
+        """Non-empty output directory is reused without re-downloading."""
         out_dir = tmp_path / "ds"
         out_dir.mkdir()
         (out_dir / "data.jsonl").write_text("{}")
@@ -269,6 +281,7 @@ class TestResolveDataset:
         assert (out_dir / "data.jsonl").exists()
 
     def test_artifact_dir_is_copied(self, log, tmp_path, mock_datasets):
+        """Artifact directory is copied to the output directory."""
         src_dir = tmp_path / "src"
         src_dir.mkdir()
         (src_dir / "train.jsonl").write_text('{"text":"hello"}')
@@ -282,6 +295,7 @@ class TestResolveDataset:
         assert (out_dir / "train.jsonl").read_text() == '{"text":"hello"}'
 
     def test_artifact_file_is_copied(self, log, tmp_path, mock_datasets):
+        """Artifact file is copied to the output directory."""
         src_file = tmp_path / "data.jsonl"
         src_file.write_text('{"text":"hello"}')
         out_dir = tmp_path / "out"
@@ -294,6 +308,7 @@ class TestResolveDataset:
         assert (out_dir / "data.jsonl").read_text() == '{"text":"hello"}'
 
     def test_artifact_file_without_extension_gets_default_name(self, log, tmp_path, mock_datasets):
+        """File without extension is renamed to train.jsonl."""
         src_file = tmp_path / "mydata"
         src_file.write_text('{"text":"data"}')
         out_dir = tmp_path / "out"
@@ -306,6 +321,7 @@ class TestResolveDataset:
         assert (out_dir / "train.jsonl").exists()
 
     def test_pvc_metadata_dir_is_copied(self, log, tmp_path, mock_datasets):
+        """PVC directory from metadata is copied to the output directory."""
         pvc_dir = tmp_path / "pvc_ds"
         pvc_dir.mkdir()
         (pvc_dir / "train.jsonl").write_text('{"text":"pvc"}')
@@ -320,6 +336,7 @@ class TestResolveDataset:
         assert (out_dir / "train.jsonl").read_text() == '{"text":"pvc"}'
 
     def test_remote_json_loads_via_hf_datasets(self, log, tmp_path, mock_datasets):
+        """Remote JSONL URL is loaded via HuggingFace datasets."""
         out_dir = tmp_path / "out"
         out_dir.mkdir()
 
@@ -337,6 +354,7 @@ class TestResolveDataset:
         mock_ds.save_to_disk.assert_called_once_with(str(out_dir))
 
     def test_hf_repo_id_loads_via_hf_datasets(self, log, tmp_path, mock_datasets):
+        """HuggingFace repo ID is loaded via datasets library."""
         out_dir = tmp_path / "out"
         out_dir.mkdir()
 
@@ -351,6 +369,7 @@ class TestResolveDataset:
         mock_datasets.load_dataset.assert_called_once_with("tatsu-lab/alpaca", split="train")
 
     def test_no_source_raises_value_error(self, log, tmp_path, mock_datasets):
+        """ValueError is raised when no dataset source is resolvable."""
         out_dir = tmp_path / "out"
         out_dir.mkdir()
 
@@ -362,6 +381,7 @@ class TestPrepareJsonl:
     """Tests for prepare_jsonl."""
 
     def test_exports_dataset_to_jsonl(self, log, tmp_path, mock_datasets):
+        """Dataset is exported to JSONL via to_json."""
         ds_dir = str(tmp_path / "ds")
         jsonl_path = str(tmp_path / "out.jsonl")
 
@@ -374,6 +394,7 @@ class TestPrepareJsonl:
         mock_ds.to_json.assert_called_once_with(jsonl_path, lines=True)
 
     def test_falls_back_to_manual_write_on_attribute_error(self, log, tmp_path, mock_datasets):
+        """Falls back to manual JSONL write when to_json raises AttributeError."""
         ds_dir = str(tmp_path / "ds")
         jsonl_path = str(tmp_path / "out.jsonl")
 
@@ -386,11 +407,13 @@ class TestPrepareJsonl:
 
         prepare_jsonl(ds_dir, jsonl_path, log)
 
-        lines = open(jsonl_path).readlines()
+        with open(jsonl_path) as f:
+            lines = f.readlines()
         assert len(lines) == 2
         assert json.loads(lines[0]) == {"text": "a"}
 
     def test_handles_dict_dataset_with_train_split(self, log, tmp_path, mock_datasets):
+        """Dict-type dataset with 'train' split is handled correctly."""
         ds_dir = str(tmp_path / "ds")
         jsonl_path = str(tmp_path / "out.jsonl")
 
@@ -401,6 +424,7 @@ class TestPrepareJsonl:
         train_split.to_json.assert_called_once_with(jsonl_path, lines=True)
 
     def test_logs_warning_on_failure(self, log, tmp_path, mock_datasets):
+        """Warning is logged when load_from_disk raises an exception."""
         ds_dir = str(tmp_path / "ds")
         jsonl_path = str(tmp_path / "out.jsonl")
 
@@ -416,6 +440,7 @@ class TestDownloadOciModel:
     """Tests for download_oci_model."""
 
     def test_orchestrates_skopeo_extract_and_find(self, log, tmp_path):
+        """Skopeo copy, tar extraction, and HF model finding are orchestrated."""
         pvc_path = str(tmp_path)
         model_ref = "oci://registry.io/model:v1"
 
@@ -433,6 +458,7 @@ class TestDownloadOciModel:
         assert result == "/pvc/model/hf"
 
     def test_returns_mod_out_when_no_hf_model_found(self, log, tmp_path):
+        """Falls back to model output directory when no HF model is found."""
         pvc_path = str(tmp_path)
         model_ref = "oci://registry.io/model:v1"
 

--- a/components/training/finetuning/shared/tests/test_data.py
+++ b/components/training/finetuning/shared/tests/test_data.py
@@ -1,12 +1,23 @@
-"""Unit tests for the shared data utilities (tarfile extraction)."""
+"""Unit tests for the shared data utilities."""
 
 import io
+import json
 import logging
+import os
 import tarfile
+from unittest import mock
 
 import pytest
 
-from ..data import _extract_tar
+from ..data import (
+    _extract_tar,
+    _find_hf_model,
+    _get_oci_auth,
+    _skopeo_copy,
+    download_oci_model,
+    prepare_jsonl,
+    resolve_dataset,
+)
 
 
 @pytest.fixture
@@ -132,3 +143,306 @@ class TestExtractTar:
 
         result = _extract_tar(str(img_dir), str(out_dir), log)
         assert result == ["models/model.bin"]
+
+
+class TestFindHfModel:
+    """Tests for _find_hf_model."""
+
+    def test_finds_valid_hf_model_dir(self, tmp_path):
+        model_dir = tmp_path / "models" / "my_model"
+        model_dir.mkdir(parents=True)
+        (model_dir / "config.json").write_text("{}")
+        (model_dir / "model.safetensors").write_bytes(b"")
+        (model_dir / "tokenizer.json").write_text("{}")
+
+        result = _find_hf_model(str(tmp_path))
+        assert result == str(model_dir)
+
+    def test_returns_none_when_no_model(self, tmp_path):
+        (tmp_path / "random.txt").write_text("nothing")
+        assert _find_hf_model(str(tmp_path)) is None
+
+    def test_requires_config_and_weights_and_tokenizer(self, tmp_path):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text("{}")
+        (model_dir / "model.safetensors").write_bytes(b"")
+        # Missing tokenizer
+        assert _find_hf_model(str(tmp_path)) is None
+
+
+class TestGetOciAuth:
+    """Tests for _get_oci_auth."""
+
+    def test_returns_none_when_unset(self, log):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert _get_oci_auth(log) is None
+
+    def test_returns_raw_json_when_valid(self, log):
+        auth = json.dumps({"auths": {"registry.io": {"auth": "abc"}}})
+        with mock.patch.dict(os.environ, {"OCI_PULL_SECRET_MODEL_DOWNLOAD": auth}):
+            result = _get_oci_auth(log)
+        assert result == auth
+
+    def test_raises_on_invalid_json(self, log):
+        with mock.patch.dict(os.environ, {"OCI_PULL_SECRET_MODEL_DOWNLOAD": "not-json"}):
+            with pytest.raises(ValueError, match="not valid JSON"):
+                _get_oci_auth(log)
+
+    def test_raises_on_missing_auths(self, log):
+        with mock.patch.dict(os.environ, {"OCI_PULL_SECRET_MODEL_DOWNLOAD": "{}"}):
+            with pytest.raises(ValueError, match="non-empty 'auths' field"):
+                _get_oci_auth(log)
+
+    def test_raises_on_empty_auths(self, log):
+        auth = json.dumps({"auths": {}})
+        with mock.patch.dict(os.environ, {"OCI_PULL_SECRET_MODEL_DOWNLOAD": auth}):
+            with pytest.raises(ValueError, match="non-empty 'auths' field"):
+                _get_oci_auth(log)
+
+
+class TestSkopeoCopy:
+    """Tests for _skopeo_copy."""
+
+    def test_runs_skopeo_without_auth(self, log, tmp_path):
+        dest = str(tmp_path / "dest")
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.return_value = mock.MagicMock(returncode=0)
+            _skopeo_copy("registry.io/model:latest", dest, None, log)
+        args = mock_run.call_args[0][0]
+        assert args[:2] == ["skopeo", "copy"]
+        assert "--authfile" not in args
+        assert f"docker://registry.io/model:latest" in args
+
+    def test_runs_skopeo_with_auth(self, log, tmp_path):
+        dest = str(tmp_path / "dest")
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.return_value = mock.MagicMock(returncode=0)
+            _skopeo_copy("registry.io/model:latest", dest, '{"auths":{}}', log)
+        args = mock_run.call_args[0][0]
+        assert "--authfile" in args
+
+    def test_raises_on_failure(self, log, tmp_path):
+        dest = str(tmp_path / "dest")
+        with mock.patch("subprocess.run") as mock_run:
+            proc = mock.MagicMock(returncode=1, stderr="pull denied")
+            proc.check_returncode.side_effect = RuntimeError("skopeo failed")
+            mock_run.return_value = proc
+            with pytest.raises(RuntimeError):
+                _skopeo_copy("registry.io/model:latest", dest, None, log)
+
+    def test_cleans_up_authfile(self, log, tmp_path):
+        dest = str(tmp_path / "dest")
+        created_files = []
+
+        original_unlink = os.unlink
+
+        def track_unlink(path):
+            created_files.append(path)
+            original_unlink(path)
+
+        with (
+            mock.patch("subprocess.run", return_value=mock.MagicMock(returncode=0)),
+            mock.patch("os.unlink", side_effect=track_unlink),
+        ):
+            _skopeo_copy("ref", dest, '{"auths":{}}', log)
+        assert len(created_files) == 1
+
+
+@pytest.fixture
+def mock_datasets():
+    """Provide a mock 'datasets' module for local imports in data.py."""
+    mod = mock.MagicMock()
+    with mock.patch.dict("sys.modules", {"datasets": mod}):
+        yield mod
+
+
+class TestResolveDataset:
+    """Tests for resolve_dataset."""
+
+    def test_existing_dir_is_reused(self, log, tmp_path, mock_datasets):
+        out_dir = tmp_path / "ds"
+        out_dir.mkdir()
+        (out_dir / "data.jsonl").write_text("{}")
+
+        resolve_dataset(None, str(out_dir), log)
+        assert (out_dir / "data.jsonl").exists()
+
+    def test_artifact_dir_is_copied(self, log, tmp_path, mock_datasets):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / "train.jsonl").write_text('{"text":"hello"}')
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        inp = mock.MagicMock()
+        inp.path = str(src_dir)
+
+        resolve_dataset(inp, str(out_dir), log)
+        assert (out_dir / "train.jsonl").read_text() == '{"text":"hello"}'
+
+    def test_artifact_file_is_copied(self, log, tmp_path, mock_datasets):
+        src_file = tmp_path / "data.jsonl"
+        src_file.write_text('{"text":"hello"}')
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        inp = mock.MagicMock()
+        inp.path = str(src_file)
+
+        resolve_dataset(inp, str(out_dir), log)
+        assert (out_dir / "data.jsonl").read_text() == '{"text":"hello"}'
+
+    def test_artifact_file_without_extension_gets_default_name(self, log, tmp_path, mock_datasets):
+        src_file = tmp_path / "mydata"
+        src_file.write_text('{"text":"data"}')
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        inp = mock.MagicMock()
+        inp.path = str(src_file)
+
+        resolve_dataset(inp, str(out_dir), log)
+        assert (out_dir / "train.jsonl").exists()
+
+    def test_pvc_metadata_dir_is_copied(self, log, tmp_path, mock_datasets):
+        pvc_dir = tmp_path / "pvc_ds"
+        pvc_dir.mkdir()
+        (pvc_dir / "train.jsonl").write_text('{"text":"pvc"}')
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        inp = mock.MagicMock()
+        inp.path = None
+        inp.metadata = {"pvc_path": str(pvc_dir)}
+
+        resolve_dataset(inp, str(out_dir), log)
+        assert (out_dir / "train.jsonl").read_text() == '{"text":"pvc"}'
+
+    def test_remote_json_loads_via_hf_datasets(self, log, tmp_path, mock_datasets):
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        inp = mock.MagicMock()
+        inp.path = None
+        inp.metadata = {"artifact_path": "https://example.com/data.jsonl"}
+
+        mock_ds = mock.MagicMock()
+        mock_datasets.load_dataset.return_value = mock_ds
+
+        resolve_dataset(inp, str(out_dir), log)
+        mock_datasets.load_dataset.assert_called_once_with(
+            "json", data_files="https://example.com/data.jsonl", split="train"
+        )
+        mock_ds.save_to_disk.assert_called_once_with(str(out_dir))
+
+    def test_hf_repo_id_loads_via_hf_datasets(self, log, tmp_path, mock_datasets):
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        inp = mock.MagicMock()
+        inp.path = None
+        inp.metadata = {"artifact_path": "tatsu-lab/alpaca"}
+
+        mock_ds = mock.MagicMock()
+        mock_datasets.load_dataset.return_value = mock_ds
+
+        resolve_dataset(inp, str(out_dir), log)
+        mock_datasets.load_dataset.assert_called_once_with("tatsu-lab/alpaca", split="train")
+
+    def test_no_source_raises_value_error(self, log, tmp_path, mock_datasets):
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        with pytest.raises(ValueError, match="No dataset provided"):
+            resolve_dataset(None, str(out_dir), log)
+
+
+class TestPrepareJsonl:
+    """Tests for prepare_jsonl."""
+
+    def test_exports_dataset_to_jsonl(self, log, tmp_path, mock_datasets):
+        ds_dir = str(tmp_path / "ds")
+        jsonl_path = str(tmp_path / "out.jsonl")
+
+        mock_ds = mock.MagicMock()
+        mock_ds.__contains__ = lambda self, key: key == "train"
+        mock_ds.__getitem__ = lambda self, key: mock_ds
+        mock_datasets.load_from_disk.return_value = mock_ds
+
+        prepare_jsonl(ds_dir, jsonl_path, log)
+        mock_ds.to_json.assert_called_once_with(jsonl_path, lines=True)
+
+    def test_falls_back_to_manual_write_on_attribute_error(self, log, tmp_path, mock_datasets):
+        ds_dir = str(tmp_path / "ds")
+        jsonl_path = str(tmp_path / "out.jsonl")
+
+        mock_ds = mock.MagicMock()
+        mock_ds.__contains__ = lambda self, key: key == "train"
+        mock_ds.__getitem__ = lambda self, key: mock_ds
+        mock_ds.to_json.side_effect = AttributeError("no to_json")
+        mock_ds.__iter__ = lambda self: iter([{"text": "a"}, {"text": "b"}])
+        mock_datasets.load_from_disk.return_value = mock_ds
+
+        prepare_jsonl(ds_dir, jsonl_path, log)
+
+        lines = open(jsonl_path).readlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0]) == {"text": "a"}
+
+    def test_handles_dict_dataset_with_train_split(self, log, tmp_path, mock_datasets):
+        ds_dir = str(tmp_path / "ds")
+        jsonl_path = str(tmp_path / "out.jsonl")
+
+        train_split = mock.MagicMock()
+        mock_datasets.load_from_disk.return_value = {"train": train_split}
+
+        prepare_jsonl(ds_dir, jsonl_path, log)
+        train_split.to_json.assert_called_once_with(jsonl_path, lines=True)
+
+    def test_logs_warning_on_failure(self, log, tmp_path, mock_datasets):
+        ds_dir = str(tmp_path / "ds")
+        jsonl_path = str(tmp_path / "out.jsonl")
+
+        mock_datasets.load_from_disk.side_effect = Exception("corrupt")
+
+        with mock.patch.object(log, "warning") as mock_warn:
+            prepare_jsonl(ds_dir, jsonl_path, log)
+        mock_warn.assert_called_once()
+        assert "JSONL export failed" in mock_warn.call_args[0][0]
+
+
+class TestDownloadOciModel:
+    """Tests for download_oci_model."""
+
+    def test_orchestrates_skopeo_extract_and_find(self, log, tmp_path):
+        pvc_path = str(tmp_path)
+        model_ref = "oci://registry.io/model:v1"
+
+        with (
+            mock.patch("components.training.finetuning.shared.data._get_oci_auth", return_value=None),
+            mock.patch("components.training.finetuning.shared.data._skopeo_copy") as mock_skopeo,
+            mock.patch("components.training.finetuning.shared.data._extract_tar"),
+            mock.patch("components.training.finetuning.shared.data._find_hf_model", return_value="/pvc/model/hf"),
+            mock.patch("os.path.isdir", return_value=True),
+        ):
+            result = download_oci_model(model_ref, pvc_path, log)
+
+        mock_skopeo.assert_called_once()
+        assert mock_skopeo.call_args[0][0] == "registry.io/model:v1"
+        assert result == "/pvc/model/hf"
+
+    def test_returns_mod_out_when_no_hf_model_found(self, log, tmp_path):
+        pvc_path = str(tmp_path)
+        model_ref = "oci://registry.io/model:v1"
+
+        with (
+            mock.patch("components.training.finetuning.shared.data._get_oci_auth", return_value=None),
+            mock.patch("components.training.finetuning.shared.data._skopeo_copy"),
+            mock.patch("components.training.finetuning.shared.data._extract_tar"),
+            mock.patch("components.training.finetuning.shared.data._find_hf_model", return_value=None),
+            mock.patch("os.path.isdir", return_value=False),
+        ):
+            result = download_oci_model(model_ref, pvc_path, log)
+
+        assert result == os.path.join(pvc_path, "model")

--- a/components/training/finetuning/shared/tests/test_output.py
+++ b/components/training/finetuning/shared/tests/test_output.py
@@ -18,19 +18,25 @@ from components.training.finetuning.shared.output import (
 
 @pytest.fixture
 def log():
+    """Create a test logger."""
     return logging.getLogger("test_output")
 
 
 class TestFindModelDir:
+    """Tests for find_model_dir checkpoint discovery."""
+
     def test_nonexistent_root_returns_none(self, tmp_path):
+        """Non-existent root directory returns None."""
         result = find_model_dir(str(tmp_path / "nonexistent"))
         assert result is None
 
     def test_empty_root_returns_none(self, tmp_path):
+        """Empty root directory returns None."""
         result = find_model_dir(str(tmp_path))
         assert result is None
 
     def test_single_checkpoint_with_config_json(self, tmp_path):
+        """Checkpoint containing config.json is discovered."""
         ckpt = tmp_path / "checkpoint-1"
         ckpt.mkdir()
         (ckpt / "config.json").write_text("{}")
@@ -38,6 +44,7 @@ class TestFindModelDir:
         assert result == str(ckpt)
 
     def test_returns_most_recent_checkpoint_by_mtime(self, tmp_path):
+        """Most recently modified checkpoint is returned."""
         old = tmp_path / "checkpoint-1"
         old.mkdir()
         (old / "config.json").write_text("{}")
@@ -49,6 +56,7 @@ class TestFindModelDir:
         assert result == str(new)
 
     def test_fallback_to_subdir_mtime_when_no_config_json(self, tmp_path):
+        """Falls back to newest subdirectory when no config.json exists."""
         sub = tmp_path / "model_dir"
         sub.mkdir()
         result = find_model_dir(str(tmp_path))
@@ -56,12 +64,16 @@ class TestFindModelDir:
 
 
 class TestExtractMetricsFromJsonl:
+    """Tests for extract_metrics_from_jsonl metric parsing."""
+
     def test_missing_file_returns_empty(self, tmp_path):
+        """Missing file returns empty metrics and loss list."""
         met, loss = extract_metrics_from_jsonl(str(tmp_path / "nonexistent.jsonl"))
         assert met == {}
         assert loss == []
 
     def test_single_line_with_loss(self, tmp_path):
+        """Single JSONL line with loss is parsed correctly."""
         f = tmp_path / "metrics.jsonl"
         f.write_text(json.dumps({"loss": 1.5, "step": 10}) + "\n")
         met, loss = extract_metrics_from_jsonl(str(f))
@@ -71,6 +83,7 @@ class TestExtractMetricsFromJsonl:
         assert met["step"] == 10.0
 
     def test_multiple_lines_accumulate_loss(self, tmp_path):
+        """Multiple lines accumulate loss values."""
         f = tmp_path / "metrics.jsonl"
         lines = [
             json.dumps({"loss": 2.0}),
@@ -84,24 +97,28 @@ class TestExtractMetricsFromJsonl:
         assert met["min_loss"] == 1.0
 
     def test_first_value_wins_for_duplicate_metric_keys(self, tmp_path):
+        """First occurrence of a metric key wins over duplicates."""
         f = tmp_path / "metrics.jsonl"
         f.write_text(json.dumps({"step": 1}) + "\n" + json.dumps({"step": 99}) + "\n")
         met, _ = extract_metrics_from_jsonl(str(f))
         assert met["step"] == 1.0
 
     def test_malformed_line_is_skipped(self, tmp_path):
+        """Malformed JSON lines are silently skipped."""
         f = tmp_path / "metrics.jsonl"
         f.write_text("not-valid-json\n" + json.dumps({"loss": 0.5}) + "\n")
         met, loss = extract_metrics_from_jsonl(str(f))
         assert loss == [0.5]
 
     def test_non_numeric_loss_is_skipped(self, tmp_path):
+        """Non-numeric loss values are skipped."""
         f = tmp_path / "metrics.jsonl"
         f.write_text(json.dumps({"loss": "not-a-number"}) + "\n")
         _, loss = extract_metrics_from_jsonl(str(f))
         assert loss == []
 
     def test_avg_loss_field_treated_as_loss(self, tmp_path):
+        """The avg_loss field is treated as a loss value."""
         f = tmp_path / "metrics.jsonl"
         f.write_text(json.dumps({"avg_loss": 0.8}) + "\n")
         met, loss = extract_metrics_from_jsonl(str(f))
@@ -110,7 +127,10 @@ class TestExtractMetricsFromJsonl:
 
 
 class TestPersistModel:
+    """Tests for persist_model artifact persistence."""
+
     def test_raises_when_no_model_found(self, tmp_path, log):
+        """Raises RuntimeError when no model checkpoint exists."""
         output_model = mock.MagicMock()
         with pytest.raises(RuntimeError, match="No model found"):
             persist_model(
@@ -122,6 +142,7 @@ class TestPersistModel:
             )
 
     def test_copies_model_to_pvc_and_artifact(self, tmp_path, log):
+        """Model files are copied to PVC and artifact paths."""
         ckpt = tmp_path / "ckpts" / "checkpoint-1"
         ckpt.mkdir(parents=True)
         (ckpt / "config.json").write_text("{}")
@@ -140,6 +161,7 @@ class TestPersistModel:
         assert output_model.metadata["pvc_model_dir"] == str(pvc / "final_model")
 
     def test_sets_artifact_name(self, tmp_path, log):
+        """Artifact name is set from the base model name."""
         ckpt = tmp_path / "ckpts" / "final"
         ckpt.mkdir(parents=True)
         (ckpt / "config.json").write_text("{}")
@@ -154,8 +176,11 @@ class TestPersistModel:
 
 
 class TestPlotTrainingLoss:
+    """Tests for plot_training_loss HTML output."""
+
     @pytest.fixture(autouse=True)
     def _mock_matplotlib(self):
+        """Patch matplotlib in sys.modules so tests run without it installed."""
         mock_mpl = mock.MagicMock()
         mock_plt = mock.MagicMock()
         mock_mpl.pyplot = mock_plt
@@ -167,6 +192,7 @@ class TestPlotTrainingLoss:
             yield
 
     def test_empty_loss_writes_no_data_html(self, tmp_path):
+        """Empty loss list produces a 'No loss data' HTML page."""
         path = str(tmp_path / "loss.html")
         plot_training_loss([], path)
         with open(path) as f:
@@ -174,6 +200,7 @@ class TestPlotTrainingLoss:
         assert "No loss data" in content
 
     def test_valid_loss_writes_html_with_base64_image(self, tmp_path):
+        """Non-empty loss list produces HTML with a base64-encoded image."""
         mock_fig = mock.MagicMock()
         mock_ax = mock.MagicMock()
         self._mock_plt.subplots.return_value = (mock_fig, mock_ax)

--- a/components/training/finetuning/shared/tests/test_output.py
+++ b/components/training/finetuning/shared/tests/test_output.py
@@ -1,0 +1,195 @@
+"""Tests for shared/output.py — model persistence, metrics extraction, loss plotting."""
+
+import json
+import logging
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+from components.training.finetuning.shared.output import (
+    extract_metrics_from_jsonl,
+    find_model_dir,
+    persist_model,
+    plot_training_loss,
+)
+
+
+@pytest.fixture
+def log():
+    return logging.getLogger("test_output")
+
+
+class TestFindModelDir:
+    def test_nonexistent_root_returns_none(self, tmp_path):
+        result = find_model_dir(str(tmp_path / "nonexistent"))
+        assert result is None
+
+    def test_empty_root_returns_none(self, tmp_path):
+        result = find_model_dir(str(tmp_path))
+        assert result is None
+
+    def test_single_checkpoint_with_config_json(self, tmp_path):
+        ckpt = tmp_path / "checkpoint-1"
+        ckpt.mkdir()
+        (ckpt / "config.json").write_text("{}")
+        result = find_model_dir(str(tmp_path))
+        assert result == str(ckpt)
+
+    def test_returns_most_recent_checkpoint_by_mtime(self, tmp_path):
+        old = tmp_path / "checkpoint-1"
+        old.mkdir()
+        (old / "config.json").write_text("{}")
+        new = tmp_path / "checkpoint-2"
+        new.mkdir()
+        (new / "config.json").write_text("{}")
+        os.utime(new / "config.json", (2_000_000_000, 2_000_000_000))
+        result = find_model_dir(str(tmp_path))
+        assert result == str(new)
+
+    def test_fallback_to_subdir_mtime_when_no_config_json(self, tmp_path):
+        sub = tmp_path / "model_dir"
+        sub.mkdir()
+        result = find_model_dir(str(tmp_path))
+        assert result == str(sub)
+
+
+class TestExtractMetricsFromJsonl:
+    def test_missing_file_returns_empty(self, tmp_path):
+        met, loss = extract_metrics_from_jsonl(str(tmp_path / "nonexistent.jsonl"))
+        assert met == {}
+        assert loss == []
+
+    def test_single_line_with_loss(self, tmp_path):
+        f = tmp_path / "metrics.jsonl"
+        f.write_text(json.dumps({"loss": 1.5, "step": 10}) + "\n")
+        met, loss = extract_metrics_from_jsonl(str(f))
+        assert loss == [1.5]
+        assert met["final_loss"] == 1.5
+        assert met["min_loss"] == 1.5
+        assert met["step"] == 10.0
+
+    def test_multiple_lines_accumulate_loss(self, tmp_path):
+        f = tmp_path / "metrics.jsonl"
+        lines = [
+            json.dumps({"loss": 2.0}),
+            json.dumps({"loss": 1.5}),
+            json.dumps({"loss": 1.0}),
+        ]
+        f.write_text("\n".join(lines) + "\n")
+        met, loss = extract_metrics_from_jsonl(str(f))
+        assert loss == [2.0, 1.5, 1.0]
+        assert met["final_loss"] == 1.0
+        assert met["min_loss"] == 1.0
+
+    def test_first_value_wins_for_duplicate_metric_keys(self, tmp_path):
+        f = tmp_path / "metrics.jsonl"
+        f.write_text(json.dumps({"step": 1}) + "\n" + json.dumps({"step": 99}) + "\n")
+        met, _ = extract_metrics_from_jsonl(str(f))
+        assert met["step"] == 1.0
+
+    def test_malformed_line_is_skipped(self, tmp_path):
+        f = tmp_path / "metrics.jsonl"
+        f.write_text("not-valid-json\n" + json.dumps({"loss": 0.5}) + "\n")
+        met, loss = extract_metrics_from_jsonl(str(f))
+        assert loss == [0.5]
+
+    def test_non_numeric_loss_is_skipped(self, tmp_path):
+        f = tmp_path / "metrics.jsonl"
+        f.write_text(json.dumps({"loss": "not-a-number"}) + "\n")
+        _, loss = extract_metrics_from_jsonl(str(f))
+        assert loss == []
+
+    def test_avg_loss_field_treated_as_loss(self, tmp_path):
+        f = tmp_path / "metrics.jsonl"
+        f.write_text(json.dumps({"avg_loss": 0.8}) + "\n")
+        met, loss = extract_metrics_from_jsonl(str(f))
+        assert loss == [0.8]
+        assert met["final_loss"] == 0.8
+
+
+class TestPersistModel:
+    def test_raises_when_no_model_found(self, tmp_path, log):
+        output_model = mock.MagicMock()
+        with pytest.raises(RuntimeError, match="No model found"):
+            persist_model(
+                str(tmp_path / "empty_ckpts"),
+                str(tmp_path / "pvc"),
+                "base-model",
+                output_model,
+                log,
+            )
+
+    def test_copies_model_to_pvc_and_artifact(self, tmp_path, log):
+        ckpt = tmp_path / "ckpts" / "checkpoint-1"
+        ckpt.mkdir(parents=True)
+        (ckpt / "config.json").write_text("{}")
+        (ckpt / "model.bin").write_bytes(b"weights")
+        pvc = tmp_path / "pvc"
+        pvc.mkdir()
+        output_model = mock.MagicMock()
+        output_model.path = str(tmp_path / "artifact")
+        output_model.metadata = {}
+
+        persist_model(str(tmp_path / "ckpts"), str(pvc), "MyModel", output_model, log)
+
+        assert (pvc / "final_model" / "config.json").exists()
+        assert (pvc / "final_model" / "model.bin").exists()
+        assert output_model.metadata["model_name"] == "MyModel"
+        assert output_model.metadata["pvc_model_dir"] == str(pvc / "final_model")
+
+    def test_sets_artifact_name(self, tmp_path, log):
+        ckpt = tmp_path / "ckpts" / "final"
+        ckpt.mkdir(parents=True)
+        (ckpt / "config.json").write_text("{}")
+        pvc = tmp_path / "pvc"
+        pvc.mkdir()
+        output_model = mock.MagicMock()
+        output_model.path = str(tmp_path / "artifact")
+
+        persist_model(str(tmp_path / "ckpts"), str(pvc), "granite-7b", output_model, log)
+
+        assert output_model.name == "granite-7b-checkpoint"
+
+
+class TestPlotTrainingLoss:
+    @pytest.fixture(autouse=True)
+    def _mock_matplotlib(self):
+        mock_mpl = mock.MagicMock()
+        mock_plt = mock.MagicMock()
+        mock_mpl.pyplot = mock_plt
+        with mock.patch.dict(
+            sys.modules,
+            {"matplotlib": mock_mpl, "matplotlib.pyplot": mock_plt},
+        ):
+            self._mock_plt = mock_plt
+            yield
+
+    def test_empty_loss_writes_no_data_html(self, tmp_path):
+        path = str(tmp_path / "loss.html")
+        plot_training_loss([], path)
+        with open(path) as f:
+            content = f.read()
+        assert "No loss data" in content
+
+    def test_valid_loss_writes_html_with_base64_image(self, tmp_path):
+        mock_fig = mock.MagicMock()
+        mock_ax = mock.MagicMock()
+        self._mock_plt.subplots.return_value = (mock_fig, mock_ax)
+
+        mock_buf = mock.MagicMock()
+        mock_buf.read.return_value = b"fake_png_data"
+        mock_buf.seek = mock.MagicMock()
+
+        path = str(tmp_path / "loss.html")
+        with (
+            mock.patch("io.BytesIO", return_value=mock_buf),
+            mock.patch("base64.b64encode", return_value=b"FAKE_BASE64_IMG"),
+        ):
+            plot_training_loss([2.0, 1.5, 1.0], path)
+
+        with open(path) as f:
+            content = f.read()
+        assert "data:image/png;base64," in content
+        assert "<!DOCTYPE html>" in content

--- a/components/training/finetuning/shared/tests/test_setup.py
+++ b/components/training/finetuning/shared/tests/test_setup.py
@@ -76,18 +76,22 @@ class TestCreateLogger:
     """Tests for create_logger."""
 
     def test_returns_logger_with_correct_name(self):
+        """Logger is created with the specified name."""
         logger = create_logger("my_component")
         assert logger.name == "my_component"
 
     def test_default_name(self):
+        """Default logger name is 'train_model'."""
         logger = create_logger()
         assert logger.name == "train_model"
 
     def test_logger_level_is_info(self):
+        """Logger level is set to INFO."""
         logger = create_logger("test_level")
         assert logger.level == logging.INFO
 
     def test_logger_has_stdout_handler(self):
+        """Logger has exactly one StreamHandler."""
         name = "test_handler_check"
         logging.getLogger(name).handlers.clear()
         logger = create_logger(name)
@@ -95,6 +99,7 @@ class TestCreateLogger:
         assert isinstance(logger.handlers[0], logging.StreamHandler)
 
     def test_no_duplicate_handlers_on_repeated_calls(self):
+        """Repeated calls do not add duplicate handlers."""
         name = "test_no_dup"
         logging.getLogger(name).handlers.clear()
         create_logger(name)
@@ -106,32 +111,41 @@ class TestParseKv:
     """Tests for parse_kv."""
 
     def test_empty_string(self):
+        """Empty string yields empty dict."""
         assert parse_kv("") == {}
 
     def test_single_pair(self):
+        """Single key=value pair is parsed."""
         assert parse_kv("FOO=bar") == {"FOO": "bar"}
 
     def test_multiple_pairs(self):
+        """Multiple comma-separated pairs are parsed."""
         assert parse_kv("A=1,B=2,C=3") == {"A": "1", "B": "2", "C": "3"}
 
     def test_strips_whitespace(self):
+        """Whitespace around keys and values is stripped."""
         assert parse_kv("  A = 1 , B = 2 ") == {"A": "1", "B": "2"}
 
     def test_value_contains_equals(self):
+        """Values containing '=' are preserved after the first split."""
         assert parse_kv("URL=http://host?a=b") == {"URL": "http://host?a=b"}
 
     def test_trailing_comma_ignored(self):
+        """Trailing comma is ignored."""
         assert parse_kv("A=1,") == {"A": "1"}
 
     def test_missing_equals_raises(self):
+        """Missing '=' raises ValueError."""
         with pytest.raises(ValueError, match="Invalid kv"):
             parse_kv("NOEQUALS")
 
     def test_empty_key_raises(self):
+        """Empty key raises ValueError."""
         with pytest.raises(ValueError, match="Empty key"):
             parse_kv("=value")
 
     def test_empty_value_allowed(self):
+        """Empty value is allowed."""
         assert parse_kv("KEY=") == {"KEY": ""}
 
 
@@ -139,21 +153,25 @@ class TestConfigureEnv:
     """Tests for configure_env."""
 
     def test_merges_base_and_csv(self, log):
+        """CSV pairs are merged with base dict."""
         with mock.patch.dict(os.environ, {}, clear=True):
             result = configure_env("X=1,Y=2", {"BASE": "val"}, log)
         assert result == {"BASE": "val", "X": "1", "Y": "2"}
 
     def test_csv_overrides_base(self, log):
+        """CSV values override base dict values."""
         with mock.patch.dict(os.environ, {}, clear=True):
             result = configure_env("K=new", {"K": "old"}, log)
         assert result == {"K": "new"}
 
     def test_sets_os_environ(self, log):
+        """Merged values are set in os.environ."""
         with mock.patch.dict(os.environ, {}, clear=True):
             configure_env("MY_VAR=hello", {}, log)
             assert os.environ["MY_VAR"] == "hello"
 
     def test_empty_csv(self, log):
+        """Empty CSV returns only base dict values."""
         with mock.patch.dict(os.environ, {}, clear=True):
             result = configure_env("", {"ONLY": "base"}, log)
         assert result == {"ONLY": "base"}
@@ -163,12 +181,14 @@ class TestSetupHfToken:
     """Tests for setup_hf_token."""
 
     def test_propagates_existing_token(self, log):
+        """Existing HF_TOKEN is propagated to menv."""
         menv = {}
         with mock.patch.dict(os.environ, {"HF_TOKEN": "tok123"}, clear=True):
             setup_hf_token(menv, "some/model", log)
         assert menv["HF_TOKEN"] == "tok123"
 
     def test_no_token_warns_for_hf_model(self, log):
+        """Warning is emitted when HF_TOKEN is missing for an HF model."""
         menv = {}
         with (
             mock.patch.dict(os.environ, {}, clear=True),
@@ -179,6 +199,7 @@ class TestSetupHfToken:
         assert "HF_TOKEN not set" in mock_warn.call_args[0][0]
 
     def test_no_token_warns_for_hf_prefix(self, log):
+        """Warning is emitted for hf:// prefixed models without token."""
         menv = {}
         with (
             mock.patch.dict(os.environ, {}, clear=True),
@@ -188,6 +209,7 @@ class TestSetupHfToken:
         mock_warn.assert_called_once()
 
     def test_no_token_no_warning_for_local_path(self, log, tmp_path):
+        """No warning is emitted for local filesystem paths."""
         menv = {}
         local_dir = str(tmp_path)
         with (
@@ -198,6 +220,7 @@ class TestSetupHfToken:
         mock_warn.assert_not_called()
 
     def test_no_token_no_warning_for_oci_model(self, log):
+        """No warning is emitted for OCI model references."""
         menv = {}
         with (
             mock.patch.dict(os.environ, {}, clear=True),

--- a/components/training/finetuning/shared/tests/test_setup.py
+++ b/components/training/finetuning/shared/tests/test_setup.py
@@ -1,11 +1,12 @@
-"""Unit tests for the shared setup utilities (K8s SSL and configuration)."""
+"""Unit tests for the shared setup utilities."""
 
 import logging
+import os
 from unittest import mock
 
 import pytest
 
-from ..setup import init_k8s
+from ..setup import configure_env, create_logger, init_k8s, parse_kv, setup_hf_token
 
 
 @pytest.fixture
@@ -69,3 +70,138 @@ class TestInitK8sSSL:
         with mock.patch.dict("sys.modules", {"kubernetes": None, "kubernetes.client": None}):
             result = init_k8s(log)
         assert result is None
+
+
+class TestCreateLogger:
+    """Tests for create_logger."""
+
+    def test_returns_logger_with_correct_name(self):
+        logger = create_logger("my_component")
+        assert logger.name == "my_component"
+
+    def test_default_name(self):
+        logger = create_logger()
+        assert logger.name == "train_model"
+
+    def test_logger_level_is_info(self):
+        logger = create_logger("test_level")
+        assert logger.level == logging.INFO
+
+    def test_logger_has_stdout_handler(self):
+        name = "test_handler_check"
+        logging.getLogger(name).handlers.clear()
+        logger = create_logger(name)
+        assert len(logger.handlers) == 1
+        assert isinstance(logger.handlers[0], logging.StreamHandler)
+
+    def test_no_duplicate_handlers_on_repeated_calls(self):
+        name = "test_no_dup"
+        logging.getLogger(name).handlers.clear()
+        create_logger(name)
+        create_logger(name)
+        assert len(logging.getLogger(name).handlers) == 1
+
+
+class TestParseKv:
+    """Tests for parse_kv."""
+
+    def test_empty_string(self):
+        assert parse_kv("") == {}
+
+    def test_single_pair(self):
+        assert parse_kv("FOO=bar") == {"FOO": "bar"}
+
+    def test_multiple_pairs(self):
+        assert parse_kv("A=1,B=2,C=3") == {"A": "1", "B": "2", "C": "3"}
+
+    def test_strips_whitespace(self):
+        assert parse_kv("  A = 1 , B = 2 ") == {"A": "1", "B": "2"}
+
+    def test_value_contains_equals(self):
+        assert parse_kv("URL=http://host?a=b") == {"URL": "http://host?a=b"}
+
+    def test_trailing_comma_ignored(self):
+        assert parse_kv("A=1,") == {"A": "1"}
+
+    def test_missing_equals_raises(self):
+        with pytest.raises(ValueError, match="Invalid kv"):
+            parse_kv("NOEQUALS")
+
+    def test_empty_key_raises(self):
+        with pytest.raises(ValueError, match="Empty key"):
+            parse_kv("=value")
+
+    def test_empty_value_allowed(self):
+        assert parse_kv("KEY=") == {"KEY": ""}
+
+
+class TestConfigureEnv:
+    """Tests for configure_env."""
+
+    def test_merges_base_and_csv(self, log):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = configure_env("X=1,Y=2", {"BASE": "val"}, log)
+        assert result == {"BASE": "val", "X": "1", "Y": "2"}
+
+    def test_csv_overrides_base(self, log):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = configure_env("K=new", {"K": "old"}, log)
+        assert result == {"K": "new"}
+
+    def test_sets_os_environ(self, log):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            configure_env("MY_VAR=hello", {}, log)
+            assert os.environ["MY_VAR"] == "hello"
+
+    def test_empty_csv(self, log):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = configure_env("", {"ONLY": "base"}, log)
+        assert result == {"ONLY": "base"}
+
+
+class TestSetupHfToken:
+    """Tests for setup_hf_token."""
+
+    def test_propagates_existing_token(self, log):
+        menv = {}
+        with mock.patch.dict(os.environ, {"HF_TOKEN": "tok123"}, clear=True):
+            setup_hf_token(menv, "some/model", log)
+        assert menv["HF_TOKEN"] == "tok123"
+
+    def test_no_token_warns_for_hf_model(self, log):
+        menv = {}
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(log, "warning") as mock_warn,
+        ):
+            setup_hf_token(menv, "meta-llama/Llama-2-7b", log)
+        mock_warn.assert_called_once()
+        assert "HF_TOKEN not set" in mock_warn.call_args[0][0]
+
+    def test_no_token_warns_for_hf_prefix(self, log):
+        menv = {}
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(log, "warning") as mock_warn,
+        ):
+            setup_hf_token(menv, "hf://some/model", log)
+        mock_warn.assert_called_once()
+
+    def test_no_token_no_warning_for_local_path(self, log, tmp_path):
+        menv = {}
+        local_dir = str(tmp_path)
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(log, "warning") as mock_warn,
+        ):
+            setup_hf_token(menv, local_dir, log)
+        mock_warn.assert_not_called()
+
+    def test_no_token_no_warning_for_oci_model(self, log):
+        menv = {}
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(log, "warning") as mock_warn,
+        ):
+            setup_hf_token(menv, "oci://registry/model:tag", log)
+        mock_warn.assert_not_called()

--- a/components/training/finetuning/shared/tests/test_training.py
+++ b/components/training/finetuning/shared/tests/test_training.py
@@ -44,6 +44,13 @@ def mock_client():
 
 
 def _make_train_job(status="Running", steps=None, name="test-job"):
+    """Create a FakeTrainJob with sensible defaults.
+
+    Args:
+        status: Job status string.
+        steps: List of FakeStep instances.
+        name: Job name.
+    """
     if steps is None:
         steps = [FakeStep(name="node-0", pod_name="test-job-node-0-abc")]
     return FakeTrainJob(
@@ -133,7 +140,6 @@ class TestSharedTrainingUnitTests:
             wait_for_training_job(mock_client, "test-job", log)
 
         assert mock_client.get_job_logs.call_count == 2
-        # Should always wait for final status
         assert mock_client.wait_for_job_status.call_count == 2
 
     def test_wait_streaming_fails_all_retries_falls_back_to_polling(self, mock_client, log):
@@ -147,7 +153,6 @@ class TestSharedTrainingUnitTests:
             wait_for_training_job(mock_client, "test-job", log)
 
         assert mock_client.get_job_logs.call_count == 3
-        # Should have fallen back to polling for Complete/Failed
         assert mock_client.wait_for_job_status.call_count == 2
         mock_client.wait_for_job_status.assert_any_call(name="test-job", status={"Complete", "Failed"}, timeout=1800)
 
@@ -163,7 +168,6 @@ class TestSharedTrainingUnitTests:
         wait_for_training_job(mock_client, "test-job", log)
 
         mock_client.get_job_logs.assert_not_called()
-        # Should fall back to polling
         assert mock_client.wait_for_job_status.call_count == 2
 
     def test_wait_get_job_fails_skips_logging_and_streaming(self, mock_client, log):
@@ -177,12 +181,10 @@ class TestSharedTrainingUnitTests:
         with mock.patch.object(log, "warning") as mock_warning:
             wait_for_training_job(mock_client, "test-job", log)
             warnings = [str(c) for c in mock_warning.call_args_list]
-            # Should warn about the API error, not about missing node-0
             assert any("Could not retrieve TrainJob details" in w for w in warnings)
             assert not any("node-0 step not found" in w for w in warnings)
 
         mock_client.get_job_logs.assert_not_called()
-        # Should fall back to polling
         assert mock_client.wait_for_job_status.call_count == 2
 
     @pytest.mark.parametrize(
@@ -207,24 +209,31 @@ class TestSafeInt:
     """Tests for safe_int."""
 
     def test_none_returns_default(self):
+        """None input returns the default value."""
         assert safe_int(None, 42) == 42
 
     def test_int_passthrough(self):
+        """Integer input passes through unchanged."""
         assert safe_int(7, 0) == 7
 
     def test_string_int(self):
+        """String integer is parsed correctly."""
         assert safe_int("10", 0) == 10
 
     def test_string_with_whitespace(self):
+        """Whitespace-padded string integer is parsed."""
         assert safe_int("  5  ", 0) == 5
 
     def test_empty_string_returns_default(self):
+        """Empty string returns the default value."""
         assert safe_int("", 99) == 99
 
     def test_zero(self):
+        """Zero is returned, not confused with falsy default."""
         assert safe_int(0, 42) == 0
 
     def test_float_string_raises(self):
+        """Float string raises ValueError."""
         with pytest.raises(ValueError):
             safe_int("3.14", 0)
 
@@ -233,6 +242,7 @@ class TestSelectRuntime:
     """Tests for select_runtime."""
 
     def test_finds_matching_runtime(self, log):
+        """Default 'training-hub' runtime is found."""
         rt = mock.MagicMock()
         rt.name = "training-hub"
         client = mock.MagicMock()
@@ -242,6 +252,7 @@ class TestSelectRuntime:
         assert result is rt
 
     def test_finds_custom_named_runtime(self, log):
+        """Custom-named runtime is found when specified."""
         rt1 = mock.MagicMock()
         rt1.name = "other"
         rt2 = mock.MagicMock()
@@ -253,6 +264,7 @@ class TestSelectRuntime:
         assert result is rt2
 
     def test_raises_when_not_found(self, log):
+        """RuntimeError raised when no runtimes exist."""
         client = mock.MagicMock()
         client.list_runtimes.return_value = []
 
@@ -260,6 +272,7 @@ class TestSelectRuntime:
             select_runtime(client, log)
 
     def test_raises_when_no_match(self, log):
+        """RuntimeError raised when target runtime name has no match."""
         rt = mock.MagicMock()
         rt.name = "wrong-name"
         client = mock.MagicMock()
@@ -273,29 +286,35 @@ class TestComputeNproc:
     """Tests for compute_nproc."""
 
     def test_auto_uses_gpu_count(self):
+        """'auto' nproc_per_node uses GPU count."""
         np, nn = compute_nproc(4, "auto", num_workers=2)
         assert np == 4
         assert nn == 2
 
     def test_auto_case_insensitive(self):
+        """'AUTO' is treated the same as 'auto'."""
         np, _ = compute_nproc(8, "AUTO")
         assert np == 8
 
     def test_explicit_nproc(self):
+        """Explicit nproc_per_node string is parsed."""
         np, nn = compute_nproc(4, "2", num_workers=3)
         assert np == 2
         assert nn == 3
 
     def test_single_node_forces_nnodes_1(self):
+        """Single-node mode forces nnodes to 1."""
         np, nn = compute_nproc(4, "auto", num_workers=8, single_node=True)
         assert np == 4
         assert nn == 1
 
     def test_min_values_clamped_to_1(self):
+        """Zero values are clamped to minimum of 1."""
         np, nn = compute_nproc(0, "0", num_workers=0)
         assert np == 1
         assert nn == 1
 
     def test_default_workers(self):
+        """Default num_workers produces nnodes of 1."""
         _, nn = compute_nproc(1, "auto")
         assert nn == 1

--- a/components/training/finetuning/shared/tests/test_training.py
+++ b/components/training/finetuning/shared/tests/test_training.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-from ..training import _log_job_details, wait_for_training_job
+from ..training import _log_job_details, compute_nproc, safe_int, select_runtime, wait_for_training_job
 
 
 @dataclass
@@ -201,3 +201,101 @@ class TestSharedTrainingUnitTests:
 
         with pytest.raises(RuntimeError, match=match):
             wait_for_training_job(mock_client, "test-job", log)
+
+
+class TestSafeInt:
+    """Tests for safe_int."""
+
+    def test_none_returns_default(self):
+        assert safe_int(None, 42) == 42
+
+    def test_int_passthrough(self):
+        assert safe_int(7, 0) == 7
+
+    def test_string_int(self):
+        assert safe_int("10", 0) == 10
+
+    def test_string_with_whitespace(self):
+        assert safe_int("  5  ", 0) == 5
+
+    def test_empty_string_returns_default(self):
+        assert safe_int("", 99) == 99
+
+    def test_zero(self):
+        assert safe_int(0, 42) == 0
+
+    def test_float_string_raises(self):
+        with pytest.raises(ValueError):
+            safe_int("3.14", 0)
+
+
+class TestSelectRuntime:
+    """Tests for select_runtime."""
+
+    def test_finds_matching_runtime(self, log):
+        rt = mock.MagicMock()
+        rt.name = "training-hub"
+        client = mock.MagicMock()
+        client.list_runtimes.return_value = [rt]
+
+        result = select_runtime(client, log)
+        assert result is rt
+
+    def test_finds_custom_named_runtime(self, log):
+        rt1 = mock.MagicMock()
+        rt1.name = "other"
+        rt2 = mock.MagicMock()
+        rt2.name = "my-runtime"
+        client = mock.MagicMock()
+        client.list_runtimes.return_value = [rt1, rt2]
+
+        result = select_runtime(client, log, runtime_name="my-runtime")
+        assert result is rt2
+
+    def test_raises_when_not_found(self, log):
+        client = mock.MagicMock()
+        client.list_runtimes.return_value = []
+
+        with pytest.raises(RuntimeError, match="not found"):
+            select_runtime(client, log)
+
+    def test_raises_when_no_match(self, log):
+        rt = mock.MagicMock()
+        rt.name = "wrong-name"
+        client = mock.MagicMock()
+        client.list_runtimes.return_value = [rt]
+
+        with pytest.raises(RuntimeError, match="training-hub.*not found"):
+            select_runtime(client, log)
+
+
+class TestComputeNproc:
+    """Tests for compute_nproc."""
+
+    def test_auto_uses_gpu_count(self):
+        np, nn = compute_nproc(4, "auto", num_workers=2)
+        assert np == 4
+        assert nn == 2
+
+    def test_auto_case_insensitive(self):
+        np, _ = compute_nproc(8, "AUTO")
+        assert np == 8
+
+    def test_explicit_nproc(self):
+        np, nn = compute_nproc(4, "2", num_workers=3)
+        assert np == 2
+        assert nn == 3
+
+    def test_single_node_forces_nnodes_1(self):
+        np, nn = compute_nproc(4, "auto", num_workers=8, single_node=True)
+        assert np == 4
+        assert nn == 1
+
+    def test_min_values_clamped_to_1(self):
+        np, nn = compute_nproc(0, "0", num_workers=0)
+        assert np == 1
+        assert nn == 1
+
+    def test_default_workers(self):
+        _, nn = compute_nproc(1, "auto")
+        assert nn == 1

--- a/pipelines/training/finetuning/lora/README.md
+++ b/pipelines/training/finetuning/lora/README.md
@@ -92,6 +92,7 @@ A 4-stage ML pipeline for fine-tuning language models with LoRA:
   - External Services:
     - Name: HuggingFace Datasets, Version: >=2.14.0
     - Name: Kubernetes, Version: >=1.28.0
+    - Name: Model Registry, Version: >=0.3.4
 - **Tags**:
   - training
   - fine_tuning

--- a/pipelines/training/finetuning/lora/metadata.yaml
+++ b/pipelines/training/finetuning/lora/metadata.yaml
@@ -11,6 +11,8 @@ dependencies:
       version: ">=2.14.0"
     - name: Kubernetes
       version: ">=1.28.0"
+    - name: Model Registry
+      version: ">=0.3.4"
 tags:
   - training
   - fine_tuning

--- a/pipelines/training/finetuning/lora_minimal/README.md
+++ b/pipelines/training/finetuning/lora_minimal/README.md
@@ -37,6 +37,7 @@ A minimal 4-stage ML pipeline for fine-tuning language models with LoRA:
 | `phase_02_train_opt_lora_load_in_8bit` | `bool` | `False` | [QLoRA] Enable 8-bit quantization (cannot use with 4-bit) |
 | `phase_02_train_opt_runtime` | `str` | `training-hub` | Name of the ClusterTrainingRuntime to use. |
 | `phase_04_registry_opt_port` | `int` | `8080` | Model registry server port |
+| `phase_04_registry_opt_format_version` | `str` | `2.9` | Model format version for registry (default "2.9") |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/finetuning/lora_minimal/pipeline.py
+++ b/pipelines/training/finetuning/lora_minimal/pipeline.py
@@ -18,7 +18,9 @@ from kfp import dsl
 
 # Import reusable components
 from components.data_processing.dataset_download import dataset_download
-from components.deployment.kubeflow_model_registry import kubeflow_model_registry
+from components.deployment.kubeflow_model_registry import (
+    kubeflow_model_registry as model_registry,
+)
 from components.evaluation.lm_eval import universal_llm_evaluator
 from components.training.finetuning.lora import train_model
 
@@ -80,6 +82,7 @@ def lora_minimal_pipeline(
     phase_02_train_opt_lora_load_in_8bit: bool = False,
     phase_02_train_opt_runtime: str = "training-hub",
     phase_04_registry_opt_port: int = 8080,
+    phase_04_registry_opt_format_version: str = "2.9",
 ):
     """LoRA Minimal Training Pipeline - Parameter-efficient fine-tuning.
 
@@ -114,6 +117,7 @@ def lora_minimal_pipeline(
         phase_02_train_opt_lora_load_in_8bit: [QLoRA] Enable 8-bit quantization (cannot use with 4-bit)
         phase_02_train_opt_runtime: Name of the ClusterTrainingRuntime to use.
         phase_04_registry_opt_port: Model registry server port
+        phase_04_registry_opt_format_version: Model format version for registry (default "2.9")
     """
     # =========================================================================
     # Stage 1: Dataset Download
@@ -231,7 +235,7 @@ def lora_minimal_pipeline(
     # =========================================================================
     # Stage 4: Model Registry
     # =========================================================================
-    model_registry_task = kubeflow_model_registry(
+    model_registry_task = model_registry(
         pvc_mount_path=dsl.WORKSPACE_PATH_PLACEHOLDER,
         input_model=training_task.outputs["output_model"],
         input_metrics=training_task.outputs["output_metrics"],
@@ -242,7 +246,7 @@ def lora_minimal_pipeline(
         model_name=phase_04_registry_man_reg_name,
         model_version=phase_04_registry_man_reg_version,
         model_format_name="pytorch",
-        model_format_version="2.9",
+        model_format_version=phase_04_registry_opt_format_version,
         model_description="",
         author="pipeline",
         shared_log_file="pipeline_log.txt",

--- a/pipelines/training/finetuning/osft/README.md
+++ b/pipelines/training/finetuning/osft/README.md
@@ -70,6 +70,7 @@ A 4-stage ML pipeline for fine-tuning language models with OSFT:
   - External Services:
     - Name: HuggingFace Datasets, Version: >=2.14.0
     - Name: Kubernetes, Version: >=1.28.0
+    - Name: Model Registry, Version: >=0.3.4
 - **Tags**:
   - training
   - fine_tuning

--- a/pipelines/training/finetuning/osft/metadata.yaml
+++ b/pipelines/training/finetuning/osft/metadata.yaml
@@ -11,6 +11,8 @@ dependencies:
       version: ">=2.14.0"
     - name: Kubernetes
       version: ">=1.28.0"
+    - name: Model Registry
+      version: ">=0.3.4"
 tags:
   - training
   - fine_tuning

--- a/pipelines/training/finetuning/osft_minimal/README.md
+++ b/pipelines/training/finetuning/osft_minimal/README.md
@@ -33,6 +33,7 @@ A minimal 4-stage ML pipeline for fine-tuning language models with OSFT:
 | `phase_02_train_opt_use_liger` | `bool` | `True` | [OSFT] Enable Liger kernel optimizations. Recommended |
 | `phase_02_train_opt_runtime` | `str` | `training-hub` | Name of the ClusterTrainingRuntime to use. |
 | `phase_04_registry_opt_port` | `int` | `8080` | Model registry server port |
+| `phase_04_registry_opt_format_version` | `str` | `2.9` | Model format version for registry (default "2.9") |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/finetuning/osft_minimal/pipeline.py
+++ b/pipelines/training/finetuning/osft_minimal/pipeline.py
@@ -17,7 +17,9 @@ from kfp import dsl
 
 # Import reusable components
 from components.data_processing.dataset_download import dataset_download
-from components.deployment.kubeflow_model_registry import kubeflow_model_registry
+from components.deployment.kubeflow_model_registry import (
+    kubeflow_model_registry as model_registry,
+)
 from components.evaluation.lm_eval import universal_llm_evaluator
 from components.training.finetuning.osft import train_model
 
@@ -72,6 +74,7 @@ def osft_minimal_pipeline(
     phase_02_train_opt_use_liger: bool = True,
     phase_02_train_opt_runtime: str = "training-hub",
     phase_04_registry_opt_port: int = 8080,
+    phase_04_registry_opt_format_version: str = "2.9",
 ):
     """OSFT Minimal Training Pipeline - Continual learning without catastrophic forgetting.
 
@@ -102,6 +105,7 @@ def osft_minimal_pipeline(
         phase_02_train_opt_use_liger: [OSFT] Enable Liger kernel optimizations. Recommended
         phase_02_train_opt_runtime: Name of the ClusterTrainingRuntime to use.
         phase_04_registry_opt_port: Model registry server port
+        phase_04_registry_opt_format_version: Model format version for registry (default "2.9")
     """
     # =========================================================================
     # Stage 1: Dataset Download
@@ -141,7 +145,6 @@ def osft_minimal_pipeline(
         training_max_tokens_per_gpu=phase_02_train_man_train_tokens,
         training_max_seq_len=phase_02_train_opt_max_seq_len,
         training_learning_rate=phase_02_train_opt_learning_rate,
-        # training_target_patterns=phase_02_train_opt_target_patterns,
         training_seed=42,
         training_num_epochs=phase_02_train_man_train_epochs,
         # OSFT-specific optimizations
@@ -211,7 +214,7 @@ def osft_minimal_pipeline(
     # =========================================================================
     # Stage 4: Model Registry
     # =========================================================================
-    model_registry_task = kubeflow_model_registry(
+    model_registry_task = model_registry(
         pvc_mount_path=dsl.WORKSPACE_PATH_PLACEHOLDER,
         input_model=training_task.outputs["output_model"],
         input_metrics=training_task.outputs["output_metrics"],
@@ -222,7 +225,7 @@ def osft_minimal_pipeline(
         model_name=phase_04_registry_man_reg_name,
         model_version=phase_04_registry_man_reg_version,
         model_format_name="pytorch",
-        model_format_version="2.9",
+        model_format_version=phase_04_registry_opt_format_version,
         model_description="",
         author="pipeline",
         shared_log_file="pipeline_log.txt",

--- a/pipelines/training/finetuning/sft/pipeline.py
+++ b/pipelines/training/finetuning/sft/pipeline.py
@@ -16,7 +16,9 @@ from kfp import dsl
 
 # Import reusable components
 from components.data_processing.dataset_download import dataset_download
-from components.deployment.kubeflow_model_registry import kubeflow_model_registry
+from components.deployment.kubeflow_model_registry import (
+    kubeflow_model_registry as model_registry,
+)
 from components.evaluation.lm_eval import universal_llm_evaluator
 from components.training.finetuning.sft import train_model
 
@@ -261,7 +263,7 @@ def sft_pipeline(
     # =========================================================================
     # Stage 4: Model Registry
     # =========================================================================
-    model_registry_task = kubeflow_model_registry(
+    model_registry_task = model_registry(
         pvc_mount_path=dsl.WORKSPACE_PATH_PLACEHOLDER,
         input_model=training_task.outputs["output_model"],
         input_metrics=training_task.outputs["output_metrics"],

--- a/pipelines/training/finetuning/sft_minimal/README.md
+++ b/pipelines/training/finetuning/sft_minimal/README.md
@@ -27,13 +27,14 @@ A 4-stage ML pipeline for fine-tuning language models:
 | `phase_04_registry_man_reg_name` | `str` | `sft-model` | Model name in registry |
 | `phase_04_registry_man_version` | `str` | `1.0.0` | Semantic version (major.minor.patch) |
 | `phase_01_dataset_opt_subset` | `int` | `0` | Limit to first N examples (0 = all) |
-| `phase_02_train_opt_env_vars` | `str` | `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True, NCCL_DEBUG=INFO, NCCL_P2P_DISABLE=1, INSTRUCTLAB_NCCL_TIMEOUT_MS=60000` | Env vars (KEY=VAL,...) with NCCL timeout and memory optimization |
+| `phase_02_train_opt_env_vars` | `str` | `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True, NCCL_DEBUG=INFO, NCCL_P2P_DISABLE=1, INSTRUCTLAB_NCCL_TIMEOUT_MS=600000` | Env vars (KEY=VAL,...) with NCCL timeout and memory optimization |
 | `phase_02_train_opt_learning_rate` | `float` | `5e-06` | Learning rate (1e-6 to 1e-4). 5e-6 recommended |
 | `phase_02_train_opt_max_seq_len` | `int` | `8192` | Max sequence length in tokens |
 | `phase_02_train_opt_fsdp_sharding` | `str` | `FULL_SHARD` | FSDP strategy (FULL_SHARD, HYBRID_SHARD, NO_SHARD) |
 | `phase_02_train_opt_use_liger` | `bool` | `False` | Enable Liger kernel optimizations |
 | `phase_02_train_opt_runtime` | `str` | `training-hub` | Name of the ClusterTrainingRuntime to use. |
 | `phase_04_registry_opt_port` | `int` | `8080` | Model Registry server port. |
+| `phase_04_registry_opt_format_version` | `str` | `2.9` | Model format version for registry (default "2.9") |
 
 ## Metadata 🗂️
 
@@ -46,6 +47,7 @@ A 4-stage ML pipeline for fine-tuning language models:
   - External Services:
     - Name: HuggingFace Datasets, Version: >=2.14.0
     - Name: Kubernetes, Version: >=1.28.0
+    - Name: Model Registry, Version: >=0.3.4
 - **Tags**:
   - training
   - fine_tuning

--- a/pipelines/training/finetuning/sft_minimal/metadata.yaml
+++ b/pipelines/training/finetuning/sft_minimal/metadata.yaml
@@ -11,6 +11,8 @@ dependencies:
       version: ">=2.14.0"
     - name: Kubernetes
       version: ">=1.28.0"
+    - name: Model Registry
+      version: ">=0.3.4"
 tags:
   - training
   - fine_tuning

--- a/pipelines/training/finetuning/sft_minimal/pipeline.py
+++ b/pipelines/training/finetuning/sft_minimal/pipeline.py
@@ -11,14 +11,9 @@ SFT is the standard approach for adapting pre-trained language models
 to new tasks or domains using labeled training data.
 """
 
-import os
-import sys
-
 import kfp
 import kfp.kubernetes
 from kfp import dsl
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from components.data_processing.dataset_download import dataset_download
 from components.deployment.kubeflow_model_registry import (
@@ -75,7 +70,7 @@ def sft_minimal_pipeline(
     phase_02_train_opt_env_vars: str = (
         "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True, "
         "NCCL_DEBUG=INFO, NCCL_P2P_DISABLE=1, "
-        "INSTRUCTLAB_NCCL_TIMEOUT_MS=60000"
+        "INSTRUCTLAB_NCCL_TIMEOUT_MS=600000"
     ),
     phase_02_train_opt_learning_rate: float = 5e-6,
     phase_02_train_opt_max_seq_len: int = 8192,
@@ -83,6 +78,7 @@ def sft_minimal_pipeline(
     phase_02_train_opt_use_liger: bool = False,
     phase_02_train_opt_runtime: str = "training-hub",
     phase_04_registry_opt_port: int = 8080,
+    phase_04_registry_opt_format_version: str = "2.9",
 ):
     """SFT Training Pipeline - Standard supervised fine-tuning with instructlab-training.
 
@@ -113,6 +109,7 @@ def sft_minimal_pipeline(
         phase_02_train_opt_use_liger: Enable Liger kernel optimizations
         phase_02_train_opt_runtime: Name of the ClusterTrainingRuntime to use.
         phase_04_registry_opt_port: Model Registry server port.
+        phase_04_registry_opt_format_version: Model format version for registry (default "2.9")
     """
     # =========================================================================
     # Stage 1: Dataset Download
@@ -183,6 +180,12 @@ def sft_minimal_pipeline(
         },
         optional=False,
     )
+    kfp.kubernetes.use_secret_as_env(
+        task=training_task,
+        secret_name="oci-pull-secret-model-download",
+        secret_key_to_env={"OCI_PULL_SECRET_MODEL_DOWNLOAD": "OCI_PULL_SECRET_MODEL_DOWNLOAD"},
+        optional=True,
+    )
 
     # =========================================================================
     # Stage 3: Evaluation
@@ -228,7 +231,7 @@ def sft_minimal_pipeline(
         model_name=phase_04_registry_man_reg_name,
         model_version=phase_04_registry_man_version,
         model_format_name="pytorch",
-        model_format_version="2.9",
+        model_format_version=phase_04_registry_opt_format_version,
         model_description="",
         author="pipeline",
         shared_log_file="pipeline_log.txt",


### PR DESCRIPTION
**Description of your changes:**

Security hardening, improved error observability, and significantly expanded unit test
coverage across finetuning components, shared utilities, and training pipelines.

### Security
- **Credential file hardening** (`shared/data.py`): replaced hardcoded `/tmp/skopeo-auth.json`
  with `tempfile.NamedTemporaryFile`, set `0o600` permissions, and ensure cleanup via
  `try/finally` block
- **OCI pull secret support** (`sft_minimal/pipeline.py`): mount `oci-pull-secret-model-download`
  secret as env var for OCI model downloads

### Improved error observability
- **lm_eval**: replace silent `except: pass` with `logger.warning` for prompt logging failures;
  fix `contains_match` to compare full target instead of truncated 50-char prefix
- **shared/output.py**: replace bare `except: pass` with `log.warning` for metrics parsing failures
- **SFT/OSFT docstrings**: document the actual training backend used (`instructlab-training`
  for SFT, `mini-trainer` for OSFT)

### Pipeline improvements
- Add `model_format_version` as a configurable pipeline parameter across LoRA, OSFT, and
  SFT minimal pipelines (previously hardcoded to `"2.9"`)
- Add `Model Registry` dependency to pipeline metadata (lora, osft, sft_minimal)
- Clean up `sft_minimal/pipeline.py`: remove unnecessary `sys.path` hack, increase
  `INSTRUCTLAB_NCCL_TIMEOUT_MS` from 60s to 600s
- Standardize `model_registry` import alias across all pipelines

### Test coverage
- **shared/tests/test_data.py**: +306 lines — full coverage for `_find_hf_model`,
  `_get_oci_auth`, `_skopeo_copy`, `resolve_dataset`, `prepare_jsonl`, `download_oci_model`
- **shared/tests/test_output.py**: new file (+170 lines) — tests for `find_model_dir`,
  `extract_metrics_from_jsonl`, `persist_model`, `plot_training_loss`
- **shared/tests/test_setup.py**: +138 lines — tests for `create_logger`, `parse_kv`,
  `configure_env`, `setup_hf_token`
- **shared/tests/test_training.py**: +100 lines — tests for `safe_int`, `select_runtime`,
  `compute_nproc`
- **Component unit tests** (lora, osft, sft): fix weak/tautological assertions that always passed

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have signed off your commits
- [x] The title for your pull request (PR) follows the title convention

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [x] All required files are present and complete
- [x] OWNERS file lists appropriate maintainers
- [x] README provides clear documentation with usage examples
- [x] Component follows `snake_case` naming convention
- [x] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Model Registry integration to training pipelines with configurable format version parameter.
  * Added optional OCI pull secret support for model downloads during training.

* **Bug Fixes**
  * Fixed evaluation substring matching to check entire target instead of truncated prefix.
  * Improved error logging for metrics parsing and authentication failures (previously silent).
  * Enhanced secure handling of OCI authentication with temporary encrypted files.

* **Improvements**
  * Increased NCCL timeout for SFT training to reduce timeout issues.
  * Enhanced component documentation and backend validation with stricter tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->