### PR TITLE
fix(autorag): prevent "You MUST respond in English" from being injected into prompts

### DIFF
--- a/components/training/autorag/rag_templates_optimization/component.py
+++ b/components/training/autorag/rag_templates_optimization/component.py
@@ -675,7 +675,7 @@ def rag_templates_optimization(
     def _build_system_message(custom_text: str | None, lang: dict | None) -> str:
         """Build system message with explicit language instruction when detected."""
         base = custom_text if custom_text else _DEFAULT_SYSTEM_MSG
-        if not lang:
+        if not lang or lang.get("code") == "en":
             return base
         lang_name = lang.get("name", "")
         if not lang_name:

--- a/components/training/autorag/search_space_preparation/component.py
+++ b/components/training/autorag/search_space_preparation/component.py
@@ -195,8 +195,6 @@ def search_space_preparation(
 
             if not detected_code:
                 return None
-            if detected_code == "en":
-                return {"code": "en", "name": "English"}
 
             name = LANGUAGE_MAP.get(detected_code)
             if not name:


### PR DESCRIPTION
## Summary
  - `_build_system_message` had no English guard — when `detected_language` was
    `{"code": "en", "name": "English"}`, it blindly prepended
    `"You MUST respond in English."` to the system message in `pattern.json`.
    Added `lang.get("code") == "en"` check to skip prompt injection for English.
  - Removed redundant English special-case in `_detect_language_via_llm` —
    `"en"` is already in `LANGUAGE_MAP`, so it now flows through the same
    lookup path as every other language (and gets the info log it was missing).

  ## Details
  
  The multilingual pipeline stores `detected_language` metadata for all languages
  including English. This is intentional — the metadata is useful for logging and
  reporting. However, only non-English languages should trigger explicit prompt
  instructions like `"You MUST respond in {language}."`.
  
  The `_explicit_language_instruction` (deployment) and the foundation model
  injection loop (optimization) both had proper `code != "en"` guards. 
  `_build_system_message` was the one call site that did not, causing English
  benchmarks to get an unnecessary and potentially harmful prompt directive.

### Pre-Submission Checklist

- [ ] All tests and CI checks pass
- [ ] Pre-commit hooks pass without errors
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced multi-language support in RAG system by adding explicit language requirement specifications to system prompts, ensuring clearer handling of non-English language queries
  * Standardized language detection and unified mapping across RAG components to ensure consistent processing of all supported languages without special-case logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->