### PR TITLE
feat(pipleines,component,AutoML): introduce new param preset

### DIFF
--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -50,7 +50,7 @@ mutates predictor state. All artifacts are written under a single output artifac
 - **Tags**:
   - training
   - automl
-- **Last Verified**: 2026-05-20 12:00:00+00:00
+- **Last Verified**: 2026-06-10 12:00:00+00:00
 - **Owners**:
   - No Parent Owners: Yes
   - Approvers:

--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -30,7 +30,8 @@ mutates predictor state. All artifacts are written under a single output artifac
 | `sampling_config` | `Optional[dict]` | `None` | Data sampling config stored in artifact metadata. |
 | `split_config` | `Optional[dict]` | `None` | Data split config stored in artifact metadata. |
 | `extra_train_data_path` | `str` | `""` | Optional path to extra training CSV passed to ``refit_full``. |
-| `positive_class` | `Optional[str]` | `None` | Optional label value for the positive class in **binary** classification (``int`` or ``str``, e.g. ``"1"`` or ``"yes"``). Passed to ``TabularPredictor`` when set. If ``None`` or empty, AutoGluon infers the positive class when ``fit`` runs (see note below). Ignored for ``multiclass`` and ``regression``. |
+| `positive_class` | `str` | `""` | Label value for the positive class in **binary** classification (e.g. ``"1"`` or ``"yes"``). Passed to ``TabularPredictor`` when set. Empty string (default) lets AutoGluon infer the positive class when ``fit`` runs. Ignored for ``multiclass`` and ``regression``. |
+| `preset` | `str` | `medium_quality` | AutoGluon quality tier. ``"medium_quality"`` (default, 30 min) or ``"good_quality"`` (60 min). |
 | `eval_metric` | `str` | `""` | Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults to ``"r2"`` for regression and ``"accuracy"`` otherwise. |
 
 ## Outputs 📤

--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -31,7 +31,7 @@ mutates predictor state. All artifacts are written under a single output artifac
 | `split_config` | `Optional[dict]` | `None` | Data split config stored in artifact metadata. |
 | `extra_train_data_path` | `str` | `""` | Optional path to extra training CSV passed to ``refit_full``. |
 | `positive_class` | `str` | `""` | Label value for the positive class in **binary** classification (e.g. ``"1"`` or ``"yes"``). Passed to ``TabularPredictor`` when set. Empty string (default) lets AutoGluon infer the positive class when ``fit`` runs. Ignored for ``multiclass`` and ``regression``. |
-| `preset` | `str` | `speed` | Training quality tier. ``"speed"`` (default, 45-min time limit) or ``"balanced"`` (90-min time limit). |
+| `preset` | `str` | `speed` | Training quality tier. ``"speed"`` (default) or ``"balanced"`` (may run more than 2x longer). |
 | `eval_metric` | `str` | `""` | Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults to ``"r2"`` for regression and ``"accuracy"`` otherwise. |
 
 ## Outputs 📤

--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -31,7 +31,7 @@ mutates predictor state. All artifacts are written under a single output artifac
 | `split_config` | `Optional[dict]` | `None` | Data split config stored in artifact metadata. |
 | `extra_train_data_path` | `str` | `""` | Optional path to extra training CSV passed to ``refit_full``. |
 | `positive_class` | `str` | `""` | Label value for the positive class in **binary** classification (e.g. ``"1"`` or ``"yes"``). Passed to ``TabularPredictor`` when set. Empty string (default) lets AutoGluon infer the positive class when ``fit`` runs. Ignored for ``multiclass`` and ``regression``. |
-| `preset` | `str` | `good_quality` | AutoGluon quality tier. ``"good_quality"`` (default, 1-hour time limit) or ``"high_quality"`` (2-hour time limit). |
+| `preset` | `str` | `speed` | Training quality tier. ``"speed"`` (default, 45-min time limit) or ``"balanced"`` (90-min time limit). |
 | `eval_metric` | `str` | `""` | Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults to ``"r2"`` for regression and ``"accuracy"`` otherwise. |
 
 ## Outputs 📤

--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -31,7 +31,7 @@ mutates predictor state. All artifacts are written under a single output artifac
 | `split_config` | `Optional[dict]` | `None` | Data split config stored in artifact metadata. |
 | `extra_train_data_path` | `str` | `""` | Optional path to extra training CSV passed to ``refit_full``. |
 | `positive_class` | `str` | `""` | Label value for the positive class in **binary** classification (e.g. ``"1"`` or ``"yes"``). Passed to ``TabularPredictor`` when set. Empty string (default) lets AutoGluon infer the positive class when ``fit`` runs. Ignored for ``multiclass`` and ``regression``. |
-| `preset` | `str` | `medium_quality` | AutoGluon quality tier. ``"medium_quality"`` (default, 30 min) or ``"good_quality"`` (60 min). |
+| `preset` | `str` | `good_quality` | AutoGluon quality tier. ``"good_quality"`` (default, 1-hour time limit) or ``"high_quality"`` (2-hour time limit). |
 | `eval_metric` | `str` | `""` | Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults to ``"r2"`` for regression and ``"accuracy"`` otherwise. |
 
 ## Outputs 📤

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -22,7 +22,8 @@ def autogluon_models_training(
     sampling_config: Optional[dict] = None,
     split_config: Optional[dict] = None,
     extra_train_data_path: str = "",
-    positive_class: Optional[str] = None,
+    positive_class: str = "",
+    preset: str = "medium_quality",
     eval_metric: str = "",
 ) -> NamedTuple("outputs", eval_metric=str):
     """Train AutoGluon models, select the top N, and refit each on the full dataset.
@@ -58,10 +59,11 @@ def autogluon_models_training(
         sampling_config: Data sampling config stored in artifact metadata.
         split_config: Data split config stored in artifact metadata.
         extra_train_data_path: Optional path to extra training CSV passed to ``refit_full``.
-        positive_class: Optional label value for the positive class in **binary** classification
-            (``int`` or ``str``, e.g. ``"1"`` or ``"yes"``). Passed to ``TabularPredictor`` when set.
-            If ``None`` or empty, AutoGluon infers the positive class when ``fit`` runs (see note below).
+        positive_class: Label value for the positive class in **binary** classification
+            (e.g. ``"1"`` or ``"yes"``). Passed to ``TabularPredictor`` when set.
+            Empty string (default) lets AutoGluon infer the positive class when ``fit`` runs.
             Ignored for ``multiclass`` and ``regression``.
+        preset: AutoGluon quality tier. ``"medium_quality"`` (default, 30 min) or ``"good_quality"`` (60 min).
         eval_metric: Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults
             to ``"r2"`` for regression and ``"accuracy"`` otherwise.
 
@@ -92,6 +94,7 @@ def autogluon_models_training(
     from autogluon.tabular import TabularPredictor
 
     VALID_TASK_TYPES = {"binary", "multiclass", "regression"}
+    VALID_PRESETS = {"medium_quality", "good_quality"}
     TOP_N_MAX = 10
 
     # Input parameters validation
@@ -99,6 +102,8 @@ def autogluon_models_training(
         raise TypeError("label_column must be a non-empty string.")
     if task_type not in VALID_TASK_TYPES:
         raise ValueError(f"task_type must be one of {VALID_TASK_TYPES}; got {task_type!r}.")
+    if preset not in VALID_PRESETS:
+        raise ValueError(f"preset must be one of {VALID_PRESETS}; got {preset!r}.")
     if not train_data_path or not isinstance(train_data_path, str) or not train_data_path.strip():
         raise TypeError("train_data_path must be a non-empty string.")
     if not workspace_path or not isinstance(workspace_path, str) or not workspace_path.strip():
@@ -116,8 +121,7 @@ def autogluon_models_training(
         raise TypeError("sampling_config must be a dictionary or None.")
     if split_config is not None and not isinstance(split_config, dict):
         raise TypeError("split_config must be a dictionary or None.")
-    if positive_class is not None and not isinstance(positive_class, str):
-        raise TypeError("positive_class must be a string or None.")
+
     if eval_metric and not eval_metric.strip():
         raise TypeError("eval_metric must be a non-empty string (or empty string '' to use the task-type default).")
     if eval_metric and eval_metric not in METRICS.get(task_type, {}):
@@ -157,9 +161,6 @@ def autogluon_models_training(
     with status:
         # Stage: load_data
         status.record("load_data", "started")
-
-        DEFAULT_PRESET = "medium_quality"
-        DEFAULT_TIME_LIMIT = 30 * 60  # 30 minutes
 
         # 1. models selection stage
 
@@ -228,15 +229,39 @@ def autogluon_models_training(
             )
 
         status.record("model_selection", "started")
-        predictor = TabularPredictor(**predictor_init_kwargs).fit(
-            train_data=train_data_df,
-            num_stack_levels=1,
-            num_bag_folds=4,
-            use_bag_holdout=True,
-            holdout_frac=0.2,
-            time_limit=DEFAULT_TIME_LIMIT,
-            presets=DEFAULT_PRESET,
-        )
+        predictor = TabularPredictor(**predictor_init_kwargs)
+        if preset == "good_quality":
+            time_limit = 60 * 60  # 60 minutes - extend for good_quality
+            predictor = predictor.fit(
+                train_data=train_data_df,
+                presets=preset,
+                # Pipeline handles refit explicitly via refit_full(); disable AutoGluon's built-in refit
+                # to prevent double-refit and incorrect model selection.
+                refit_full=False,
+                set_best_to_refit_full=False,
+                # Required so refit_full() can access bag fold models after fit().
+                save_bag_folds=True,
+                time_limit=time_limit,
+            )
+        else:
+            import copy
+
+            from autogluon.tabular.configs.hyperparameter_configs import get_hyperparameter_config
+
+            time_limit = 30 * 60  # 30 minutes
+            RF_XT_MAX_DEPTH = 10
+            hyperparams = copy.deepcopy(get_hyperparameter_config("default"))
+            for model_type in ("RF", "XT"):
+                for config in hyperparams.get(model_type, []):
+                    config["max_depth"] = RF_XT_MAX_DEPTH
+            predictor = predictor.fit(
+                train_data=train_data_df,
+                use_bag_holdout=True,
+                holdout_frac=0.2,
+                time_limit=time_limit,
+                presets=preset,
+                hyperparameters=hyperparams,
+            )
 
         # Select top N models
         leaderboard = predictor.leaderboard(test_data_df)
@@ -251,9 +276,9 @@ def autogluon_models_training(
         )
 
         model_config = {
-            "preset": DEFAULT_PRESET,
+            "preset": preset,
             "eval_metric": eval_metric,
-            "time_limit": DEFAULT_TIME_LIMIT,
+            "time_limit": time_limit,
         }
 
         def retrieve_pipeline_name(name: str) -> str:

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -23,7 +23,7 @@ def autogluon_models_training(
     split_config: Optional[dict] = None,
     extra_train_data_path: str = "",
     positive_class: str = "",
-    preset: str = "good_quality",
+    preset: str = "speed",
     eval_metric: str = "",
 ) -> NamedTuple("outputs", eval_metric=str):
     """Train AutoGluon models, select the top N, and refit each on the full dataset.
@@ -63,8 +63,8 @@ def autogluon_models_training(
             (e.g. ``"1"`` or ``"yes"``). Passed to ``TabularPredictor`` when set.
             Empty string (default) lets AutoGluon infer the positive class when ``fit`` runs.
             Ignored for ``multiclass`` and ``regression``.
-        preset: AutoGluon quality tier. ``"good_quality"`` (default, 1-hour time limit) or
-            ``"high_quality"`` (2-hour time limit).
+        preset: Training quality tier. ``"speed"`` (default, 45-min time limit) or
+            ``"balanced"`` (90-min time limit).
         eval_metric: Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults
             to ``"r2"`` for regression and ``"accuracy"`` otherwise.
 
@@ -95,8 +95,9 @@ def autogluon_models_training(
     from autogluon.tabular import TabularPredictor
 
     VALID_TASK_TYPES = {"binary", "multiclass", "regression"}
-    VALID_PRESETS = {"good_quality", "high_quality"}
-    PRESET_TIME_LIMITS = {"good_quality": 60 * 60, "high_quality": 2 * 60 * 60}
+    VALID_PRESETS = {"speed", "balanced"}
+    PRESET_TIME_LIMITS = {"speed": 45 * 60, "balanced": 90 * 60}
+    PRESET_AG_NAMES = {"speed": "good_quality", "balanced": "high_quality"}
     TOP_N_MAX = 10
 
     # Input parameters validation
@@ -234,7 +235,7 @@ def autogluon_models_training(
         time_limit = PRESET_TIME_LIMITS[preset]
         predictor = TabularPredictor(**predictor_init_kwargs).fit(
             train_data=train_data_df,
-            presets=preset,
+            presets=PRESET_AG_NAMES[preset],
             # Pipeline handles refit explicitly via refit_full(); disable AutoGluon's built-in refit
             # to prevent double-refit and incorrect model selection.
             refit_full=False,

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -63,8 +63,8 @@ def autogluon_models_training(
             (e.g. ``"1"`` or ``"yes"``). Passed to ``TabularPredictor`` when set.
             Empty string (default) lets AutoGluon infer the positive class when ``fit`` runs.
             Ignored for ``multiclass`` and ``regression``.
-        preset: Training quality tier. ``"speed"`` (default, 45-min time limit) or
-            ``"balanced"`` (90-min time limit).
+        preset: Training quality tier. ``"speed"`` (default) or ``"balanced"``
+            (may run more than 2x longer).
         eval_metric: Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults
             to ``"r2"`` for regression and ``"accuracy"`` otherwise.
 

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -23,7 +23,7 @@ def autogluon_models_training(
     split_config: Optional[dict] = None,
     extra_train_data_path: str = "",
     positive_class: str = "",
-    preset: str = "medium_quality",
+    preset: str = "good_quality",
     eval_metric: str = "",
 ) -> NamedTuple("outputs", eval_metric=str):
     """Train AutoGluon models, select the top N, and refit each on the full dataset.
@@ -63,7 +63,8 @@ def autogluon_models_training(
             (e.g. ``"1"`` or ``"yes"``). Passed to ``TabularPredictor`` when set.
             Empty string (default) lets AutoGluon infer the positive class when ``fit`` runs.
             Ignored for ``multiclass`` and ``regression``.
-        preset: AutoGluon quality tier. ``"medium_quality"`` (default, 30 min) or ``"good_quality"`` (60 min).
+        preset: AutoGluon quality tier. ``"good_quality"`` (default, 1-hour time limit) or
+            ``"high_quality"`` (2-hour time limit).
         eval_metric: Metric for model ranking (e.g. ``"r2"``, ``"accuracy"``). Defaults
             to ``"r2"`` for regression and ``"accuracy"`` otherwise.
 
@@ -228,40 +229,29 @@ def autogluon_models_training(
                 "classes ['abc', 'def'] -> positive_class='def')."
             )
 
-        status.record("model_selection", "started")
+        VALID_PRESETS = {"good_quality", "high_quality"}
+        PRESET_TIME_LIMITS = {
+            "good_quality": 45 * 60,  # 45 minutes
+            "high_quality": 90 * 60,  # 90 minutes
+        }
+        if preset not in VALID_PRESETS:
+            raise ValueError(f"preset must be one of {VALID_PRESETS}; got {preset!r}.")
+        time_limit = PRESET_TIME_LIMITS[preset]
+
         predictor = TabularPredictor(**predictor_init_kwargs)
-        if preset == "good_quality":
-            time_limit = 60 * 60  # 60 minutes - extend for good_quality
-            predictor = predictor.fit(
-                train_data=train_data_df,
-                presets=preset,
-                # Pipeline handles refit explicitly via refit_full(); disable AutoGluon's built-in refit
-                # to prevent double-refit and incorrect model selection.
-                refit_full=False,
-                set_best_to_refit_full=False,
-                # Required so refit_full() can access bag fold models after fit().
-                save_bag_folds=True,
-                time_limit=time_limit,
-            )
-        else:
-            import copy
+        predictor = predictor.fit(
+            train_data=train_data_df,
+            presets=preset,
+            # Pipeline handles refit explicitly via refit_full(); disable AutoGluon's built-in refit
+            # to prevent double-refit and incorrect model selection.
+            refit_full=False,
+            set_best_to_refit_full=False,
+            # Required so refit_full() can access bag fold models after fit().
+            save_bag_folds=True,
+            time_limit=time_limit,
+        )
 
-            from autogluon.tabular.configs.hyperparameter_configs import get_hyperparameter_config
-
-            time_limit = 30 * 60  # 30 minutes
-            RF_XT_MAX_DEPTH = 10
-            hyperparams = copy.deepcopy(get_hyperparameter_config("default"))
-            for model_type in ("RF", "XT"):
-                for config in hyperparams.get(model_type, []):
-                    config["max_depth"] = RF_XT_MAX_DEPTH
-            predictor = predictor.fit(
-                train_data=train_data_df,
-                use_bag_holdout=True,
-                holdout_frac=0.2,
-                time_limit=time_limit,
-                presets=preset,
-                hyperparameters=hyperparams,
-            )
+        status.record("model_selection", "started")
 
         # Select top N models
         leaderboard = predictor.leaderboard(test_data_df)

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -95,7 +95,8 @@ def autogluon_models_training(
     from autogluon.tabular import TabularPredictor
 
     VALID_TASK_TYPES = {"binary", "multiclass", "regression"}
-    VALID_PRESETS = {"medium_quality", "good_quality"}
+    VALID_PRESETS = {"good_quality", "high_quality"}
+    PRESET_TIME_LIMITS = {"good_quality": 60 * 60, "high_quality": 2 * 60 * 60}
     TOP_N_MAX = 10
 
     # Input parameters validation
@@ -229,17 +230,9 @@ def autogluon_models_training(
                 "classes ['abc', 'def'] -> positive_class='def')."
             )
 
-        VALID_PRESETS = {"good_quality", "high_quality"}
-        PRESET_TIME_LIMITS = {
-            "good_quality": 45 * 60,  # 45 minutes
-            "high_quality": 90 * 60,  # 90 minutes
-        }
-        if preset not in VALID_PRESETS:
-            raise ValueError(f"preset must be one of {VALID_PRESETS}; got {preset!r}.")
+        status.record("model_selection", "started")
         time_limit = PRESET_TIME_LIMITS[preset]
-
-        predictor = TabularPredictor(**predictor_init_kwargs)
-        predictor = predictor.fit(
+        predictor = TabularPredictor(**predictor_init_kwargs).fit(
             train_data=train_data_df,
             presets=preset,
             # Pipeline handles refit explicitly via refit_full(); disable AutoGluon's built-in refit
@@ -250,8 +243,6 @@ def autogluon_models_training(
             save_bag_folds=True,
             time_limit=time_limit,
         )
-
-        status.record("model_selection", "started")
 
         # Select top N models
         leaderboard = predictor.leaderboard(test_data_df)

--- a/components/training/automl/autogluon_models_training/metadata.yaml
+++ b/components/training/automl/autogluon_models_training/metadata.yaml
@@ -8,4 +8,4 @@ dependencies:
 tags:
   - training
   - automl
-lastVerified: 2026-05-20T12:00:00Z
+lastVerified: 2026-06-10T12:00:00Z

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -23,11 +23,21 @@ def isolated_sys_modules():
         _ag.__path__ = []
         _ag.__spec__ = None
         mocked_modules["autogluon"] = _ag
-        for sub in ("autogluon.tabular", "autogluon.core", "autogluon.core.metrics"):
+        for sub in (
+            "autogluon.tabular",
+            "autogluon.tabular.configs",
+            "autogluon.tabular.configs.hyperparameter_configs",
+            "autogluon.core",
+            "autogluon.core.metrics",
+        ):
             _m = mock.MagicMock()
             _m.__spec__ = None
-            if sub == "autogluon.core":
+            if sub in ("autogluon.tabular", "autogluon.tabular.configs", "autogluon.core"):
                 _m.__path__ = []
+            if sub == "autogluon.tabular.configs.hyperparameter_configs":
+                _m.get_hyperparameter_config = mock.MagicMock(
+                    return_value={"RF": [{"max_depth": None}], "XT": [{"max_depth": None}]}
+                )
             if sub == "autogluon.core.metrics":
                 _m.METRICS = {
                     "binary": {
@@ -288,15 +298,13 @@ class TestAutogluonModelsTrainingUnitTests:
             path=Path(workspace_path) / "autogluon_predictor",
             verbosity=2,
         )
-        mock_predictor_class.return_value.fit.assert_called_once_with(
-            train_data=mock_train_df,
-            num_stack_levels=1,
-            num_bag_folds=4,
-            use_bag_holdout=True,
-            holdout_frac=0.2,
-            time_limit=1800,
-            presets="medium_quality",
-        )
+        fit_call = mock_predictor_class.return_value.fit.call_args
+        assert fit_call[1]["train_data"] is mock_train_df
+        assert fit_call[1]["presets"] == "medium_quality"
+        assert fit_call[1]["use_bag_holdout"] is True
+        assert fit_call[1]["holdout_frac"] == 0.2
+        assert fit_call[1]["time_limit"] == 1800
+        assert "hyperparameters" in fit_call[1]
 
         # read_csv: train, test, extra
         assert mock_read_csv.call_count == 3
@@ -380,6 +388,59 @@ class TestAutogluonModelsTrainingUnitTests:
             # label column stripped from sample row
             assert "feature1" in nb_text
             assert "'target'" not in nb_text
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_good_quality_preset_fit_args(self, mock_predictor_class, mock_read_csv, tmp_path):
+        """good_quality preset uses 60-min time limit and specific fit args (no hyperparams override)."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        mock_predictor.eval_metric = "r2"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"r2": 0.9}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+
+        mock_train_df, mock_test_df = _mock_csv_frame(), _mock_csv_frame()
+        mock_read_csv.side_effect = [mock_train_df, mock_test_df]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        autogluon_models_training.python_func(
+            label_column="target",
+            task_type="regression",
+            top_n=1,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            preset="good_quality",
+        )
+
+        fit_call = mock_predictor_class.return_value.fit.call_args
+        assert fit_call[1]["presets"] == "good_quality"
+        assert fit_call[1]["time_limit"] == 3600
+        assert fit_call[1]["refit_full"] is False
+        assert fit_call[1]["set_best_to_refit_full"] is False
+        assert fit_call[1]["save_bag_folds"] is True
+        assert "hyperparameters" not in fit_call[1]
+
+        context = mock_models_artifact.metadata["context"]
+        assert context["model_config"]["preset"] == "good_quality"
+        assert context["model_config"]["time_limit"] == 3600
 
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.tabular.TabularPredictor")
@@ -1310,6 +1371,23 @@ class TestAutogluonModelsTrainingUnitTests:
                 sample_row=SAMPLE_ROW,
                 models_artifact=self._minimal_artifact(),
                 split_config=[],
+            )
+
+    def test_rejects_invalid_preset(self):
+        """Reject unknown preset value."""
+        with pytest.raises(ValueError, match="preset must be one of"):
+            autogluon_models_training.python_func(
+                label_column="target",
+                task_type="regression",
+                top_n=1,
+                train_data_path="/tmp/train.csv",
+                test_data=mock.MagicMock(path="/tmp/test.csv"),
+                workspace_path="/tmp/ws",
+                pipeline_name=PIPELINE_NAME,
+                run_id=RUN_ID,
+                sample_row=SAMPLE_ROW,
+                models_artifact=self._minimal_artifact(),
+                preset="best_quality",
             )
 
     def test_rejects_whitespace_eval_metric(self):

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -301,7 +301,7 @@ class TestAutogluonModelsTrainingUnitTests:
         fit_call = mock_predictor_class.return_value.fit.call_args
         assert fit_call[1]["train_data"] is mock_train_df
         assert fit_call[1]["presets"] == "good_quality"
-        assert fit_call[1]["time_limit"] == 3600
+        assert fit_call[1]["time_limit"] == 45 * 60
         assert fit_call[1]["refit_full"] is False
         assert fit_call[1]["set_best_to_refit_full"] is False
         assert fit_call[1]["save_bag_folds"] is True
@@ -392,8 +392,8 @@ class TestAutogluonModelsTrainingUnitTests:
 
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.tabular.TabularPredictor")
-    def test_good_quality_preset_fit_args(self, mock_predictor_class, mock_read_csv, tmp_path):
-        """good_quality preset uses 1-hour time limit and the same fit args as all presets."""
+    def test_speed_preset_fit_args(self, mock_predictor_class, mock_read_csv, tmp_path):
+        """Speed preset uses 1-hour time limit and the original fit args."""
         mock_predictor = mock.MagicMock()
         mock_predictor_clone = mock.MagicMock()
         mock_predictor_class.return_value.fit.return_value = mock_predictor
@@ -428,20 +428,20 @@ class TestAutogluonModelsTrainingUnitTests:
             run_id=RUN_ID,
             sample_row=SAMPLE_ROW,
             models_artifact=mock_models_artifact,
-            preset="good_quality",
+            preset="speed",
         )
 
         fit_call = mock_predictor_class.return_value.fit.call_args
-        assert fit_call[1]["presets"] == "good_quality"
-        assert fit_call[1]["time_limit"] == 3600
+        assert fit_call[1]["presets"] == "good_quality"  # AG internal name
+        assert fit_call[1]["time_limit"] == 45 * 60
         assert fit_call[1]["refit_full"] is False
         assert fit_call[1]["set_best_to_refit_full"] is False
         assert fit_call[1]["save_bag_folds"] is True
         assert "hyperparameters" not in fit_call[1]
 
         context = mock_models_artifact.metadata["context"]
-        assert context["model_config"]["preset"] == "good_quality"
-        assert context["model_config"]["time_limit"] == 3600
+        assert context["model_config"]["preset"] == "speed"
+        assert context["model_config"]["time_limit"] == 45 * 60
 
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.tabular.TabularPredictor")

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -300,11 +300,12 @@ class TestAutogluonModelsTrainingUnitTests:
         )
         fit_call = mock_predictor_class.return_value.fit.call_args
         assert fit_call[1]["train_data"] is mock_train_df
-        assert fit_call[1]["presets"] == "medium_quality"
-        assert fit_call[1]["use_bag_holdout"] is True
-        assert fit_call[1]["holdout_frac"] == 0.2
-        assert fit_call[1]["time_limit"] == 1800
-        assert "hyperparameters" in fit_call[1]
+        assert fit_call[1]["presets"] == "good_quality"
+        assert fit_call[1]["time_limit"] == 3600
+        assert fit_call[1]["refit_full"] is False
+        assert fit_call[1]["set_best_to_refit_full"] is False
+        assert fit_call[1]["save_bag_folds"] is True
+        assert "hyperparameters" not in fit_call[1]
 
         # read_csv: train, test, extra
         assert mock_read_csv.call_count == 3
@@ -392,7 +393,7 @@ class TestAutogluonModelsTrainingUnitTests:
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.tabular.TabularPredictor")
     def test_good_quality_preset_fit_args(self, mock_predictor_class, mock_read_csv, tmp_path):
-        """good_quality preset uses 60-min time limit and specific fit args (no hyperparams override)."""
+        """good_quality preset uses 1-hour time limit and the same fit args as all presets."""
         mock_predictor = mock.MagicMock()
         mock_predictor_clone = mock.MagicMock()
         mock_predictor_class.return_value.fit.return_value = mock_predictor

--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -32,7 +32,7 @@ Refit outputs for all selected models are written under one ``models_artifact`` 
 | `split_config` | `Optional[dict]` | `None` | Optional split config stored in artifact metadata. |
 | `prediction_length` | `int` | `1` | Forecast horizon (number of timesteps). |
 | `known_covariates_names` | `Optional[List[str]]` | `None` | Optional list of known covariate column names. |
-| `preset` | `str` | `fast_training` | AutoGluon quality tier. ``"fast_training"`` (default, 10 min) or ``"medium_quality"`` (60 min). |
+| `preset` | `str` | `speed` | Training quality tier. ``"speed"`` (default, 10 min) or ``"balanced"`` (60 min). |
 | `eval_metric` | `str` | `MASE` | Metric for model ranking (e.g. ``"MASE"``, ``"WQL"``). Defaults to ``"MASE"``. |
 
 ## Outputs 📤

--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -32,6 +32,7 @@ Refit outputs for all selected models are written under one ``models_artifact`` 
 | `split_config` | `Optional[dict]` | `None` | Optional split config stored in artifact metadata. |
 | `prediction_length` | `int` | `1` | Forecast horizon (number of timesteps). |
 | `known_covariates_names` | `Optional[List[str]]` | `None` | Optional list of known covariate column names. |
+| `preset` | `str` | `fast_training` | AutoGluon quality tier. ``"fast_training"`` (default, 10 min) or ``"medium_quality"`` (60 min). |
 | `eval_metric` | `str` | `MASE` | Metric for model ranking (e.g. ``"MASE"``, ``"WQL"``). Defaults to ``"MASE"``. |
 
 ## Outputs 📤

--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -111,7 +111,7 @@ def example_pipeline(
   - timeseries
   - automl
   - model-selection
-- **Last Verified**: 2026-05-27 12:00:00+00:00
+- **Last Verified**: 2026-06-10 12:00:00+00:00
 - **Owners**:
   - No Parent Owners: Yes
   - Approvers:

--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -32,7 +32,7 @@ Refit outputs for all selected models are written under one ``models_artifact`` 
 | `split_config` | `Optional[dict]` | `None` | Optional split config stored in artifact metadata. |
 | `prediction_length` | `int` | `1` | Forecast horizon (number of timesteps). |
 | `known_covariates_names` | `Optional[List[str]]` | `None` | Optional list of known covariate column names. |
-| `preset` | `str` | `speed` | Training quality tier. ``"speed"`` (default, 10 min) or ``"balanced"`` (60 min). |
+| `preset` | `str` | `speed` | Training quality tier. ``"speed"`` (default) or ``"balanced"`` (may run more than 2x longer). |
 | `eval_metric` | `str` | `MASE` | Metric for model ranking (e.g. ``"MASE"``, ``"WQL"``). Defaults to ``"MASE"``. |
 
 ## Outputs 📤

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -62,7 +62,8 @@ def autogluon_timeseries_models_training(
         prediction_length: Forecast horizon (number of timesteps).
         known_covariates_names: Optional list of known covariate column names.
         component_status: Output artifact containing stage-level progress tracking for this component.
-        preset: Training quality tier. ``"speed"`` (default, 10 min) or ``"balanced"`` (60 min).
+        preset: Training quality tier. ``"speed"`` (default) or ``"balanced"``
+            (may run more than 2x longer).
         eval_metric: Metric for model ranking (e.g. ``"MASE"``, ``"WQL"``). Defaults to ``"MASE"``.
 
     Returns:

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -25,6 +25,7 @@ def autogluon_timeseries_models_training(
     split_config: Optional[dict] = None,
     prediction_length: int = 1,
     known_covariates_names: Optional[List[str]] = None,
+    preset: str = "fast_training",
     eval_metric: str = "MASE",
 ) -> NamedTuple(
     "outputs",
@@ -61,6 +62,7 @@ def autogluon_timeseries_models_training(
         prediction_length: Forecast horizon (number of timesteps).
         known_covariates_names: Optional list of known covariate column names.
         component_status: Output artifact containing stage-level progress tracking for this component.
+        preset: AutoGluon quality tier. ``"fast_training"`` (default, 10 min) or ``"medium_quality"`` (60 min).
         eval_metric: Metric for model ranking (e.g. ``"MASE"``, ``"WQL"``). Defaults to ``"MASE"``.
 
     Returns:
@@ -87,10 +89,12 @@ def autogluon_timeseries_models_training(
     status = ComponentStatusTracker(component_status.path, "autogluon_timeseries_models_training")
     with status:
         TOP_N_MAX = 7
-        DEFAULT_PRESETS = "fast_training"
-        DEFAULT_TIME_LIMIT = 600  # 10 minutes
+        VALID_PRESETS = {"fast_training", "medium_quality"}
+        time_limit = 3600 if preset == "medium_quality" else 600
 
         # Input validation
+        if preset not in VALID_PRESETS:
+            raise ValueError(f"preset must be one of {VALID_PRESETS}; got {preset!r}.")
         for param, value in (
             ("target", target),
             ("id_column", id_column),
@@ -182,16 +186,16 @@ def autogluon_timeseries_models_training(
 
         logger.info(
             "Timeseries selection: training (preset=%s, time_limit=%ss, prediction_length=%s)...",
-            DEFAULT_PRESETS,
-            DEFAULT_TIME_LIMIT,
+            preset,
+            time_limit,
             prediction_length,
         )
         status.record("model_selection", "started")
         try:
             predictor.fit(
                 train_data=train_ts,
-                presets=DEFAULT_PRESETS,
-                time_limit=DEFAULT_TIME_LIMIT,
+                presets=preset,
+                time_limit=time_limit,
                 # exclude deep learning models pretrained on large time series datasets
                 excluded_model_types=["Chronos", "Toto", "Chronos2"],
             )
@@ -232,8 +236,8 @@ def autogluon_timeseries_models_training(
             "target": target,
             "id_column": id_column,
             "timestamp_column": timestamp_column,
-            "presets": DEFAULT_PRESETS,
-            "time_limit": DEFAULT_TIME_LIMIT,
+            "presets": preset,
+            "time_limit": time_limit,
             "known_covariates_names": known_covariates_names or [],
             "num_models_trained": len(leaderboard),
         }
@@ -329,7 +333,7 @@ def autogluon_timeseries_models_training(
                 predictor_refit.fit(
                     train_data=full_train_ts_df,
                     **additional_fit_params,
-                    time_limit=DEFAULT_TIME_LIMIT,
+                    time_limit=time_limit,
                     excluded_model_types=["Chronos", "Chronos2", "Toto"],
                 )
                 metrics = predictor_refit.evaluate(test_ts, metrics=list(AVAILABLE_METRICS.keys()))

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -25,7 +25,7 @@ def autogluon_timeseries_models_training(
     split_config: Optional[dict] = None,
     prediction_length: int = 1,
     known_covariates_names: Optional[List[str]] = None,
-    preset: str = "fast_training",
+    preset: str = "speed",
     eval_metric: str = "MASE",
 ) -> NamedTuple(
     "outputs",
@@ -62,7 +62,7 @@ def autogluon_timeseries_models_training(
         prediction_length: Forecast horizon (number of timesteps).
         known_covariates_names: Optional list of known covariate column names.
         component_status: Output artifact containing stage-level progress tracking for this component.
-        preset: AutoGluon quality tier. ``"fast_training"`` (default, 10 min) or ``"medium_quality"`` (60 min).
+        preset: Training quality tier. ``"speed"`` (default, 10 min) or ``"balanced"`` (60 min).
         eval_metric: Metric for model ranking (e.g. ``"MASE"``, ``"WQL"``). Defaults to ``"MASE"``.
 
     Returns:
@@ -89,8 +89,9 @@ def autogluon_timeseries_models_training(
     status = ComponentStatusTracker(component_status.path, "autogluon_timeseries_models_training")
     with status:
         TOP_N_MAX = 7
-        VALID_PRESETS = {"fast_training", "medium_quality"}
-        time_limit = 60 * 60 if preset == "medium_quality" else 10 * 60
+        VALID_PRESETS = {"speed", "balanced"}
+        PRESET_AG_NAMES = {"speed": "fast_training", "balanced": "medium_quality"}
+        PRESET_TIME_LIMITS = {"speed": 10 * 60, "balanced": 60 * 60}
 
         # Input validation
         if preset not in VALID_PRESETS:
@@ -141,6 +142,7 @@ def autogluon_timeseries_models_training(
             raise TypeError("split_config must be a dictionary or None.")
         sampling_config = sampling_config or {}
         split_config = split_config or {}
+        time_limit = PRESET_TIME_LIMITS[preset]
 
         status.record("load_data", "started")
         train_df = pd.read_csv(train_data_path)
@@ -194,7 +196,7 @@ def autogluon_timeseries_models_training(
         try:
             predictor.fit(
                 train_data=train_ts,
-                presets=preset,
+                presets=PRESET_AG_NAMES[preset],
                 time_limit=time_limit,
                 # exclude deep learning models pretrained on large time series datasets
                 excluded_model_types=["Chronos", "Toto", "Chronos2"],

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -90,7 +90,7 @@ def autogluon_timeseries_models_training(
     with status:
         TOP_N_MAX = 7
         VALID_PRESETS = {"fast_training", "medium_quality"}
-        time_limit = 3600 if preset == "medium_quality" else 600
+        time_limit = 60 * 60 if preset == "medium_quality" else 10 * 60
 
         # Input validation
         if preset not in VALID_PRESETS:

--- a/components/training/automl/autogluon_timeseries_models_training/metadata.yaml
+++ b/components/training/automl/autogluon_timeseries_models_training/metadata.yaml
@@ -10,4 +10,4 @@ tags:
   - timeseries
   - automl
   - model-selection
-lastVerified: 2026-05-27T12:00:00Z
+lastVerified: 2026-06-10T12:00:00Z

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -163,7 +163,7 @@ class TestTimeseriesModelsTrainingUnitTests:
         assert result.eval_metric == "MASE"
         assert result.predictor_path == "/tmp/workspace/timeseries_predictor"
         assert result.model_config["prediction_length"] == 24
-        assert result.model_config["presets"] == "fast_training"
+        assert result.model_config["presets"] == "speed"
         assert result.model_config["time_limit"] == 600
         assert result.model_config["known_covariates_names"] == []
         assert result.model_config["num_models_trained"] == 3

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -330,6 +330,27 @@ class TestTimeseriesModelsTrainingUnitTests:
                 prediction_length=0,
             )
 
+    def test_rejects_invalid_preset(self, mock_artifacts):
+        """Preset must be one of the valid AutoGluon quality tiers."""
+        models_artifact, extra_train_path = mock_artifacts
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+        with pytest.raises(ValueError, match="preset must be one of"):
+            autogluon_timeseries_models_training.python_func(
+                target="sales",
+                id_column="item_id",
+                timestamp_column="timestamp",
+                train_data_path="/tmp/train.csv",
+                test_data=test_data,
+                top_n=1,
+                workspace_path="/tmp/workspace",
+                pipeline_name="ts-pipeline-123",
+                run_id="run-123",
+                models_artifact=models_artifact,
+                extra_train_data_path=extra_train_path,
+                preset="best_quality",
+            )
+
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
     @mock.patch("autogluon.timeseries.TimeSeriesPredictor")

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
@@ -76,7 +76,7 @@ The pipeline leverages AutoGluon's unique ensembling strategy that combines mult
   - pipeline
   - automl
   - autogluon-tabular-training-pipeline
-- **Last Verified**: 2026-05-20 12:00:00+00:00
+- **Last Verified**: 2026-06-10 12:00:00+00:00
 - **Owners**:
   - No Parent Owners: Yes
   - Approvers:

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
@@ -60,7 +60,7 @@ The pipeline leverages AutoGluon's unique ensembling strategy that combines mult
 | `top_n` | `int` | `3` | Number of top models to select and refit (default: 3); positive integer from range [1, 10]. |
 | `positive_class` | `str` | `""` | Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values. |
 | `eval_metric` | `str` | `""` | Metric used for model ranking. Empty string (default) is resolved by the component to "r2" for regression and "accuracy" for binary and multiclass classification. |
-| `preset` | `str` | `good_quality` | AutoGluon quality tier. "good_quality" (default, 1 hour time limit) or "high_quality" (90 min time limit). |
+| `preset` | `str` | `speed` | Training quality tier. "speed" (default, 45-min time limit, 8 vCPU / 32 GiB) or "balanced" (90-min time limit, 16 vCPU / 64 GiB). |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
@@ -58,8 +58,9 @@ The pipeline leverages AutoGluon's unique ensembling strategy that combines mult
 | `label_column` | `str` | `None` | Name of the target/label column in the dataset. |
 | `task_type` | `str` | `None` | "binary", "multiclass", or "regression"; drives metrics and model types. |
 | `top_n` | `int` | `3` | Number of top models to select and refit (default: 3); positive integer from range [1, 10]. |
-| `positive_class` | `Optional[str]` | `None` | Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values. |
+| `positive_class` | `str` | `""` | Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values. |
 | `eval_metric` | `str` | `""` | Metric used for model ranking. Empty string (default) is resolved by the component to "r2" for regression and "accuracy" for binary and multiclass classification. |
+| `preset` | `str` | `medium_quality` | AutoGluon quality tier (default: "medium_quality", 4 vCPU / 16 GiB). "good_quality" trains stronger models at higher resource cost (8 vCPU / 32 GiB). |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
@@ -60,7 +60,7 @@ The pipeline leverages AutoGluon's unique ensembling strategy that combines mult
 | `top_n` | `int` | `3` | Number of top models to select and refit (default: 3); positive integer from range [1, 10]. |
 | `positive_class` | `str` | `""` | Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values. |
 | `eval_metric` | `str` | `""` | Metric used for model ranking. Empty string (default) is resolved by the component to "r2" for regression and "accuracy" for binary and multiclass classification. |
-| `preset` | `str` | `speed` | Training quality tier. "speed" (default, 45-min time limit, 8 vCPU / 32 GiB) or "balanced" (90-min time limit, 16 vCPU / 64 GiB). |
+| `preset` | `str` | `speed` | Training quality tier. "speed" (default, 8 vCPU / 32 GiB) or "balanced" (may run more than 2x longer, 16 vCPU / 64 GiB). |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/README.md
@@ -60,7 +60,7 @@ The pipeline leverages AutoGluon's unique ensembling strategy that combines mult
 | `top_n` | `int` | `3` | Number of top models to select and refit (default: 3); positive integer from range [1, 10]. |
 | `positive_class` | `str` | `""` | Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values. |
 | `eval_metric` | `str` | `""` | Metric used for model ranking. Empty string (default) is resolved by the component to "r2" for regression and "accuracy" for binary and multiclass classification. |
-| `preset` | `str` | `medium_quality` | AutoGluon quality tier (default: "medium_quality", 4 vCPU / 16 GiB). "good_quality" trains stronger models at higher resource cost (8 vCPU / 32 GiB). |
+| `preset` | `str` | `good_quality` | AutoGluon quality tier. "good_quality" (default, 1 hour time limit) or "high_quality" (90 min time limit). |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/metadata.yaml
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/metadata.yaml
@@ -13,4 +13,4 @@ tags:
   - pipeline
   - automl
   - autogluon-tabular-training-pipeline
-lastVerified: 2026-05-20T12:00:00Z
+lastVerified: 2026-06-10T12:00:00Z

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
@@ -125,7 +125,7 @@ def autogluon_tabular_training_pipeline(
         top_n: Number of top models to select and refit (default: 3); positive integer from range [1, 10].
         positive_class: Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values.
         eval_metric: Metric used for model ranking. Empty string (default) is resolved by the component to "r2" for regression and "accuracy" for binary and multiclass classification.
-        preset: Training quality tier. "speed" (default, 45-min time limit, 8 vCPU / 32 GiB) or "balanced" (90-min time limit, 16 vCPU / 64 GiB).
+        preset: Training quality tier. "speed" (default, 8 vCPU / 32 GiB) or "balanced" (may run more than 2x longer, 16 vCPU / 64 GiB).
 
     Returns:
         HTML artifact with leaderboard of refitted models ranked by task_type metric (e.g. accuracy, r2).

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from kfp import dsl
 from kfp_components.components.data_processing.automl.tabular_data_loader import automl_data_loader
 from kfp_components.components.training.automl.autogluon_leaderboard_evaluation import leaderboard_evaluation
@@ -41,8 +39,9 @@ def autogluon_tabular_training_pipeline(
     label_column: str,
     task_type: str,
     top_n: int = 3,
-    positive_class: Optional[str] = None,
+    positive_class: str = "",
     eval_metric: str = "",
+    preset: str = "medium_quality",
 ):
     """AutoGluon Tabular Training Pipeline.
 
@@ -126,6 +125,7 @@ def autogluon_tabular_training_pipeline(
         top_n: Number of top models to select and refit (default: 3); positive integer from range [1, 10].
         positive_class: Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values.
         eval_metric: Metric used for model ranking. Empty string (default) is resolved by the component to "r2" for regression and "accuracy" for binary and multiclass classification.
+        preset: AutoGluon quality tier (default: "medium_quality", 4 vCPU / 16 GiB). "good_quality" trains stronger models at higher resource cost (8 vCPU / 32 GiB).
 
     Returns:
         HTML artifact with leaderboard of refitted models ranked by task_type metric (e.g. accuracy, r2).
@@ -186,8 +186,10 @@ def autogluon_tabular_training_pipeline(
         optional=True,  # Mark as optional to not block the pipeline. If needed, error will be raised by component
     )
 
-    # Stage 1 + 2: Model selection and sequential refit of top N models
-    training_task = autogluon_models_training(
+    # Stage 1 + 2: Model selection and sequential refit of top N models.
+    # Resource limits differ by preset: good_quality needs more CPU/memory.
+    # TODO: when possible, the leaderboard evaluation task should be outside the if/else block.
+    _training_kwargs = dict(
         label_column=label_column,
         task_type=task_type,
         top_n=top_n,
@@ -201,20 +203,40 @@ def autogluon_tabular_training_pipeline(
         sampling_config=data_loader_task.outputs["sample_config"],
         split_config=data_loader_task.outputs["split_config"],
         extra_train_data_path=data_loader_task.outputs["extra_train_data_path"],
+        preset=preset,
         eval_metric=eval_metric,
     )
-    training_task.set_caching_options(False)
-    training_task.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(MAX_MEMORY)
+    with dsl.If(preset == "good_quality"):
+        training_task_gq = autogluon_models_training(**_training_kwargs)
+        training_task_gq.set_caching_options(False)
+        training_task_gq.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
 
-    # Generate leaderboard
-    leaderboard_evaluation_task = leaderboard_evaluation(
-        models_artifact=training_task.outputs["models_artifact"],
-        eval_metric=training_task.outputs["eval_metric"],
-    )
-    leaderboard_evaluation_task.set_caching_options(False)
-    leaderboard_evaluation_task.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
-        MAX_MEMORY
-    )
+        leaderboard_evaluation_task_gq = leaderboard_evaluation(
+            models_artifact=training_task_gq.outputs["models_artifact"],
+            eval_metric=training_task_gq.outputs["eval_metric"],
+        )
+        leaderboard_evaluation_task_gq.set_caching_options(False)
+        leaderboard_evaluation_task_gq.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(
+            MAX_CPUS
+        ).set_memory_limit(MAX_MEMORY)
+
+    with dsl.Else():
+        training_task_mq = autogluon_models_training(**_training_kwargs)
+        training_task_mq.set_caching_options(False)
+        training_task_mq.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
+
+        leaderboard_evaluation_task_mq = leaderboard_evaluation(
+            models_artifact=training_task_mq.outputs["models_artifact"],
+            eval_metric=training_task_mq.outputs["eval_metric"],
+        )
+        leaderboard_evaluation_task_mq.set_caching_options(False)
+        leaderboard_evaluation_task_mq.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(
+            MAX_CPUS
+        ).set_memory_limit(MAX_MEMORY)
 
 
 if __name__ == "__main__":

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
@@ -41,7 +41,7 @@ def autogluon_tabular_training_pipeline(
     top_n: int = 3,
     positive_class: str = "",
     eval_metric: str = "",
-    preset: str = "good_quality",
+    preset: str = "speed",
 ):
     """AutoGluon Tabular Training Pipeline.
 
@@ -125,7 +125,7 @@ def autogluon_tabular_training_pipeline(
         top_n: Number of top models to select and refit (default: 3); positive integer from range [1, 10].
         positive_class: Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values.
         eval_metric: Metric used for model ranking. Empty string (default) is resolved by the component to "r2" for regression and "accuracy" for binary and multiclass classification.
-        preset: AutoGluon quality tier. "good_quality" (default, 1 hour time limit) or "high_quality" (90 min time limit).
+        preset: Training quality tier. "speed" (default, 45-min time limit, 8 vCPU / 32 GiB) or "balanced" (90-min time limit, 16 vCPU / 64 GiB).
 
     Returns:
         HTML artifact with leaderboard of refitted models ranked by task_type metric (e.g. accuracy, r2).
@@ -187,7 +187,7 @@ def autogluon_tabular_training_pipeline(
     )
 
     # Stage 1 + 2: Model selection and sequential refit of top N models.
-    # Resource limits differ by preset: good_quality needs more CPU/memory.
+    # Resource limits differ by preset: balanced needs more CPU/memory than speed.
     # TODO: when possible, the leaderboard evaluation task should be outside the if/else block.
     _training_kwargs = dict(
         label_column=label_column,
@@ -206,35 +206,35 @@ def autogluon_tabular_training_pipeline(
         preset=preset,
         eval_metric=eval_metric,
     )
-    with dsl.If(preset == "good_quality"):
-        training_task_gq = autogluon_models_training(**_training_kwargs)
-        training_task_gq.set_caching_options(False)
-        training_task_gq.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+    with dsl.If(preset == "speed"):
+        training_task_sp = autogluon_models_training(**_training_kwargs)
+        training_task_sp.set_caching_options(False)
+        training_task_sp.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
             MAX_MEMORY
         )
 
-        leaderboard_evaluation_task_gq = leaderboard_evaluation(
-            models_artifact=training_task_gq.outputs["models_artifact"],
-            eval_metric=training_task_gq.outputs["eval_metric"],
+        leaderboard_evaluation_task_sp = leaderboard_evaluation(
+            models_artifact=training_task_sp.outputs["models_artifact"],
+            eval_metric=training_task_sp.outputs["eval_metric"],
         )
-        leaderboard_evaluation_task_gq.set_caching_options(False)
-        leaderboard_evaluation_task_gq.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(
+        leaderboard_evaluation_task_sp.set_caching_options(False)
+        leaderboard_evaluation_task_sp.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(
             MAX_CPUS
         ).set_memory_limit(MAX_MEMORY)
 
     with dsl.Else():
-        training_task_mq = autogluon_models_training(**_training_kwargs)
-        training_task_mq.set_caching_options(False)
-        training_task_mq.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+        training_task_bl = autogluon_models_training(**_training_kwargs)
+        training_task_bl.set_caching_options(False)
+        training_task_bl.set_cpu_request("16").set_memory_request("64Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
             MAX_MEMORY
         )
 
-        leaderboard_evaluation_task_mq = leaderboard_evaluation(
-            models_artifact=training_task_mq.outputs["models_artifact"],
-            eval_metric=training_task_mq.outputs["eval_metric"],
+        leaderboard_evaluation_task_bl = leaderboard_evaluation(
+            models_artifact=training_task_bl.outputs["models_artifact"],
+            eval_metric=training_task_bl.outputs["eval_metric"],
         )
-        leaderboard_evaluation_task_mq.set_caching_options(False)
-        leaderboard_evaluation_task_mq.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(
+        leaderboard_evaluation_task_bl.set_caching_options(False)
+        leaderboard_evaluation_task_bl.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(
             MAX_CPUS
         ).set_memory_limit(MAX_MEMORY)
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
@@ -41,7 +41,7 @@ def autogluon_tabular_training_pipeline(
     top_n: int = 3,
     positive_class: str = "",
     eval_metric: str = "",
-    preset: str = "medium_quality",
+    preset: str = "good_quality",
 ):
     """AutoGluon Tabular Training Pipeline.
 
@@ -125,7 +125,7 @@ def autogluon_tabular_training_pipeline(
         top_n: Number of top models to select and refit (default: 3); positive integer from range [1, 10].
         positive_class: Optional label value for the positive class in binary classification. Defaults to the second unique class after sorting label values.
         eval_metric: Metric used for model ranking. Empty string (default) is resolved by the component to "r2" for regression and "accuracy" for binary and multiclass classification.
-        preset: AutoGluon quality tier (default: "medium_quality", 4 vCPU / 16 GiB). "good_quality" trains stronger models at higher resource cost (8 vCPU / 32 GiB).
+        preset: AutoGluon quality tier. "good_quality" (default, 1 hour time limit) or "high_quality" (90 min time limit).
 
     Returns:
         HTML artifact with leaderboard of refitted models ranked by task_type metric (e.g. accuracy, r2).

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/pipeline.py
@@ -206,23 +206,7 @@ def autogluon_tabular_training_pipeline(
         preset=preset,
         eval_metric=eval_metric,
     )
-    with dsl.If(preset == "speed"):
-        training_task_sp = autogluon_models_training(**_training_kwargs)
-        training_task_sp.set_caching_options(False)
-        training_task_sp.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
-            MAX_MEMORY
-        )
-
-        leaderboard_evaluation_task_sp = leaderboard_evaluation(
-            models_artifact=training_task_sp.outputs["models_artifact"],
-            eval_metric=training_task_sp.outputs["eval_metric"],
-        )
-        leaderboard_evaluation_task_sp.set_caching_options(False)
-        leaderboard_evaluation_task_sp.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(
-            MAX_CPUS
-        ).set_memory_limit(MAX_MEMORY)
-
-    with dsl.Else():
+    with dsl.If(preset == "balanced"):
         training_task_bl = autogluon_models_training(**_training_kwargs)
         training_task_bl.set_caching_options(False)
         training_task_bl.set_cpu_request("16").set_memory_request("64Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
@@ -235,6 +219,22 @@ def autogluon_tabular_training_pipeline(
         )
         leaderboard_evaluation_task_bl.set_caching_options(False)
         leaderboard_evaluation_task_bl.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(
+            MAX_CPUS
+        ).set_memory_limit(MAX_MEMORY)
+
+    with dsl.Else():
+        training_task_sp = autogluon_models_training(**_training_kwargs)
+        training_task_sp.set_caching_options(False)
+        training_task_sp.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
+
+        leaderboard_evaluation_task_sp = leaderboard_evaluation(
+            models_artifact=training_task_sp.outputs["models_artifact"],
+            eval_metric=training_task_sp.outputs["eval_metric"],
+        )
+        leaderboard_evaluation_task_sp.set_caching_options(False)
+        leaderboard_evaluation_task_sp.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(
             MAX_CPUS
         ).set_memory_limit(MAX_MEMORY)
 

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
@@ -60,7 +60,7 @@ class TestAutogluonTabularTrainingPipelineUnitTests:
         params = set(inputs.keys())
         assert params == expected_params, f"Pipeline params {params} != expected {expected_params}"
         assert inputs["top_n"].default == 3
-        assert inputs["preset"].default == "good_quality"
+        assert inputs["preset"].default == "speed"
         assert inputs["eval_metric"].default == ""
 
     def test_compiled_pipeline_has_expected_inputs(self):

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
@@ -13,9 +13,8 @@ from ..pipeline import autogluon_tabular_training_pipeline
 
 # Root DAG task IDs from ``root.dag.tasks`` (fresh compile). Update when the graph changes.
 _EXPECTED_ROOT_DAG_TASK_IDS = (
-    "autogluon-models-training",
+    "condition-branches-1",
     "automl-data-loader",
-    "leaderboard-evaluation",
     "publish-component-stage-map",
 )
 
@@ -54,12 +53,14 @@ class TestAutogluonTabularTrainingPipelineUnitTests:
             "task_type",
             "top_n",
             "positive_class",
+            "preset",
             "eval_metric",
         }
         inputs = autogluon_tabular_training_pipeline.component_spec.inputs
         params = set(inputs.keys())
         assert params == expected_params, f"Pipeline params {params} != expected {expected_params}"
         assert inputs["top_n"].default == 3
+        assert inputs["preset"].default == "medium_quality"
         assert inputs["eval_metric"].default == ""
 
     def test_compiled_pipeline_has_expected_inputs(self):
@@ -81,6 +82,7 @@ class TestAutogluonTabularTrainingPipelineUnitTests:
                 "task_type",
                 "top_n",
                 "positive_class",
+                "preset",
                 "eval_metric",
             ):
                 assert name in content, f"Expected pipeline input '{name}' in compiled YAML"
@@ -153,6 +155,22 @@ class TestAutogluonTabularTrainingPipelineUnitTests:
 
         assert "componentInputParameter: eval_metric" in content
         assert "outputParameterKey: eval_metric" in content
+
+    def test_compiled_pipeline_wires_preset_to_training_task(self):
+        """Preset pipeline input is forwarded into the training task; good_quality branch has higher resources."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp_file:
+            tmp_path = tmp_file.name
+        try:
+            compiler.Compiler().compile(
+                pipeline_func=autogluon_tabular_training_pipeline,
+                package_path=tmp_path,
+            )
+            content = Path(tmp_path).read_text(encoding="utf-8")
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+        assert "componentInputParameter: preset" in content
+        assert "condition-branches-1" in content
 
     def test_compiled_pipeline_data_loader_declares_task_type_and_label(self):
         """Tabular data loader component exposes task_type and label_column inputs."""

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/tests/test_pipeline_unit.py
@@ -60,7 +60,7 @@ class TestAutogluonTabularTrainingPipelineUnitTests:
         params = set(inputs.keys())
         assert params == expected_params, f"Pipeline params {params} != expected {expected_params}"
         assert inputs["top_n"].default == 3
-        assert inputs["preset"].default == "medium_quality"
+        assert inputs["preset"].default == "good_quality"
         assert inputs["eval_metric"].default == ""
 
     def test_compiled_pipeline_has_expected_inputs(self):

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -32,7 +32,8 @@ Args: train_data_secret_name: Kubernetes secret name containing S3 credentials (
 file (CSV or Parquet). File must include columns for item_id, timestamp, and target; optional columns for known covariates. target: Name of the column containing the numeric values to forecast. Corresponds to :attr:`~autogluon.timeseries.TimeSeriesDataFrame` target column. id_column: Name of the
 column that identifies each time series (e.g. product_id, store_id). Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. timestamp_column: Name of the column containing the timestamp/datetime for each observation. Passed as ``timestamp_column`` when constructing
 TimeSeriesDataFrame; result uses ``timestamp`` as the second index level. known_covariates_names: Optional list of column names known in advance for the forecast horizon (e.g. holidays, promotions). See :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`. prediction_length:
-Number of time steps to forecast (horizon length). Positive integer (default: 1). top_n: Number of top models to select for the leaderboard and output (default: 3). eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or snake_case form. Defaults to ``"MASE"``.
+Number of time steps to forecast (horizon length). Positive integer (default: 1). top_n: Number of top models to select for the leaderboard and output (default: 3). eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or snake_case form. Defaults to ``"MASE"``. preset:
+AutoGluon quality tier (default: ``"fast_training"``). ``"medium_quality"`` trains stronger models at higher resource cost (8 vCPU / 32 GiB).
 
 Returns: This pipeline wires task outputs between components; compiled runs expose the combined models artifact (per-model predictor, metrics, notebook paths) and leaderboard evaluation artifact (HTML + aggregated metrics), subject to Kubeflow Pipelines UI and artifact configuration.
 
@@ -55,6 +56,7 @@ prediction_length=14, top_n=3, )
 | `prediction_length` | `int` | `1` |  |
 | `top_n` | `int` | `3` |  |
 | `eval_metric` | `str` | `MASE` |  |
+| `preset` | `str` | `fast_training` |  |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -33,7 +33,7 @@ file (CSV or Parquet). File must include columns for item_id, timestamp, and tar
 column that identifies each time series (e.g. product_id, store_id). Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. timestamp_column: Name of the column containing the timestamp/datetime for each observation. Passed as ``timestamp_column`` when constructing
 TimeSeriesDataFrame; result uses ``timestamp`` as the second index level. known_covariates_names: Optional list of column names known in advance for the forecast horizon (e.g. holidays, promotions). See :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`. prediction_length:
 Number of time steps to forecast (horizon length). Positive integer (default: 1). top_n: Number of top models to select for the leaderboard and output (default: 3). eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or snake_case form. Defaults to ``"MASE"``. preset:
-AutoGluon quality tier. ``"fast_training"`` (default, 4 vCPU / 16 GiB) or ``"medium_quality"`` (8 vCPU / 32 GiB) for stronger models at higher resource cost.
+Training quality tier. ``"speed"`` (default, 4 vCPU / 16 GiB) or ``"balanced"`` (8 vCPU / 32 GiB) for stronger models at higher resource cost.
 
 Returns: This pipeline wires task outputs between components; compiled runs expose the combined models artifact (per-model predictor, metrics, notebook paths) and leaderboard evaluation artifact (HTML + aggregated metrics), subject to Kubeflow Pipelines UI and artifact configuration.
 
@@ -56,7 +56,7 @@ prediction_length=14, top_n=3, )
 | `prediction_length` | `int` | `1` |  |
 | `top_n` | `int` | `3` |  |
 | `eval_metric` | `str` | `MASE` |  |
-| `preset` | `str` | `fast_training` |  |
+| `preset` | `str` | `speed` |  |
 
 ## Metadata 🗂️
 

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -33,7 +33,7 @@ file (CSV or Parquet). File must include columns for item_id, timestamp, and tar
 column that identifies each time series (e.g. product_id, store_id). Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. timestamp_column: Name of the column containing the timestamp/datetime for each observation. Passed as ``timestamp_column`` when constructing
 TimeSeriesDataFrame; result uses ``timestamp`` as the second index level. known_covariates_names: Optional list of column names known in advance for the forecast horizon (e.g. holidays, promotions). See :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`. prediction_length:
 Number of time steps to forecast (horizon length). Positive integer (default: 1). top_n: Number of top models to select for the leaderboard and output (default: 3). eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or snake_case form. Defaults to ``"MASE"``. preset:
-Training quality tier. ``"speed"`` (default, 4 vCPU / 16 GiB) or ``"balanced"`` (8 vCPU / 32 GiB) for stronger models at higher resource cost.
+Training quality tier. ``"speed"`` (default, 4 vCPU / 16 GiB) or ``"balanced"`` (may run more than 2x longer, 8 vCPU / 32 GiB).
 
 Returns: This pipeline wires task outputs between components; compiled runs expose the combined models artifact (per-model predictor, metrics, notebook paths) and leaderboard evaluation artifact (HTML + aggregated metrics), subject to Kubeflow Pipelines UI and artifact configuration.
 

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -72,7 +72,7 @@ prediction_length=14, top_n=3, )
   - pipeline
   - automl
   - autogluon-timeseries-training-pipeline
-- **Last Verified**: 2026-05-07 12:00:00+00:00
+- **Last Verified**: 2026-06-10 12:00:00+00:00
 - **Owners**:
   - No Parent Owners: Yes
   - Approvers:

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -33,7 +33,7 @@ file (CSV or Parquet). File must include columns for item_id, timestamp, and tar
 column that identifies each time series (e.g. product_id, store_id). Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. timestamp_column: Name of the column containing the timestamp/datetime for each observation. Passed as ``timestamp_column`` when constructing
 TimeSeriesDataFrame; result uses ``timestamp`` as the second index level. known_covariates_names: Optional list of column names known in advance for the forecast horizon (e.g. holidays, promotions). See :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`. prediction_length:
 Number of time steps to forecast (horizon length). Positive integer (default: 1). top_n: Number of top models to select for the leaderboard and output (default: 3). eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or snake_case form. Defaults to ``"MASE"``. preset:
-AutoGluon quality tier (default: ``"fast_training"``). ``"medium_quality"`` trains stronger models at higher resource cost (8 vCPU / 32 GiB).
+AutoGluon quality tier. ``"fast_training"`` (default, 4 vCPU / 16 GiB) or ``"medium_quality"`` (8 vCPU / 32 GiB) for stronger models at higher resource cost.
 
 Returns: This pipeline wires task outputs between components; compiled runs expose the combined models artifact (per-model predictor, metrics, notebook paths) and leaderboard evaluation artifact (HTML + aggregated metrics), subject to Kubeflow Pipelines UI and artifact configuration.
 

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/metadata.yaml
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/metadata.yaml
@@ -13,4 +13,4 @@ tags:
   - pipeline
   - automl
   - autogluon-timeseries-training-pipeline
-lastVerified: 2026-05-07T12:00:00Z
+lastVerified: 2026-06-10T12:00:00Z

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
@@ -107,7 +107,7 @@ def autogluon_timeseries_training_pipeline(
         eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or
             snake_case form. Defaults to ``"MASE"``.
         preset: Training quality tier. ``"speed"`` (default, 4 vCPU / 16 GiB) or
-            ``"balanced"`` (8 vCPU / 32 GiB) for stronger models at higher resource cost.
+            ``"balanced"`` (may run more than 2x longer, 8 vCPU / 32 GiB).
 
     Returns:
         This pipeline wires task outputs between components; compiled runs expose the combined models artifact

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
@@ -45,6 +45,7 @@ def autogluon_timeseries_training_pipeline(
     prediction_length: int = 1,
     top_n: int = 3,
     eval_metric: str = "MASE",
+    preset: str = "fast_training",
 ):
     """AutoGluon time series training pipeline.
 
@@ -105,6 +106,8 @@ def autogluon_timeseries_training_pipeline(
         top_n: Number of top models to select for the leaderboard and output (default: 3).
         eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or
             snake_case form. Defaults to ``"MASE"``.
+        preset: AutoGluon quality tier (default: ``"fast_training"``). ``"medium_quality"``
+            trains stronger models at higher resource cost (8 vCPU / 32 GiB).
 
     Returns:
         This pipeline wires task outputs between components; compiled runs expose the combined models artifact
@@ -167,8 +170,10 @@ def autogluon_timeseries_training_pipeline(
         optional=True,
     )
 
-    # Stage 2: Combined model generation + full refit
-    training_task = autogluon_timeseries_models_training(
+    # Stage 2: Combined model generation + full refit.
+    # Resource limits differ by preset: medium_quality needs more CPU/memory.
+    # TODO: when possible, the leaderboard evaluation task should be outside the if/else block.
+    _training_kwargs = dict(
         target=target,
         id_column=id_column,
         timestamp_column=timestamp_column,
@@ -184,18 +189,40 @@ def autogluon_timeseries_training_pipeline(
         sampling_config=data_loader_task.outputs["sample_config"],
         split_config=data_loader_task.outputs["split_config"],
         extra_train_data_path=data_loader_task.outputs["extra_train_data_path"],
+        preset=preset,
         eval_metric=eval_metric,
     )
-    training_task.set_caching_options(False)
-    training_task.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(MAX_MEMORY)
+    with dsl.If(preset == "medium_quality"):
+        training_task_mq = autogluon_timeseries_models_training(**_training_kwargs)
+        training_task_mq.set_caching_options(False)
+        training_task_mq.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
 
-    # Stage 3: Common leaderboard evaluation
-    leaderboard_task = leaderboard_evaluation(
-        models_artifact=training_task.outputs["models_artifact"],
-        eval_metric=training_task.outputs["eval_metric"],
-    )
-    leaderboard_task.set_caching_options(False)
-    leaderboard_task.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(MAX_MEMORY)
+        leaderboard_task_mq = leaderboard_evaluation(
+            models_artifact=training_task_mq.outputs["models_artifact"],
+            eval_metric=training_task_mq.outputs["eval_metric"],
+        )
+        leaderboard_task_mq.set_caching_options(False)
+        leaderboard_task_mq.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
+
+    with dsl.Else():
+        training_task_ft = autogluon_timeseries_models_training(**_training_kwargs)
+        training_task_ft.set_caching_options(False)
+        training_task_ft.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
+
+        leaderboard_task_ft = leaderboard_evaluation(
+            models_artifact=training_task_ft.outputs["models_artifact"],
+            eval_metric=training_task_ft.outputs["eval_metric"],
+        )
+        leaderboard_task_ft.set_caching_options(False)
+        leaderboard_task_ft.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+            MAX_MEMORY
+        )
 
 
 if __name__ == "__main__":

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
@@ -45,7 +45,7 @@ def autogluon_timeseries_training_pipeline(
     prediction_length: int = 1,
     top_n: int = 3,
     eval_metric: str = "MASE",
-    preset: str = "fast_training",
+    preset: str = "speed",
 ):
     """AutoGluon time series training pipeline.
 
@@ -106,8 +106,8 @@ def autogluon_timeseries_training_pipeline(
         top_n: Number of top models to select for the leaderboard and output (default: 3).
         eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or
             snake_case form. Defaults to ``"MASE"``.
-        preset: AutoGluon quality tier. ``"fast_training"`` (default, 4 vCPU / 16 GiB) or
-            ``"medium_quality"`` (8 vCPU / 32 GiB) for stronger models at higher resource cost.
+        preset: Training quality tier. ``"speed"`` (default, 4 vCPU / 16 GiB) or
+            ``"balanced"`` (8 vCPU / 32 GiB) for stronger models at higher resource cost.
 
     Returns:
         This pipeline wires task outputs between components; compiled runs expose the combined models artifact
@@ -192,35 +192,35 @@ def autogluon_timeseries_training_pipeline(
         preset=preset,
         eval_metric=eval_metric,
     )
-    with dsl.If(preset == "medium_quality"):
-        training_task_mq = autogluon_timeseries_models_training(**_training_kwargs)
-        training_task_mq.set_caching_options(False)
-        training_task_mq.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+    with dsl.If(preset == "balanced"):
+        training_task_bl = autogluon_timeseries_models_training(**_training_kwargs)
+        training_task_bl.set_caching_options(False)
+        training_task_bl.set_cpu_request("8").set_memory_request("32Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
             MAX_MEMORY
         )
 
-        leaderboard_task_mq = leaderboard_evaluation(
-            models_artifact=training_task_mq.outputs["models_artifact"],
-            eval_metric=training_task_mq.outputs["eval_metric"],
+        leaderboard_task_bl = leaderboard_evaluation(
+            models_artifact=training_task_bl.outputs["models_artifact"],
+            eval_metric=training_task_bl.outputs["eval_metric"],
         )
-        leaderboard_task_mq.set_caching_options(False)
-        leaderboard_task_mq.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+        leaderboard_task_bl.set_caching_options(False)
+        leaderboard_task_bl.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
             MAX_MEMORY
         )
 
     with dsl.Else():
-        training_task_ft = autogluon_timeseries_models_training(**_training_kwargs)
-        training_task_ft.set_caching_options(False)
-        training_task_ft.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+        training_task_sp = autogluon_timeseries_models_training(**_training_kwargs)
+        training_task_sp.set_caching_options(False)
+        training_task_sp.set_cpu_request("4").set_memory_request("16Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
             MAX_MEMORY
         )
 
-        leaderboard_task_ft = leaderboard_evaluation(
-            models_artifact=training_task_ft.outputs["models_artifact"],
-            eval_metric=training_task_ft.outputs["eval_metric"],
+        leaderboard_task_sp = leaderboard_evaluation(
+            models_artifact=training_task_sp.outputs["models_artifact"],
+            eval_metric=training_task_sp.outputs["eval_metric"],
         )
-        leaderboard_task_ft.set_caching_options(False)
-        leaderboard_task_ft.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
+        leaderboard_task_sp.set_caching_options(False)
+        leaderboard_task_sp.set_cpu_request("1").set_memory_request("4Gi").set_cpu_limit(MAX_CPUS).set_memory_limit(
             MAX_MEMORY
         )
 

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
@@ -106,8 +106,8 @@ def autogluon_timeseries_training_pipeline(
         top_n: Number of top models to select for the leaderboard and output (default: 3).
         eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or
             snake_case form. Defaults to ``"MASE"``.
-        preset: AutoGluon quality tier (default: ``"fast_training"``). ``"medium_quality"``
-            trains stronger models at higher resource cost (8 vCPU / 32 GiB).
+        preset: AutoGluon quality tier. ``"fast_training"`` (default, 4 vCPU / 16 GiB) or
+            ``"medium_quality"`` (8 vCPU / 32 GiB) for stronger models at higher resource cost.
 
     Returns:
         This pipeline wires task outputs between components; compiled runs expose the combined models artifact

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
@@ -62,7 +62,7 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
         assert inputs["prediction_length"].default == 1
         assert inputs["top_n"].default == 3
         assert inputs["known_covariates_names"].default is None
-        assert inputs["preset"].default == "fast_training"
+        assert inputs["preset"].default == "speed"
         assert inputs["eval_metric"].default == "MASE"
 
     def test_compiled_pipeline_has_expected_inputs(self):

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
@@ -12,8 +12,7 @@ from kfp_components.utils.pipeline_dag_tasks import (
 from ..pipeline import autogluon_timeseries_training_pipeline
 
 _EXPECTED_ROOT_DAG_TASK_IDS = (
-    "autogluon-timeseries-models-training",
-    "leaderboard-evaluation",
+    "condition-branches-1",
     "publish-component-stage-map",
     "timeseries-data-loader",
 )
@@ -54,6 +53,7 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
             "known_covariates_names",
             "prediction_length",
             "top_n",
+            "preset",
             "eval_metric",
         }
         inputs = autogluon_timeseries_training_pipeline.component_spec.inputs
@@ -62,6 +62,7 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
         assert inputs["prediction_length"].default == 1
         assert inputs["top_n"].default == 3
         assert inputs["known_covariates_names"].default is None
+        assert inputs["preset"].default == "fast_training"
         assert inputs["eval_metric"].default == "MASE"
 
     def test_compiled_pipeline_has_expected_inputs(self):
@@ -85,6 +86,7 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
                 "known_covariates_names",
                 "prediction_length",
                 "top_n",
+                "preset",
                 "eval_metric",
             ):
                 assert name in content, f"Expected pipeline input '{name}' in compiled YAML"
@@ -119,3 +121,20 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
             Path(tmp_path).unlink(missing_ok=True)
         assert "componentInputParameter: eval_metric" in content
         assert "outputParameterKey: eval_metric" in content
+        assert "componentInputParameter: preset" in content
+
+    def test_compiled_pipeline_wires_preset_to_training_task(self):
+        """Preset pipeline input is forwarded into the training task; medium_quality branch has higher resources."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp_file:
+            tmp_path = tmp_file.name
+        try:
+            compiler.Compiler().compile(
+                pipeline_func=autogluon_timeseries_training_pipeline,
+                package_path=tmp_path,
+            )
+            content = Path(tmp_path).read_text(encoding="utf-8")
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+        assert "componentInputParameter: preset" in content
+        assert "condition-branches-1" in content


### PR DESCRIPTION
Assisted-by: Claude Code

## Description of your changes

  Introduces a `preset` parameter to both AutoML training components and their pipelines,
  allowing users to trade off training time and resource cost against model quality.
  The pipeline allocates different CPU/memory limits per preset via `dsl.If/Else`
  conditional branches.

  Preset names exposed to users (`"speed"`, `"balanced"`) are decoupled from AutoGluon's
  internal preset names via a `PRESET_AG_NAMES` mapping inside each component. Future
  changes to the underlying AutoGluon preset or fit parameters do not require a breaking
  change to the pipeline API.

  ---

  ### Changes

  #### `autogluon_models_training` (tabular component)

  - Added `preset: str = "speed"` parameter:
    - `"speed"` (default) — 45-minute time limit; maps to AutoGluon `good_quality`
    - `"balanced"` — 90-minute time limit; maps to AutoGluon `high_quality`
  - Both presets share identical fit args: `refit_full=False`,
    `set_best_to_refit_full=False`, `save_bag_folds=True`; the pipeline controls
    refit explicitly via `refit_full()`
  - `PRESET_AG_NAMES` translates the user-visible preset to the AutoGluon `presets=`
    argument; `PRESET_TIME_LIMITS` drives `time_limit=`
  - `preset` and `time_limit` recorded in `model_config` artifact metadata
  - `positive_class` changed from `Optional[str] = None` to `str = ""` to prevent
    KFP driver null-parameter failures inside `dsl.If/Else` branches

  #### `autogluon_timeseries_models_training` (timeseries component)

  - Added `preset: str = "speed"` parameter:
    - `"speed"` (default) — 10-minute time limit; maps to AutoGluon `fast_training`
    - `"balanced"` — 60-minute time limit; maps to AutoGluon `medium_quality`
  - Same `PRESET_AG_NAMES` / `PRESET_TIME_LIMITS` pattern as the tabular component

  #### `autogluon_tabular_training_pipeline`

  - New `preset: str = "speed"` pipeline input, forwarded to the training component
  - `dsl.If(preset == "speed") / dsl.Else()` sets resource limits:
    - `"speed"` → 8 vCPU / 32 GiB
    - `"balanced"` → 16 vCPU / 64 GiB
  - Leaderboard evaluation duplicated inside both branches (KFP requires outputs to
    be consumed within the same branch scope)

  #### `autogluon_timeseries_training_pipeline`

  - New `preset: str = "speed"` pipeline input, same pattern as tabular
  - `dsl.If(preset == "balanced") / dsl.Else()` sets resource limits:
    - `"balanced"` → 8 vCPU / 32 GiB
    - `"speed"` → 4 vCPU / 16 GiB

  ---

  ### Tests

  - **Tabular component:** `test_speed_preset_fit_args` verifies the 45-minute time
    limit and shared fit args (`refit_full=False`, `set_best_to_refit_full=False`,
    `save_bag_folds=True`); `test_rejects_invalid_preset` covers unknown preset values;
    `isolated_sys_modules` fixture extended with
    `autogluon.tabular.configs.hyperparameter_configs`
  - **Timeseries component:** `test_rejects_invalid_preset` updated for new preset names;
    `test_basic_flow_returns_expected_outputs` updated to assert
    `model_config["presets"] == "speed"`
  - **Pipelines:** `preset` added to expected parameter sets; `dsl.If` condition
    branches updated to match new preset names

  ---

  ### Metadata

  `lastVerified` bumped to `2026-06-10` in all four `metadata.yaml` files.

**Checklist:**

### Pre-Submission Checklist

- [ ] All tests and CI checks pass
- [ ] Pre-commit hooks pass without errors
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `preset` input (default: `"speed"`, alternative: `"balanced"`) to AutoGluon tabular and timeseries training components and pipelines, controlling the training quality/resource tier and related time budgeting. Pipelines now branch per preset with different training resource profiles.
* **Documentation**
  * Updated READMEs and pipeline docs: `preset` options/defaults and `positive_class` is now a `str` defaulting to `""` (empty string lets AutoGluon infer).
* **Tests**
  * Updated and added unit tests to cover preset wiring, fit behavior expectations, and invalid-preset rejection.
* **Chores**
  * Refreshed component/pipeline “last verified” metadata timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->