### PR TITLE
(chore): remove kfp embedded artifact usage in auto rag pipeline

### DIFF
--- a/components/training/autorag/rag_templates_optimization/README.md
+++ b/components/training/autorag/rag_templates_optimization/README.md
@@ -16,7 +16,6 @@ Carries out the iterative RAG optimization process.
 | `test_data` | `dsl.InputPath(dsl.Artifact)` | `None` | A path pointing to test data used for evaluating RAG pattern quality. |
 | `search_space_prep_report` | `dsl.InputPath(dsl.Artifact)` | `None` | A path pointing to a .yml file containig short report on the experiment's first phase (search space preparation). |
 | `rag_patterns` | `dsl.Output[dsl.Artifact]` | `None` | kfp-enforced argument specifying an output artifact. Provided by kfp backend automatically. |
-| `embedded_artifact` | `dsl.EmbeddedInput[dsl.Dataset]` | `None` | kfp-enforced argument to allow access of base64 encoded dir with notebook templates. |
 | `test_data_key` | `Optional[str]` | `None` | Path to the benchmark JSON file in object storage used by generated notebooks. |
 | `vector_io_provider_id` | `str` | `None` | Vector I/O provider identifier as registered in OGX. |
 | `optimization_settings` | `Optional[dict]` | `None` | Additional settings customising the experiment. |

--- a/components/training/autorag/rag_templates_optimization/component.py
+++ b/components/training/autorag/rag_templates_optimization/component.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Optional
 
 from kfp import dsl
@@ -7,7 +6,6 @@ from kfp_components.utils.consts import AUTORAG_IMAGE  # pyright: ignore[reportM
 
 @dsl.component(
     base_image=AUTORAG_IMAGE,  # noqa: E501
-    embedded_artifact_path=str(Path(__file__).parents[1] / "shared"),
     install_kfp_package=False,
 )
 def rag_templates_optimization(
@@ -15,7 +13,6 @@ def rag_templates_optimization(
     test_data: dsl.InputPath(dsl.Artifact),
     search_space_prep_report: dsl.InputPath(dsl.Artifact),
     rag_patterns: dsl.Output[dsl.Artifact],
-    embedded_artifact: dsl.EmbeddedInput[dsl.Dataset],
     test_data_key: Optional[str],
     vector_io_provider_id: str,
     optimization_settings: Optional[dict] = None,
@@ -34,8 +31,6 @@ def rag_templates_optimization(
             report on the experiment's first phase (search space preparation).
 
         rag_patterns: kfp-enforced argument specifying an output artifact. Provided by kfp backend automatically.
-
-        embedded_artifact: kfp-enforced argument to allow access of base64 encoded dir with notebook templates.
 
         test_data_key: Path to the benchmark JSON file in object storage used by generated notebooks.
 
@@ -62,6 +57,7 @@ def rag_templates_optimization(
 
     import logging
     import os
+    import site
     from json import dump as json_dump
     from json import load as json_load
     from pathlib import Path
@@ -328,7 +324,17 @@ def rag_templates_optimization(
             --------
             >>> nb = Notebook.load("existing_notebook.ipynb")
             """
-            with open(Path(embedded_artifact.path) / "notebook_templates" / notebook_name, "r") as f:
+            with open(
+                Path(site.getsitepackages()[0])
+                / "kfp_components"
+                / "components"
+                / "training"
+                / "autorag"
+                / "shared"
+                / "notebook_templates"
+                / notebook_name,
+                "r",
+            ) as f:
                 nb_dict = json_load(f)
 
             loaded_cells = []
@@ -822,9 +828,16 @@ def rag_templates_optimization(
         template_context = {
             "responses_template": pattern_data["settings"]["responses_template"],
         }
-        with (Path(embedded_artifact.path) / "script_templates" / "create_model_response.py.templ").open(
-            "r", encoding="utf-8"
-        ) as f:
+        with (
+            Path(site.getsitepackages()[0])
+            / "kfp_components"
+            / "components"
+            / "training"
+            / "autorag"
+            / "shared"
+            / "script_templates"
+            / "create_model_response.py.templ"
+        ).open("r", encoding="utf-8") as f:
             model_responses_templ = Template(f.read())
             with (patt_dir / "create_model_response.py").open("w+", encoding="utf-8") as ff:
                 ff.write(model_responses_templ.substitute(template_context))

--- a/components/training/autorag/rag_templates_optimization/tests/test_component_unit.py
+++ b/components/training/autorag/rag_templates_optimization/tests/test_component_unit.py
@@ -209,7 +209,6 @@ class TestRagTemplatesOptimizationUnitTests:
                 "test_data": test_data,
                 "search_space_prep_report": search_space_report,
                 "rag_patterns": mock.MagicMock(path="/tmp/rag_patterns", metadata={}, uri=""),
-                "embedded_artifact": mock.MagicMock(path="/tmp/embedded"),
                 "test_data_key": "small-dataset/benchmark.json",
                 "optimization_settings": {"metric": "faithfulness", "max_number_of_rag_patterns": 8},
             }
@@ -260,7 +259,6 @@ class TestRagTemplatesOptimizationUnitTests:
                         test_data="/tmp/test_data.json",
                         search_space_prep_report="/tmp/report.yml",
                         rag_patterns=mock.MagicMock(path="/tmp/rag_patterns", metadata={}, uri=""),
-                        embedded_artifact=mock.MagicMock(path="/tmp/embedded"),
                         test_data_key="small-dataset/benchmark.json",
                         vector_io_provider_id="milvus",
                         optimization_settings={
@@ -293,7 +291,6 @@ class TestRagTemplatesOptimizationUnitTests:
         test_data_path.write_text("[]")
         test_data = str(test_data_path)
         rag_patterns = mock.MagicMock()
-        embedded_artifact = mock.MagicMock()
 
         with mock.patch.dict(sys.modules, mocks):
             with pytest.raises(_SentinelAbort):
@@ -302,7 +299,6 @@ class TestRagTemplatesOptimizationUnitTests:
                     test_data=test_data,
                     search_space_prep_report=str(search_space_report),
                     rag_patterns=rag_patterns,
-                    embedded_artifact=embedded_artifact,
                     test_data_key="small-dataset/benchmark.json",
                     vector_io_provider_id="milvus",
                     optimization_settings={"metric": "faithfulness", "max_number_of_rag_patterns": "8"},
@@ -320,7 +316,6 @@ class TestRagTemplatesOptimizationUnitTests:
                         test_data="/tmp/test_data.json",
                         search_space_prep_report="/tmp/report.yml",
                         rag_patterns=mock.MagicMock(path="/tmp/rag_patterns", metadata={}, uri=""),
-                        embedded_artifact=mock.MagicMock(path="/tmp/embedded"),
                         test_data_key="small-dataset/benchmark.json",
                         vector_io_provider_id="milvus",
                         optimization_settings={"metric": "faithfulness", "max_number_of_rag_patterns": 8},
@@ -342,8 +337,7 @@ class TestSSLFallbackRagTemplatesOptimization:
 
     def _make_output_artifacts(self):
         rag_patterns = mock.MagicMock()
-        embedded_artifact = mock.MagicMock()
-        return rag_patterns, embedded_artifact
+        return (rag_patterns,)
 
     @mock.patch.dict(
         "os.environ",
@@ -382,7 +376,7 @@ class TestSSLFallbackRagTemplatesOptimization:
         mocks["ai4rag.search_space.src.search_space"].AI4RAGSearchSpace.side_effect = _SentinelAbort
 
         extracted_text, test_data, search_space_report = self._make_paths(tmp_path)
-        rag_patterns, embedded_artifact = self._make_output_artifacts()
+        (rag_patterns,) = self._make_output_artifacts()
 
         with mock.patch.dict(sys.modules, mocks):
             with pytest.raises(_SentinelAbort):
@@ -391,7 +385,6 @@ class TestSSLFallbackRagTemplatesOptimization:
                     test_data=test_data,
                     search_space_prep_report=search_space_report,
                     rag_patterns=rag_patterns,
-                    embedded_artifact=embedded_artifact,
                     test_data_key="small-dataset/benchmark.json",
                     vector_io_provider_id="milvus",
                 )
@@ -430,7 +423,7 @@ class TestSSLFallbackRagTemplatesOptimization:
         mocks["ai4rag.search_space.src.search_space"].AI4RAGSearchSpace.side_effect = _SentinelAbort
 
         extracted_text, test_data, search_space_report = self._make_paths(tmp_path)
-        rag_patterns, embedded_artifact = self._make_output_artifacts()
+        (rag_patterns,) = self._make_output_artifacts()
 
         with mock.patch.dict(sys.modules, mocks):
             with pytest.raises(_SentinelAbort):
@@ -439,7 +432,6 @@ class TestSSLFallbackRagTemplatesOptimization:
                     test_data=test_data,
                     search_space_prep_report=search_space_report,
                     rag_patterns=rag_patterns,
-                    embedded_artifact=embedded_artifact,
                     test_data_key="small-dataset/benchmark.json",
                     vector_io_provider_id="milvus",
                 )
@@ -466,7 +458,7 @@ class TestSSLFallbackRagTemplatesOptimization:
         mocks["ogx_client"] = ogx_mod
 
         extracted_text, test_data, search_space_report = self._make_paths(tmp_path)
-        rag_patterns, embedded_artifact = self._make_output_artifacts()
+        (rag_patterns,) = self._make_output_artifacts()
 
         with mock.patch.dict(sys.modules, mocks):
             with pytest.raises(httpx_mod.ConnectError, match="Connection refused"):
@@ -475,7 +467,6 @@ class TestSSLFallbackRagTemplatesOptimization:
                     test_data=test_data,
                     search_space_prep_report=search_space_report,
                     rag_patterns=rag_patterns,
-                    embedded_artifact=embedded_artifact,
                     test_data_key="small-dataset/benchmark.json",
                     vector_io_provider_id="milvus",
                 )
@@ -505,7 +496,7 @@ class TestSSLFallbackRagTemplatesOptimization:
         mocks["ai4rag.search_space.src.search_space"].AI4RAGSearchSpace.side_effect = _SentinelAbort
 
         extracted_text, test_data, search_space_report = self._make_paths(tmp_path)
-        rag_patterns, embedded_artifact = self._make_output_artifacts()
+        (rag_patterns,) = self._make_output_artifacts()
 
         with mock.patch.dict(sys.modules, mocks):
             with pytest.raises(_SentinelAbort):
@@ -514,7 +505,6 @@ class TestSSLFallbackRagTemplatesOptimization:
                     test_data=test_data,
                     search_space_prep_report=search_space_report,
                     rag_patterns=rag_patterns,
-                    embedded_artifact=embedded_artifact,
                     test_data_key="small-dataset/benchmark.json",
                     vector_io_provider_id="milvus",
                 )
@@ -566,7 +556,6 @@ class TestMultilingualPromptOverrides:
                 test_data=test_data,
                 search_space_prep_report=report,
                 rag_patterns=mock.MagicMock(path="/tmp/rag_patterns", metadata={}, uri=""),
-                embedded_artifact=mock.MagicMock(path="/tmp/embedded"),
                 test_data_key="small-dataset/benchmark.json",
                 vector_io_provider_id="milvus",
                 optimization_settings={"metric": "faithfulness", "max_number_of_rag_patterns": 8},

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/Containerfile
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/Containerfile
@@ -17,6 +17,12 @@ COPY pipelines/training/autorag/documents_rag_optimization_pipeline/artifacts.lo
      pipelines/training/autorag/documents_rag_optimization_pipeline/install_sqlite_from_source.sh \
      /tmp/
 
+USER root
+COPY . /tmp/kfp-components
+RUN pip install --no-deps --no-cache-dir /tmp/kfp-components && \
+    rm -rf /tmp/kfp-components
+USER default
+
 # Build SQLite from sqlite-autoconf (Hermeto generic prefetch or download); replace system libsqlite3.
 # https://github.com/hermetoproject/hermeto/blob/main/docs/generic.md
 ARG HERMETO_GENERIC_DEPS=/cachi2/output/deps/generic

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/requirements.txt
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/requirements.txt
@@ -66,6 +66,7 @@ jsonref==1.1.0
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 kfp==2.16.1
+kfp-kubernetes==2.16.1
 kfp-pipeline-spec==2.16.1
 kfp-server-api==2.16.1
 kubernetes==36.0.2


### PR DESCRIPTION
**Description of your changes:**

- removed embedded artifact in AutoRAG pipeline in favour of copying data files directly into the AutoRAG container
- moved data files (notebook templates) to a broader-scoped components/autorag/shared common directory

Resolves [RHOAIENG-68185](https://redhat.atlassian.net/browse/RHOAIENG-68185)

Pipeline execution using an image built as part of this PR: https://rh-ai.apps.rosa.ai-eng-gpu.socc.p3.openshiftapps.com/develop-train/pipelines/runs/ai-eng-cracow/runs/3fa72383-a17f-400a-955e-2b1829c0e6f9

**Checklist:**

### Pre-Submission Checklist

- [ ] All tests and CI checks pass
- [ ] Pre-commit hooks pass without errors
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * The `rag_templates_optimization` component no longer accepts the `embedded_artifact` input parameter. Existing pipelines using this component will require updates.

* **Documentation**
  * Updated component documentation to reflect input parameter changes.

* **Chores**
  * Updated container build process and added `kfp-kubernetes==2.16.1` dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->