### PR TITLE
feat(automl): add backtesting charts to AutoML time series inference notebook

### DIFF
--- a/components/data_processing/automl/timeseries_data_loader/component.py
+++ b/components/data_processing/automl/timeseries_data_loader/component.py
@@ -61,6 +61,7 @@ def timeseries_data_loader(
         NamedTuple: sample_config, split_config, sample_rows, models_selection_train_data_path, extra_train_data_path.
     """
     import io
+    import json
     import logging
     import os
     from pathlib import Path
@@ -428,8 +429,16 @@ def timeseries_data_loader(
         status.record("write_outputs", "completed")
         component_status.metadata["display_name"] = "Timeseries Data Loader Status"
 
-        # Sample row for downstream use (JSON string to avoid NaN issues)
-        sample_rows = test_df.tail(min(5, len(test_df))).to_json(orient="records")
+        # Sample rows for downstream use (ISO timestamps when supported; JSON string to avoid NaN issues)
+        sample_tail = test_df.tail(min(5, len(test_df)))
+        if hasattr(sample_tail, "to_dict"):
+            from kfp_components.components.training.automl.shared.timeseries_notebook_utils import (
+                _json_records,
+            )
+
+            sample_rows = json.dumps(_json_records(sample_tail))
+        else:
+            sample_rows = sample_tail.to_json(orient="records")
 
         return NamedTuple(
             "outputs",

--- a/components/data_processing/automl/timeseries_data_loader/tests/test_component_unit.py
+++ b/components/data_processing/automl/timeseries_data_loader/tests/test_component_unit.py
@@ -279,6 +279,7 @@ class TestTimeseriesDataLoaderUnitTests:
         assert isinstance(parsed, list)
         assert len(parsed) == 5
         assert parsed[-1]["target"] == "99"
+        assert isinstance(parsed[0]["timestamp"], str)
 
     @mock.patch.dict(os.environ, mocked_env_variables, clear=True)
     def test_sampling_truncates_below_minimum_raises(self, tmp_path):

--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -136,6 +136,4 @@ Under each ``{model_name}_FULL/metrics/`` directory:
 - **`back_testing.json`**: Multi-window backtest with ``per_window_metrics`` and ``series_analysis``
   (best/worst forecast timelines). Window error metrics use **natural positive** signs via
   ``filter_finite_metrics``. Best-effort after refit; omitted if backtest APIs or history are
-  insufficient.
-
-The timeseries notebook template loads ``back_testing.json`` when present for model insights.
+  insufficient. Visualized in the generated inference notebook when present.

--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -110,7 +110,7 @@ def example_pipeline(
   - timeseries
   - automl
   - model-selection
-- **Last Verified**: 2026-05-27 12:00:00+00:00
+- **Last Verified**: 2026-06-10 12:00:00+00:00
 - **Owners**:
   - No Parent Owners: Yes
   - Approvers:

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -85,6 +85,7 @@ def autogluon_timeseries_models_training(
     )
     from kfp_components.components.training.automl.shared.timeseries_notebook_utils import (
         build_predict_sample_artifact,
+        notebook_timeseries_sample_helpers_source,
     )
 
     status = ComponentStatusTracker(component_status.path, "autogluon_timeseries_models_training")
@@ -396,6 +397,7 @@ def autogluon_timeseries_models_training(
                     "<REPLACE_MODEL_NAME>": model_name_full,
                     "<REPLACE_PREDICT_SAMPLE>": str(predict_sample),
                     "<REPLACE_BACKTEST_PLOT_HELPERS>": notebook_backtest_charts_source(),
+                    "<REPLACE_TIMESERIES_SAMPLE_HELPERS>": notebook_timeseries_sample_helpers_source(),
                 }
                 notebook = replace_placeholder_in_notebook(notebook, replacements)
 

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -80,6 +80,9 @@ def autogluon_timeseries_models_training(
     logger = logging.getLogger(__name__)
 
     from kfp_components.components.training.automl.shared.back_testing import build_back_testing_json
+    from kfp_components.components.training.automl.shared.back_testing_charts import (
+        notebook_backtest_charts_source,
+    )
     from kfp_components.components.training.automl.shared.timeseries_notebook_utils import (
         build_predict_sample_artifact,
     )
@@ -392,6 +395,7 @@ def autogluon_timeseries_models_training(
                     "<REPLACE_PIPELINE_NAME>": pipeline_name_trimmed,
                     "<REPLACE_MODEL_NAME>": model_name_full,
                     "<REPLACE_PREDICT_SAMPLE>": str(predict_sample),
+                    "<REPLACE_BACKTEST_PLOT_HELPERS>": notebook_backtest_charts_source(),
                 }
                 notebook = replace_placeholder_in_notebook(notebook, replacements)
 

--- a/components/training/automl/autogluon_timeseries_models_training/metadata.yaml
+++ b/components/training/automl/autogluon_timeseries_models_training/metadata.yaml
@@ -10,4 +10,4 @@ tags:
   - timeseries
   - automl
   - model-selection
-lastVerified: 2026-05-27T12:00:00Z
+lastVerified: 2026-06-10T12:00:00Z

--- a/components/training/automl/shared/back_testing.py
+++ b/components/training/automl/shared/back_testing.py
@@ -153,10 +153,18 @@ def _quantile_bounds(predictions: pd.DataFrame) -> tuple[str | None, str | None]
     if not levels:
         return None, None
 
-    def _closest(target: float) -> str | None:
-        return min(levels, key=lambda item: abs(item[0] - target))[1]
+    def _closest(candidates: list[tuple[float, str]], target: float) -> str | None:
+        if not candidates:
+            return None
+        return min(candidates, key=lambda item: abs(item[0] - target))[1]
 
-    return _closest(0.1), _closest(0.9)
+    lower = _closest(levels, 0.1)
+    if lower is None:
+        return None, None
+
+    remaining = [(value, name) for value, name in levels if name != lower]
+    upper = _closest(remaining, 0.9)
+    return lower, upper
 
 
 def _item_ids(tsdf: pd.DataFrame) -> list[Any]:

--- a/components/training/automl/shared/back_testing.py
+++ b/components/training/automl/shared/back_testing.py
@@ -140,35 +140,23 @@ def _mean_prediction_column(predictions: pd.DataFrame) -> str:
 
 
 def _quantile_bounds(predictions: pd.DataFrame) -> tuple[str | None, str | None]:
-    """Extract lower/upper quantile columns for uncertainty visualization.
+    """Extract lower/upper quantile columns aligned with ``TimeSeriesPredictor.plot`` defaults.
 
-    Selects the first quantile <= 0.2 for lower bound and >= 0.8 for upper bound.
-    These thresholds provide a ~60% coverage interval suitable for chart rendering
-    without overwhelming the visualization with too many bands.
-
-    AutoGluon typically generates quantiles at [0.1, 0.2, ..., 0.9]. If present,
-    this function will select 0.2 and 0.8. If AutoGluon uses different levels
-    (e.g., 0.1/0.9), the function adapts by picking the closest match.
-
-    Args:
-        predictions: Forecast DataFrame with quantile columns (numeric names like "0.1")
-
-    Returns:
-        Tuple of (lower_quantile_column, upper_quantile_column) as strings, or None if not found
+    Prefers quantile levels closest to 0.1 and 0.9 (AutoGluon's typical P10/P90 band).
     """
-    lower = None
-    upper = None
+    levels: list[tuple[float, str]] = []
     for col in predictions.columns:
-        col_text = str(col)
         try:
-            level = float(col)
+            levels.append((float(col), str(col)))
         except (TypeError, ValueError):
             continue
-        if level <= 0.2 and lower is None:
-            lower = col_text
-        if level >= 0.8 and upper is None:
-            upper = col_text
-    return lower, upper
+    if not levels:
+        return None, None
+
+    def _closest(target: float) -> str | None:
+        return min(levels, key=lambda item: abs(item[0] - target))[1]
+
+    return _closest(0.1), _closest(0.9)
 
 
 def _item_ids(tsdf: pd.DataFrame) -> list[Any]:
@@ -244,10 +232,12 @@ def _forecast_data_for_item(
             lower = to_finite_float(pred_item.loc[ts, lower_col])
             if lower is not None:
                 row["lower_bound"] = lower
+                row["lower_quantile"] = float(lower_col)
         if upper_col is not None:
             upper = to_finite_float(pred_item.loc[ts, upper_col])
             if upper is not None:
                 row["upper_bound"] = upper
+                row["upper_quantile"] = float(upper_col)
         rows.append(row)
     return rows
 
@@ -502,6 +492,7 @@ def build_back_testing_json(
         per_window_metrics.append(
             {
                 "window_id": window_id,
+                "cutoff": cutoff,
                 "test_start": test_start,
                 "test_end": test_end,
                 "metrics": window_scores,

--- a/components/training/automl/shared/back_testing_charts.py
+++ b/components/training/automl/shared/back_testing_charts.py
@@ -15,8 +15,13 @@ _CUTOFF = "gray"
 
 def _matplotlib():
     """Import matplotlib on demand (same pattern as ROC/PR cells in tabular notebooks)."""
-    import matplotlib.dates as mdates
-    import matplotlib.pyplot as plt
+    try:
+        import matplotlib.dates as mdates
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise ImportError(
+            "Matplotlib is required for back-testing charts. Install it with: pip install matplotlib"
+        ) from exc
 
     return plt, mdates
 
@@ -205,6 +210,8 @@ def _resolve_cutoff_timestamp(cutoff_start: str | None, timestamps: pd.Series) -
 
 
 def _target_column_name(data: pd.DataFrame) -> str:
+    if data.columns.empty:
+        raise ValueError("Cannot extract target column name from DataFrame with no columns")
     return str(data.columns[0])
 
 

--- a/components/training/automl/shared/back_testing_charts.py
+++ b/components/training/automl/shared/back_testing_charts.py
@@ -1,0 +1,250 @@
+"""Matplotlib charts for ``metrics/back_testing.json`` (same library as tabular ROC/PR curves)."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import pandas as pd
+
+_ACCENT = "#EE0000"
+_NEUTRAL = "#161616"
+_CUTOFF = "gray"
+
+
+def _normalize_metric(metric: str) -> str:
+    return (metric or "").strip().lstrip("-").upper()
+
+
+def pick_window_metric(metrics: dict[str, Any], eval_metric: str) -> float | None:
+    """Return a finite window metric value, preferring ``eval_metric``."""
+    if not metrics:
+        return None
+    wanted = _normalize_metric(eval_metric)
+    for key, value in metrics.items():
+        if _normalize_metric(key) == wanted and isinstance(value, (int, float)):
+            number = float(value)
+            if math.isfinite(number):
+                return number
+    for value in metrics.values():
+        if isinstance(value, (int, float)) and math.isfinite(float(value)):
+            return float(value)
+    return None
+
+
+def forecast_data_to_frame(forecast_data: list[dict[str, Any]]) -> pd.DataFrame:
+    """Parse ``forecast_data`` rows from ``back_testing.json``."""
+    if not forecast_data:
+        return pd.DataFrame(columns=["timestamp", "actual", "predicted", "lower_bound", "upper_bound"])
+    frame = pd.DataFrame(forecast_data)
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+    return frame.sort_values("timestamp")
+
+
+def per_window_metrics_table(
+    per_window_metrics: list[dict[str, Any]],
+    eval_metric: str,
+) -> pd.DataFrame:
+    """Build a per-cutoff metrics table aligned with AutoGluon backtest tutorials."""
+    rows: list[dict[str, Any]] = []
+    for index, window in enumerate(per_window_metrics):
+        metrics = window.get("metrics") or {}
+        metric_value = pick_window_metric(metrics, eval_metric)
+        rows.append(
+            {
+                "cutoff": window.get("cutoff"),
+                "window_id": window.get("window_id", index),
+                "test_start": window.get("test_start", ""),
+                "test_end": window.get("test_end", ""),
+                eval_metric: metric_value,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def mean_window_metric(per_window_metrics: list[dict[str, Any]], eval_metric: str) -> float | None:
+    """Return the mean ``eval_metric`` across validation windows (each window is all-series)."""
+    table = per_window_metrics_table(per_window_metrics, eval_metric)
+    if eval_metric not in table.columns:
+        return None
+    values = table[eval_metric].dropna()
+    if values.empty:
+        return None
+    mean = float(values.mean())
+    return mean if math.isfinite(mean) else None
+
+
+def _present_frame(frame: pd.DataFrame) -> None:
+    try:
+        from IPython.display import display
+
+        display(frame)
+    except ImportError:
+        print(frame.to_string(index=False))
+
+
+def _show_overall_backtest_summary(
+    per_window_metrics: list[dict[str, Any]],
+    eval_metric: str,
+    *,
+    num_series_evaluated: int | None = None,
+) -> None:
+    """Print mean ``eval_metric`` across windows (AutoGluon-style cross-series aggregate)."""
+    overall = mean_window_metric(per_window_metrics, eval_metric)
+    if overall is None:
+        return
+    window_count = len(per_window_metrics)
+    window_label = "window" if window_count == 1 else "windows"
+    summary = (
+        f"Overall {eval_metric} (mean across {window_count} validation {window_label}, all series): "
+        f"{overall:.6g}"
+    )
+    if num_series_evaluated is not None:
+        summary += f" | Series evaluated: {num_series_evaluated}"
+    print(summary)
+
+
+def _show_per_window_metrics(
+    per_window_metrics: list[dict[str, Any]],
+    eval_metric: str,
+    *,
+    num_series_evaluated: int | None = None,
+) -> None:
+    """Print cutoff scores and show a table (AutoGluon uses print + pivot, not bar charts)."""
+    table = per_window_metrics_table(per_window_metrics, eval_metric)
+    if eval_metric not in table.columns or table[eval_metric].notna().sum() == 0:
+        print(f"No finite {eval_metric} values per validation window.")
+        return
+
+    for _, row in table.iterrows():
+        value = row[eval_metric]
+        if pd.notna(value):
+            print(f"Cutoff {row['cutoff']}: {eval_metric} = {value}")
+
+    _present_frame(table)
+    _show_overall_backtest_summary(
+        per_window_metrics,
+        eval_metric,
+        num_series_evaluated=num_series_evaluated,
+    )
+
+
+def _style_date_axis(ax: plt.Axes) -> None:
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%m-%d"))
+    ax.tick_params(axis="x", labelsize=8, rotation=45)
+    plt.setp(ax.get_xticklabels(), ha="right")
+
+
+def _interval_label(frame: pd.DataFrame) -> str:
+    if {"lower_quantile", "upper_quantile"}.issubset(frame.columns):
+        lower = frame["lower_quantile"].dropna()
+        upper = frame["upper_quantile"].dropna()
+        if not lower.empty and not upper.empty:
+            lo = float(lower.iloc[0])
+            hi = float(upper.iloc[0])
+            return f"{lo * 100:.0f}%-{hi * 100:.0f}% interval"
+    return "10%-90% interval"
+
+
+def _draw_cutoff(ax: plt.Axes, cutoff_start: str | None) -> None:
+    if not cutoff_start:
+        return
+    ax.axvline(pd.to_datetime(cutoff_start), color=_CUTOFF, linestyle="--", alpha=0.7, label="Cutoff")
+
+
+def _draw_forecast(
+    ax: plt.Axes,
+    rows: list[dict[str, Any]],
+    *,
+    title: str,
+    target: str,
+    cutoff_start: str | None = None,
+) -> None:
+    frame = forecast_data_to_frame(rows)
+    if frame.empty:
+        raise ValueError("forecast_data is empty")
+
+    timestamps = frame["timestamp"]
+    if "actual" in frame.columns and frame["actual"].notna().any():
+        ax.plot(timestamps, frame["actual"], marker="o", color=_NEUTRAL, label=f"Actual ({target})")
+    ax.plot(timestamps, frame["predicted"], marker="s", linestyle="--", color=_ACCENT, label="Predicted")
+
+    if {"lower_bound", "upper_bound"}.issubset(frame.columns):
+        lower, upper = frame["lower_bound"], frame["upper_bound"]
+        if lower.notna().any() and upper.notna().any():
+            ax.fill_between(timestamps, lower, upper, alpha=0.1, color=_ACCENT, label=_interval_label(frame))
+
+    _draw_cutoff(ax, cutoff_start)
+
+    ax.set(title=title, xlabel="Date", ylabel=target)
+    ax.legend(loc="best", fontsize=8)
+    ax.grid(linestyle="--", alpha=0.3)
+    _style_date_axis(ax)
+
+
+def render_back_testing_charts(back_testing: dict[str, Any]) -> None:
+    """Render per-window metrics and best/worst holdout forecast panels."""
+    eval_metric = back_testing.get("eval_metric", "MASE")
+    target = back_testing.get("target", "target")
+
+    per_window = back_testing.get("per_window_metrics") or []
+    series_analysis = back_testing.get("series_analysis") or {}
+    num_series = series_analysis.get("num_series_evaluated")
+    _show_per_window_metrics(
+        per_window,
+        eval_metric,
+        num_series_evaluated=num_series if isinstance(num_series, int) else None,
+    )
+
+    plotted_ids: set[Any] = set()
+    for heading, role in (("Best", "best_performer"), ("Worst", "worst_performer")):
+        performer = series_analysis.get(role)
+        if not performer:
+            continue
+        item_id = performer.get("item_id")
+        if item_id in plotted_ids:
+            continue
+        plotted_ids.add(item_id)
+
+        item_windows = performer.get("windows") or []
+        if not item_windows:
+            continue
+
+        count = len(item_windows)
+        figure, axes = plt.subplots(1, count, figsize=(max(8.0, 4.0 * count), 4.2), squeeze=False)
+        window_starts = {
+            window.get("window_id"): window.get("test_start")
+            for window in per_window
+            if window.get("window_id") is not None
+        }
+        for index, window in enumerate(item_windows):
+            axis = axes[0, index]
+            window_id = window.get("window_id", index)
+            metric_value = pick_window_metric(window.get("metrics") or {}, eval_metric)
+            metric_text = f"{eval_metric}={metric_value:.3g}" if metric_value is not None else eval_metric
+            try:
+                _draw_forecast(
+                    axis,
+                    window.get("forecast_data") or [],
+                    title=f"Window {window_id} ({metric_text})",
+                    target=target,
+                    cutoff_start=window_starts.get(window_id),
+                )
+            except ValueError as exc:
+                print(exc)
+            if index:
+                axis.set_ylabel("")
+
+        figure.suptitle(f"{heading} performer: {item_id}", fontsize=12)
+        figure.tight_layout(rect=[0, 0.04, 1, 0.92])
+        plt.show()
+
+
+def notebook_backtest_charts_source() -> str:
+    """Return plotting module source copied into generated inference notebooks."""
+    source = Path(__file__).read_text(encoding="utf-8")
+    marker = "def notebook_backtest_charts_source"
+    return source.split(marker, maxsplit=1)[0]

--- a/components/training/automl/shared/back_testing_charts.py
+++ b/components/training/automl/shared/back_testing_charts.py
@@ -41,6 +41,43 @@ def pick_window_metric(metrics: dict[str, Any], eval_metric: str) -> float | Non
     return None
 
 
+def _resolve_item_id(item_id: Any, available_item_ids: list[Any]) -> Any | None:
+    """Map a backtest ``item_id`` to the matching ID in ``available_item_ids``."""
+    if item_id is None:
+        return None
+    if item_id in available_item_ids:
+        return item_id
+    item_text = str(item_id)
+    for candidate in available_item_ids:
+        if str(candidate) == item_text:
+            return candidate
+    return None
+
+
+def backtest_highlight_item_ids(
+    back_testing: dict[str, Any],
+    available_item_ids: list[Any],
+    *,
+    max_items: int = 4,
+) -> list[Any]:
+    """Return best/worst performer IDs from backtest JSON that exist in the sample data."""
+    if not available_item_ids or max_items <= 0:
+        return []
+
+    series_analysis = back_testing.get("series_analysis") or {}
+    resolved: list[Any] = []
+    for role in ("best_performer", "worst_performer"):
+        performer = series_analysis.get(role)
+        if not performer:
+            continue
+        item_id = _resolve_item_id(performer.get("item_id"), available_item_ids)
+        if item_id is not None and item_id not in resolved:
+            resolved.append(item_id)
+        if len(resolved) >= max_items:
+            break
+    return resolved[:max_items]
+
+
 def forecast_data_to_frame(forecast_data: list[dict[str, Any]]) -> pd.DataFrame:
     """Parse ``forecast_data`` rows from ``back_testing.json``."""
     if not forecast_data:
@@ -138,8 +175,102 @@ def _show_per_window_metrics(
 def _style_date_axis(ax: Any) -> None:
     plt, mdates = _matplotlib()
     ax.xaxis.set_major_formatter(mdates.DateFormatter("%m-%d"))
+    ax.xaxis.set_major_locator(mdates.AutoDateLocator(minticks=3, maxticks=8))
     ax.tick_params(axis="x", labelsize=8, rotation=45)
     plt.setp(ax.get_xticklabels(), ha="right")
+
+
+def _target_column_name(data: pd.DataFrame) -> str:
+    return str(data.columns[0])
+
+
+def _point_forecast_column(predictions: pd.DataFrame) -> str:
+    if "0.5" in predictions.columns:
+        return "0.5"
+    if "mean" in predictions.columns:
+        return "mean"
+    raise ValueError("predictions must include a 'mean' or '0.5' forecast column")
+
+
+def plot_timeseries_forecasts(
+    data: pd.DataFrame,
+    predictions: pd.DataFrame,
+    *,
+    item_ids: list[Any] | None = None,
+    quantile_levels: list[float] | None = None,
+    max_history_length: int | None = None,
+    target: str | None = None,
+) -> None:
+    """Plot history and forecast quantiles (AutoGluon ``predictor.plot``-compatible axes)."""
+    plt, _ = _matplotlib()
+    quantile_levels = quantile_levels or [0.1, 0.9]
+    q_low, q_high = (str(level) for level in quantile_levels[:2])
+    point_column = _point_forecast_column(predictions)
+
+    if item_ids is None:
+        if hasattr(data, "item_ids"):
+            plot_ids = list(data.item_ids)[:4]
+        elif isinstance(data.index, pd.MultiIndex):
+            plot_ids = list(data.index.get_level_values(0).unique()[:4])
+        else:
+            plot_ids = [None]
+    else:
+        plot_ids = list(item_ids)
+
+    target_name = target or _target_column_name(data)
+    count = max(len(plot_ids), 1)
+    figure, axes = plt.subplots(1, count, figsize=(max(8.0, 4.0 * count), 4.5), squeeze=False)
+
+    for index, item_id in enumerate(plot_ids):
+        axis = axes[0, index]
+        if item_id is None:
+            history = data
+            preds = predictions
+        else:
+            history = data.loc[item_id]
+            preds = predictions.loc[item_id]
+
+        if max_history_length:
+            history = history.iloc[-max_history_length:]
+
+        axis.plot(history.index, history.iloc[:, 0], label="Observed", color=_NEUTRAL)
+        point_forecast = preds[point_column]
+        axis.plot(
+            preds.index,
+            point_forecast,
+            marker="s",
+            linestyle="--",
+            color=_ACCENT,
+            label="Forecast",
+        )
+
+        if q_low in preds.columns and q_high in preds.columns:
+            axis.fill_between(
+                preds.index,
+                preds[q_low],
+                preds[q_high],
+                alpha=0.1,
+                color=_ACCENT,
+                label=f"P{float(q_low) * 100:.0f}-P{float(q_high) * 100:.0f} interval",
+            )
+
+        if not preds.index.empty:
+            axis.axvline(
+                preds.index[0],
+                color=_CUTOFF,
+                linestyle=":",
+                alpha=0.8,
+                label="Forecast start",
+            )
+
+        title = str(item_id) if item_id is not None else target_name
+        axis.set(title=title, xlabel="Date", ylabel=target_name if index == 0 else "")
+        axis.legend(loc="best", fontsize=8)
+        axis.grid(linestyle="--", alpha=0.3)
+        _style_date_axis(axis)
+
+    figure.tight_layout(rect=[0, 0.08, 1, 0.96])
+    plt.show()
 
 
 def _interval_label(frame: pd.DataFrame) -> str:
@@ -189,11 +320,9 @@ def _draw_forecast(
     _style_date_axis(ax)
 
 
-def render_back_testing_charts(back_testing: dict[str, Any]) -> None:
-    """Render per-window metrics and best/worst holdout forecast panels."""
+def render_back_testing_metrics(back_testing: dict[str, Any]) -> None:
+    """Print per-window backtest scores and summary table (no plots)."""
     eval_metric = back_testing.get("eval_metric", "MASE")
-    target = back_testing.get("target", "target")
-
     per_window = back_testing.get("per_window_metrics") or []
     series_analysis = back_testing.get("series_analysis") or {}
     num_series = series_analysis.get("num_series_evaluated")
@@ -202,6 +331,14 @@ def render_back_testing_charts(back_testing: dict[str, Any]) -> None:
         eval_metric,
         num_series_evaluated=num_series if isinstance(num_series, int) else None,
     )
+
+
+def render_back_testing_forecast_charts(back_testing: dict[str, Any]) -> None:
+    """Render best/worst holdout forecast matplotlib panels."""
+    eval_metric = back_testing.get("eval_metric", "MASE")
+    target = back_testing.get("target", "target")
+    per_window = back_testing.get("per_window_metrics") or []
+    series_analysis = back_testing.get("series_analysis") or {}
 
     plotted_ids: set[Any] = set()
     plt, _ = _matplotlib()
@@ -246,6 +383,12 @@ def render_back_testing_charts(back_testing: dict[str, Any]) -> None:
         figure.suptitle(f"{heading} performer: {item_id}", fontsize=12)
         figure.tight_layout(rect=[0, 0.04, 1, 0.92])
         plt.show()
+
+
+def render_back_testing_charts(back_testing: dict[str, Any]) -> None:
+    """Render per-window metrics and best/worst holdout forecast panels."""
+    render_back_testing_metrics(back_testing)
+    render_back_testing_forecast_charts(back_testing)
 
 
 def notebook_backtest_charts_source() -> str:

--- a/components/training/automl/shared/back_testing_charts.py
+++ b/components/training/automl/shared/back_testing_charts.py
@@ -173,11 +173,35 @@ def _show_per_window_metrics(
 
 
 def _style_date_axis(ax: Any) -> None:
-    plt, mdates = _matplotlib()
-    ax.xaxis.set_major_formatter(mdates.DateFormatter("%m-%d"))
-    ax.xaxis.set_major_locator(mdates.AutoDateLocator(minticks=3, maxticks=8))
+    """Rotate x labels to reduce overlap; keep matplotlib's default date formatting."""
+    plt, _ = _matplotlib()
     ax.tick_params(axis="x", labelsize=8, rotation=45)
     plt.setp(ax.get_xticklabels(), ha="right")
+
+
+def _resolve_cutoff_timestamp(cutoff_start: str | None, timestamps: pd.Series) -> pd.Timestamp | None:
+    """Map a window ``test_start`` bound onto plotted timestamps.
+
+    ``test_start`` is stored as YYYY-MM-DD for compact tables; for hourly (or sub-daily)
+    data that resolves to midnight and can sit left of the first plotted point.
+    """
+    if timestamps.empty:
+        return pd.to_datetime(cutoff_start, utc=True) if cutoff_start else None
+
+    first_ts = pd.Timestamp(timestamps.min())
+    if first_ts.tzinfo is not None:
+        first_ts = first_ts.tz_convert("UTC").tz_localize(None)
+
+    if not cutoff_start:
+        return first_ts
+
+    cutoff = pd.to_datetime(cutoff_start, utc=True)
+    if cutoff.tzinfo is not None:
+        cutoff = cutoff.tz_convert("UTC").tz_localize(None)
+
+    if cutoff.normalize() == cutoff and cutoff < first_ts:
+        return first_ts
+    return cutoff
 
 
 def _target_column_name(data: pd.DataFrame) -> str:
@@ -284,10 +308,16 @@ def _interval_label(frame: pd.DataFrame) -> str:
     return "10%-90% interval"
 
 
-def _draw_cutoff(ax: Any, cutoff_start: str | None) -> None:
-    if not cutoff_start:
+def _draw_cutoff(ax: Any, cutoff_start: str | None, timestamps: pd.Series | None = None) -> None:
+    if timestamps is not None:
+        cutoff = _resolve_cutoff_timestamp(cutoff_start, timestamps)
+    elif cutoff_start:
+        cutoff = pd.to_datetime(cutoff_start)
+    else:
         return
-    ax.axvline(pd.to_datetime(cutoff_start), color=_CUTOFF, linestyle="--", alpha=0.7, label="Cutoff")
+    if cutoff is None:
+        return
+    ax.axvline(cutoff, color=_CUTOFF, linestyle="--", alpha=0.7, label="Cutoff")
 
 
 def _draw_forecast(
@@ -312,7 +342,7 @@ def _draw_forecast(
         if lower.notna().any() and upper.notna().any():
             ax.fill_between(timestamps, lower, upper, alpha=0.1, color=_ACCENT, label=_interval_label(frame))
 
-    _draw_cutoff(ax, cutoff_start)
+    _draw_cutoff(ax, cutoff_start, timestamps)
 
     ax.set(title=title, xlabel="Date", ylabel=target)
     ax.legend(loc="best", fontsize=8)

--- a/components/training/automl/shared/back_testing_charts.py
+++ b/components/training/automl/shared/back_testing_charts.py
@@ -6,13 +6,19 @@ import math
 from pathlib import Path
 from typing import Any
 
-import matplotlib.dates as mdates
-import matplotlib.pyplot as plt
 import pandas as pd
 
 _ACCENT = "#EE0000"
 _NEUTRAL = "#161616"
 _CUTOFF = "gray"
+
+
+def _matplotlib():
+    """Import matplotlib on demand (same pattern as ROC/PR cells in tabular notebooks)."""
+    import matplotlib.dates as mdates
+    import matplotlib.pyplot as plt
+
+    return plt, mdates
 
 
 def _normalize_metric(metric: str) -> str:
@@ -98,10 +104,7 @@ def _show_overall_backtest_summary(
         return
     window_count = len(per_window_metrics)
     window_label = "window" if window_count == 1 else "windows"
-    summary = (
-        f"Overall {eval_metric} (mean across {window_count} validation {window_label}, all series): "
-        f"{overall:.6g}"
-    )
+    summary = f"Overall {eval_metric} (mean across {window_count} validation {window_label}, all series): {overall:.6g}"
     if num_series_evaluated is not None:
         summary += f" | Series evaluated: {num_series_evaluated}"
     print(summary)
@@ -132,7 +135,8 @@ def _show_per_window_metrics(
     )
 
 
-def _style_date_axis(ax: plt.Axes) -> None:
+def _style_date_axis(ax: Any) -> None:
+    plt, mdates = _matplotlib()
     ax.xaxis.set_major_formatter(mdates.DateFormatter("%m-%d"))
     ax.tick_params(axis="x", labelsize=8, rotation=45)
     plt.setp(ax.get_xticklabels(), ha="right")
@@ -149,14 +153,14 @@ def _interval_label(frame: pd.DataFrame) -> str:
     return "10%-90% interval"
 
 
-def _draw_cutoff(ax: plt.Axes, cutoff_start: str | None) -> None:
+def _draw_cutoff(ax: Any, cutoff_start: str | None) -> None:
     if not cutoff_start:
         return
     ax.axvline(pd.to_datetime(cutoff_start), color=_CUTOFF, linestyle="--", alpha=0.7, label="Cutoff")
 
 
 def _draw_forecast(
-    ax: plt.Axes,
+    ax: Any,
     rows: list[dict[str, Any]],
     *,
     title: str,
@@ -200,6 +204,7 @@ def render_back_testing_charts(back_testing: dict[str, Any]) -> None:
     )
 
     plotted_ids: set[Any] = set()
+    plt, _ = _matplotlib()
     for heading, role in (("Best", "best_performer"), ("Worst", "worst_performer")):
         performer = series_analysis.get(role)
         if not performer:

--- a/components/training/automl/shared/notebook_templates/timeseries_notebook.ipynb
+++ b/components/training/automl/shared/notebook_templates/timeseries_notebook.ipynb
@@ -1,512 +1,504 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "a12d957a-c313-4e92-9578-44f6a48560d5",
-      "metadata": {},
-      "source": [
-        "<img src='data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxNzk2IDEwMCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMTc5NiAxMDA7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7ZmlsbDp1cmwoI1NWR0lEXzFfKTt9Cgkuc3Qxe2ZpbGw6bm9uZTtzdHJva2U6I0ZGRkZGRjtzdHJva2Utd2lkdGg6MjtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3Qye2ZpbGw6bm9uZTtzdHJva2U6I0ZGRkZGRjtzdHJva2Utd2lkdGg6MS41O3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDN7ZmlsbDojRkZGRkZGO30KCS5zdDR7Zm9udC1mYW1pbHk6J0hlbHZldGljYSBOZXVlJywgQXJpYWwsIHNhbnMtc2VyaWY7fQoJLnN0NXtmb250LXNpemU6MzJweDt9Cgkuc3Q2e2ZpbGw6IzNEM0QzRDt9Cgkuc3Q3e2ZpbGw6IzkzOTU5ODt9Cgkuc3Q4e29wYWNpdHk6MC4yO2ZpbGw6dXJsKCNTVkdJRF8yXyk7ZW5hYmxlLWJhY2tncm91bmQ6bmV3O30KCS5zdDl7Zm9udC13ZWlnaHQ6NTAwO30KPC9zdHlsZT4KPHJlY3Qgd2lkdGg9IjE3OTYiIGhlaWdodD0iMTAwIiBmaWxsPSIjMTYxNjE2Ii8+CjxsaW5lYXJHcmFkaWVudCBpZD0iU1ZHSURfMV8iIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIiB4MT0iNDIuODYiIHkxPSI1MCIgeDI9Ijc5LjcxIiB5Mj0iNTAiPgoJPHN0b3Agb2Zmc2V0PSIwIiBzdHlsZT0ic3RvcC1jb2xvcjojRkY2QjZCIi8+Cgk8c3RvcCBvZmZzZXQ9IjAuMjEiIHN0eWxlPSJzdG9wLWNvbG9yOiNFRTAwMDAiLz4KCTxzdG9wIG9mZnNldD0iMC43NSIgc3R5bGU9InN0b3AtY29sb3I6I0NDMDAwMCIvPgoJPHN0b3Agb2Zmc2V0PSIxIiBzdHlsZT0ic3RvcC1jb2xvcjojQUEwMDAwIi8+CjwvbGluZWFyR3JhZGllbnQ+CjwhLS0gQXV0b01MIEljb24vTG9nbyBwbGFjZWhvbGRlciAtIHNpbXBsaWZpZWQgZ2VvbWV0cmljIHNoYXBlIC0tPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNTIuNCw0NS45YzAtMi4zLDEuOC00LjEsNC4xLTQuMXM0LjEsMS44LDQuMSw0LjFTNTguOCw1MCw1Ni41LDUwbDAsMGMtMi4yLDAuMS00LTEuNy00LjEtMy45CglDNTIuNCw0Niw1Mi40LDQ2LDUyLjQsNDUuOXogTTc3LjUsNTIuNWMtMC44LTEuMS0xLjQtMi4zLTEuOS0zLjVjMS4yLTQuNSwwLjctOC42LTEuOC0xMS45Yy0yLjktMy44LTguMi02LTE0LjUtNi4xCgljLTQuNS0wLjEtOC44LDEuNy0xMiw0LjhjLTMsMy00LjYsNy4yLTQuNSwxMS41Yy0wLjEsMi45LDAuOSw1LjgsMi43LDguMWMwLjgsMC44LDEuMywxLjksMS40LDN2NC41Yy0wLjgsMC41LTEuNCwxLjMtMS40LDIuMwoJYzAuMiwxLjUsMS41LDIuNiwzLDIuNGMxLjItMC4yLDIuMi0xLjEsMi40LTIuNGMwLTEtMC41LTEuOS0xLjQtMi4zdi00LjVjMC0yLTEtMy4zLTEuOS00LjZjLTEuNS0xLjktMi4yLTQuMi0yLjEtNi41CgljMC0zLjUsMS40LTYuOSwzLjgtOS40YzIuNy0yLjcsNi4zLTQuMSwxMC00LjFjNS41LDAsOS44LDEuOSwxMi4xLDVjMiwyLjgsMi41LDYuMywxLjQsOS42Yy0wLjQsMS4yLDAuNiwyLjcsMi4zLDUuNgoJYzAuNiwwLjksMS4yLDEuOSwxLjYsMi45Yy0wLjksMC43LTIsMS4yLTMuMSwxLjVjLTAuNSwwLjQtMC43LDAuOS0wLjgsMS41VjY1YzAsMC40LTAuMSwwLjgtMC40LDEuMWMtMC4zLDAuMi0wLjcsMC4zLTEuMSwwLjMKCWMtMS42LTAuMy0zLjQtMC43LTUuMi0xLjF2LTQuOGMwLjgtMC41LDEuNC0xLjQsMS40LTIuM2MwLTEuNS0xLjItMi43LTIuNy0yLjdzLTIuNywxLjItMi43LDIuN2MwLDEsMC41LDEuOSwxLjQsMi4zdjQuMQoJYy0wLjQtMC4xLTAuNy0wLjEtMS4xLTAuM2MtNC41LTEuMS00LjUtMi42LTQuNS0zLjR2LTguM2MzLjItMC43LDUuNC0zLjUsNS41LTYuN2MtMC4xLTMuOC0zLjMtNi43LTcuMS02LjZjLTMuNiwwLjEtNi40LDMtNi42LDYuNgoJYzAsMy4yLDIuMyw2LDUuNSw2Ljd2OC4zYzAsMiwwLjcsNC42LDYuNiw2LjFjMywwLjgsNiwxLjUsOS4xLDEuOWMwLjMsMCwwLjYsMC4xLDAuOCwwLjFjMSwwLDEuOS0wLjMsMi42LTEKCWMwLjktMC44LDEuNC0xLjksMS40LTMuMXYtNC41YzItMC44LDQuMS0yLDQuMS0zLjdDNzkuNyw1NS45LDc5LDU0LjYsNzcuNSw1Mi41eiIvPgo8Y2lyY2xlIGNsYXNzPSJzdDEiIGN4PSI1Ni41IiBjeT0iNDUuOSIgcj0iNS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MiIgY3g9IjQ4LjMiIGN5PSI2NSIgcj0iMS42Ii8+CjxjaXJjbGUgY2xhc3M9InN0MiIgY3g9IjY0LjgiIGN5PSI1OC4yIiByPSIxLjYiLz4KPHRleHQgdHJhbnNmb3JtPSJtYXRyaXgoMSAwIDAgMSAxMDEuMDIgNTkuMzMpIiBjbGFzcz0ic3QzIHN0NCBzdDUiPkF1dG9NTDwvdGV4dD4KPHJlY3QgeD0iMjMxLjEiIHk9IjM0IiBjbGFzcz0ic3Q2IiB3aWR0aD0iMSIgaGVpZ2h0PSIzMiIvPgo8dGV4dCB0cmFuc2Zvcm09Im1hdHJpeCgxIDAgMCAxIDI1Ni4yOSA1OS42NikiIGNsYXNzPSJzdDcgc3Q0IHN0NSI+UGFydCBvZiBSZWQgSGF0IE9wZW5TaGlmdCBBSTwvdGV4dD4KPGxpbmVhckdyYWRpZW50IGlkPSJTVkdJRF8yXyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiIHgxPSI3NzMuOCIgeTE9IjUwIiB4Mj0iMTc5NiIgeTI9IjUwIj4KCTxzdG9wIG9mZnNldD0iMCIgc3R5bGU9InN0b3AtY29sb3I6IzE2MTYxNiIvPgoJPHN0b3Agb2Zmc2V0PSIwLjUyIiBzdHlsZT0ic3RvcC1jb2xvcjojRkY2QjZCIi8+Cgk8c3RvcCBvZmZzZXQ9IjAuNjIiIHN0eWxlPSJzdG9wLWNvbG9yOiNFRTAwMDAiLz4KCTxzdG9wIG9mZnNldD0iMC44OCIgc3R5bGU9InN0b3AtY29sb3I6I0NDMDAwMCIvPgoJPHN0b3Agb2Zmc2V0PSIxIiBzdHlsZT0ic3RvcC1jb2xvcjojQUEwMDAwIi8+CjwvbGluZWFyR3JhZGllbnQ+CjxyZWN0IHg9Ijc3My44IiBjbGFzcz0ic3Q4IiB3aWR0aD0iMTAyMi4yIiBoZWlnaHQ9IjEwMCIvPgo8dGV4dCB0cmFuc2Zvcm09Im1hdHJpeCgxIDAgMCAxIDE0NDguMTY0MSA1OS40NikiIGNsYXNzPSJzdDMgc3Q0IHN0NSBzdDkiPlByZWRpY3RvciBOb3RlYm9vazwvdGV4dD4KPC9zdmc+Cg==' />"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "0e9aa72f",
-      "metadata": {},
-      "source": [
-        "## Notebook content\n",
-        "\n",
-        "This notebook is for **AutoGluon Time Series** models produced by the timeseries training pipeline. It helps you:\n",
-        "\n",
-        "- Load a refitted model artifact from S3 (same run as the pipeline).\n",
-        "- Inspect test metrics and predictor metadata.\n",
-        "- Run **`TimeSeriesPredictor.predict()`** to forecast the next `prediction_length` steps per time series.\n",
-        "\n",
-        "**Tips**\n",
-        "\n",
-        "- Configure S3 access (workbench secret or `.env`) so the notebook can download `model_artifact/.../<MODEL>_FULL/`.\n",
-        "- `model_name` must match the refitted model folder (e.g. `ETS_FULL`, `Naive_FULL`), as in the pipeline leaderboard.\n",
-        "- For `predict`, pass historical rows per `item_id` (target column + timestamps). The model forecasts after the last timestamp you provide—not a single “score row” like tabular classification.\n",
-        "\n",
-        "### Contents\n",
-        "\n",
-        "**[Setup](#setup)**  \n",
-        "**[Experiment run details](#experiment-run-details)**  \n",
-        "**[Download trained model](#download-trained-model)**  \n",
-        "**[Model insights](#model-insights)**  \n",
-        "**[Back-testing metrics](#back-testing-metrics)**  \n",
-        "**[Back-testing charts](#back-testing-charts)**  \n",
-        "**[Load the predictor](#load-the-predictor)**  \n",
-        "**[Refit training leaderboard](#refit-training-leaderboard)**  \n",
-        "**[Forecast (predict)](#predict-the-values)**  \n",
-        "**[Plot forecasted data](#plot-forecasted-data)**  \n",
-        "**[Summary and next steps](#summary-and-next-steps)**"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a7d9cf2b-18cc-4ac9-87af-a74f8bf60322",
-      "metadata": {},
-      "source": [
-        "<a id=\"setup\"></a>\n",
-        "## Setup"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "5bacd972",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import warnings\n",
-        "\n",
-        "warnings.filterwarnings(\"ignore\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cec84205-8ee9-4aaf-a97e-4ef576e7b9da",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "os.environ[\"PIP_EXTRA_INDEX_URL\"] = (\n",
-        "    \"https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9/simple/\"\n",
-        ")\n",
-        "\n",
-        "%pip install autogluon.timeseries==1.5.0+rhaiv.3 | tail -n 1\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e8ff506e-f1a3-4990-a979-7790a5105251",
-      "metadata": {},
-      "source": [
-        "<a id=\"experiment-run-details\"></a>\n",
-        "## Experiment run details\n",
-        "\n",
-        "Set the pipeline name and run ID that identify the training run whose artifacts you want to load. These values are typically available from the pipeline run or workbench."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fa7f736d-0b5c-4988-87a5-4d1a5cde0873",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "pipeline_name = \"<REPLACE_PIPELINE_NAME>\"\n",
-        "run_id = \"<REPLACE_RUN_ID>\"\n",
-        "model_name = \"<REPLACE_MODEL_NAME>\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "54525a94-7799-41cc-822e-91bae88b3b78",
-      "metadata": {},
-      "source": [
-        "<a id=\"download-trained-model\"></a>\n",
-        "## Download trained model\n",
-        "\n",
-        " 📌 **Action:** Ensure the S3 connection is added to the workbench so the notebook can access the results."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "fba16ca7-b15f-4d7a-95b4-d3cf73163440",
-      "metadata": {},
-      "source": [
-        "Download the refitted model directory from S3: `predictor/`, `metrics/`, `notebooks/` under `models_artifact/<model_name>/`.\n",
-        "\n",
-        "The download cell lists objects under `<pipeline_name>/<run_id>/autogluon-timeseries-models-training/` and matches keys containing `models_artifact/<model_name>/`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "e88370df-ecda-453d-913a-9524088ccc36",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import boto3\n",
-        "import os\n",
-        "import warnings\n",
-        "\n",
-        "from botocore.exceptions import SSLError\n",
-        "\n",
-        "required_env_vars = (\n",
-        "    \"AWS_S3_ENDPOINT\",\n",
-        "    \"AWS_ACCESS_KEY_ID\",\n",
-        "    \"AWS_SECRET_ACCESS_KEY\",\n",
-        "    \"AWS_S3_BUCKET\",\n",
-        ")\n",
-        "missing_vars = [name for name in required_env_vars if not os.environ.get(name, \"\").strip()]\n",
-        "\n",
-        "if missing_vars:\n",
-        "    raise ValueError(\n",
-        "        f\"Missing required environment variable(s): {', '.join(missing_vars)}. \"\n",
-        "        \"Attach your S3 connection to this notebook workbench and try again.\"\n",
-        "    )\n",
-        "\n",
-        "\n",
-        "def _get_s3_bucket(verify=True):\n",
-        "    return boto3.resource(\n",
-        "        \"s3\",\n",
-        "        endpoint_url=os.environ[\"AWS_S3_ENDPOINT\"],\n",
-        "        verify=verify,\n",
-        "    ).Bucket(os.environ[\"AWS_S3_BUCKET\"])\n",
-        "\n",
-        "\n",
-        "def _download_model(bucket):\n",
-        "    full_refit_prefix = os.path.join(pipeline_name, run_id, \"autogluon-timeseries-models-training\")\n",
-        "    best_model_subpath = os.path.join(\"models_artifact\", model_name)\n",
-        "    marker = best_model_subpath + \"/\"\n",
-        "    base_dir = os.path.abspath(model_name)\n",
-        "    for obj in bucket.objects.filter(Prefix=full_refit_prefix):\n",
-        "        if obj.key.endswith(\"/\") or marker not in obj.key:\n",
-        "            continue\n",
-        "        relative = obj.key.split(marker, 1)[1]\n",
-        "        relative = os.path.normpath(relative)\n",
-        "        if relative == \".\" or relative.startswith(\"..\") or os.path.isabs(relative):\n",
-        "            warnings.warn(f\"Skipping due to invalid path detected: {obj.key!r}\")\n",
-        "            continue\n",
-        "        target = os.path.join(model_name, relative)\n",
-        "        abs_target = os.path.abspath(target)\n",
-        "        if abs_target != base_dir and not abs_target.startswith(base_dir + os.sep):\n",
-        "            warnings.warn(f\"Skipping due to invalid path detected: {obj.key!r}\")\n",
-        "            continue\n",
-        "        parent = os.path.dirname(abs_target)\n",
-        "        if parent:\n",
-        "            os.makedirs(parent, exist_ok=True)\n",
-        "        bucket.download_file(obj.key, target)\n",
-        "    return model_name\n",
-        "\n",
-        "\n",
-        "try:\n",
-        "    best_model_path = _download_model(_get_s3_bucket())\n",
-        "except SSLError:\n",
-        "    warnings.warn(\"SSL error when accessing S3, retrying with verify=False\")\n",
-        "    best_model_path = _download_model(_get_s3_bucket(verify=False))\n",
-        "\n",
-        "print(\"Model artifact stored under\", best_model_path)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cf53ddb3-14af-44e2-9c5d-6636095cb2b5",
-      "metadata": {},
-      "source": [
-        "<a id=\"model-insights\"></a>\n",
-        "## Model insights"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1df774b4",
-      "metadata": {},
-      "source": [
-        "### Metrics\n",
-        "\n",
-        "Metrics computed on the holdout test `TimeSeriesDataFrame` during pipeline refit (e.g. MASE, WQL). Signs may be flipped so higher is better, per AutoGluon convention."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f71f38c1",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import json\n",
-        "import os\n",
-        "\n",
-        "import pandas as pd\n",
-        "\n",
-        "with open(os.path.join(best_model_path, \"metrics\", \"metrics.json\")) as f:\n",
-        "    metrics = pd.json_normalize(json.load(f))\n",
-        "\n",
-        "metrics"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "6f766335",
-      "metadata": {},
-      "source": [
-        "<a id=\"back-testing-metrics\"></a>\n",
-        "### Back-testing metrics\n",
-        "\n",
-        "Rolling validation scores from ``metrics/back_testing.json`` (AutoGluon-style ``Cutoff …: MASE = …`` lines, per-window table, and overall mean). Scores are positive error values; AutoGluon ``evaluate()`` negates them interactively."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "201fb693",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "<REPLACE_BACKTEST_PLOT_HELPERS>\n",
-        "\n",
-        "import json\n",
-        "from pathlib import Path\n",
-        "\n",
-        "back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\n",
-        "if not back_testing_path.is_file():\n",
-        "    print(\"back_testing.json was not found for this model (older pipeline runs may omit it).\")\n",
-        "else:\n",
-        "    with back_testing_path.open(encoding=\"utf-8\") as f:\n",
-        "        back_testing = json.load(f)\n",
-        "    render_back_testing_metrics(back_testing)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b4c8e2a1-backtest-charts",
-      "metadata": {},
-      "source": [
-        "<a id=\"back-testing-charts\"></a>\n",
-        "### Back-testing charts\n",
-        "\n",
-        "Best/worst series holdout forecasts from ``metrics/back_testing.json``. Run **Back-testing metrics** first (defines helpers). Uses **matplotlib** like tabular ROC/PR curves; no ``TimeSeriesPredictor`` required."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "c7d9f3b2-backtest-plots",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\n",
-        "if not back_testing_path.is_file():\n",
-        "    print(\"Skipping backtest charts: back_testing.json not found.\")\n",
-        "elif \"render_back_testing_forecast_charts\" not in globals():\n",
-        "    print(\"Run the Back-testing metrics cell first.\")\n",
-        "else:\n",
-        "    render_back_testing_forecast_charts(back_testing)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "6686ef6f-3251-43fa-bc9d-a9e911c7908c",
-      "metadata": {},
-      "source": [
-        "<a id=\"load-the-predictor\"></a>\n",
-        "## Load the predictor\n",
-        "\n",
-        "Load a **`TimeSeriesPredictor`** from the downloaded `predictor/` directory (not `TabularPredictor`)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 20,
-      "id": "9ebc576f-17eb-49a7-8dcb-6b237dcc2218",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesPredictor\n",
-        "\n",
-        "predictor = TimeSeriesPredictor.load(os.path.join(best_model_path, \"predictor\"), require_version_match=False)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ts-leaderboard-md",
-      "metadata": {},
-      "source": [
-        "<a id=\"refit-training-leaderboard\"></a>\n",
-        "### Refit training leaderboard\n",
-        "\n",
-        "Run after **Load the predictor**. Shows models trained in this refit step (often one row)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ts-leaderboard-inspect",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Models in this refit predictor (refit often trains one model)\n",
-        "predictor.leaderboard()\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "57cc1e1a-707f-431f-9cb5-1d24e09d1249",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "predictor.info()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "064c76e4-1b44-4bba-8f2b-3178633a326a",
-      "metadata": {},
-      "source": [
-        "<a id=\"predict-the-values\"></a>\n",
-        "## Forecast (`predict`)\n",
-        "\n",
-        "Use the sample data below (embedded when this notebook was generated) as historical context for ``predict()``. When the model uses known covariates, future covariate values for the forecast horizon are included in the same payload."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d6955253-1891-4ff7-8b3e-ffa338d928f8",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import pandas as pd\n",
-        "\n",
-        "sample = <REPLACE_PREDICT_SAMPLE>\n",
-        "\n",
-        "history = pd.DataFrame(sample[\"history\"])\n",
-        "history[sample[\"timestamp_column\"]] = pd.to_datetime(history[sample[\"timestamp_column\"]])\n",
-        "\n",
-        "ts_df = TimeSeriesDataFrame.from_data_frame(\n",
-        "    history,\n",
-        "    id_column=sample[\"id_column\"],\n",
-        "    timestamp_column=sample[\"timestamp_column\"],\n",
-        ")\n",
-        "\n",
-        "known_covariates = None\n",
-        "if sample.get(\"known_covariates\"):\n",
-        "    known_covariates = pd.DataFrame(sample[\"known_covariates\"])\n",
-        "    known_covariates[\"timestamp\"] = pd.to_datetime(known_covariates[\"timestamp\"])\n",
-        "\n",
-        "ts_df.head()\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f07e1d71-85e8-4484-877a-5af40547de4f",
-      "metadata": {},
-      "source": [
-        "Run **`predict`** to get quantile forecasts. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "8441133b-2984-4ea9-92a1-4e427d25ee1b",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "forecasts = predictor.predict(\n",
-        "    ts_df,\n",
-        "    known_covariates=known_covariates,\n",
-        "    use_cache=False,\n",
-        ")\n",
-        "forecasts\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "7c1d5562",
-      "metadata": {},
-      "source": [
-        "<a id=\"plot-forecasted-data\"></a>\n",
-        "### Plot forecasted data\n",
-        "\n",
-        "Visualize historical values and the forecast distribution (mean and 10%/90% interval). Uses **matplotlib** with the same date-axis styling as back-testing charts (aligned with [AutoGluon ``predictor.plot()``](https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-quick-start.html)). When ``back_testing.json`` is available (run **Back-testing metrics** first), plots the same best/worst series as the backtest charts; otherwise uses the first series in the embedded sample."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "65ad5642",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import json\n",
-        "from pathlib import Path\n",
-        "\n",
-        "available_item_ids = list(ts_df.item_ids)\n",
-        "plot_item_ids = available_item_ids[:4]\n",
-        "\n",
-        "back_testing_for_plot = globals().get(\"back_testing\")\n",
-        "if back_testing_for_plot is None:\n",
-        "    back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\n",
-        "    if back_testing_path.is_file():\n",
-        "        with back_testing_path.open(encoding=\"utf-8\") as f:\n",
-        "            back_testing_for_plot = json.load(f)\n",
-        "\n",
-        "if back_testing_for_plot and \"backtest_highlight_item_ids\" in globals():\n",
-        "    highlight_ids = backtest_highlight_item_ids(back_testing_for_plot, available_item_ids)\n",
-        "    if highlight_ids:\n",
-        "        plot_item_ids = highlight_ids\n",
-        "        print(\"Plotting backtest best/worst performers:\", plot_item_ids)\n",
-        "    else:\n",
-        "        print(\"Backtest performers not in sample; plotting first sample series.\")\n",
-        "elif back_testing_for_plot:\n",
-        "    print(\"Run Back-testing metrics first to align plot series with backtest charts.\")\n",
-        "\n",
-        "if isinstance(ts_df.index, pd.MultiIndex):\n",
-        "    history_limit = min(200, int(ts_df.groupby(level=0).size().min()))\n",
-        "else:\n",
-        "    history_limit = min(200, len(ts_df))\n",
-        "\n",
-        "if \"plot_timeseries_forecasts\" not in globals():\n",
-        "    print(\"Run Back-testing metrics first (defines plot helpers).\")\n",
-        "else:\n",
-        "    plot_timeseries_forecasts(\n",
-        "        data=ts_df,\n",
-        "        predictions=forecasts,\n",
-        "        item_ids=plot_item_ids,\n",
-        "        quantile_levels=[0.1, 0.9],\n",
-        "        max_history_length=history_limit,\n",
-        "    )"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "7ee6d313-4612-4fb9-bee2-b2dcc83772ef",
-      "metadata": {},
-      "source": [
-        "<a id=\"summary-and-next-steps\"></a>\n",
-        "## Summary and next steps\n",
-        "\n",
-        "**Summary:** Loaded an AutoGluon Time Series predictor from S3 and ran **`predict()`** to forecast `prediction_length` steps ahead per item.\n",
-        "\n",
-        "**Next steps:**\n",
-        "- Run predictions on your own data (ensure columns match the training schema).\n",
-        "- Optionally create the Predictor's online deployment using KServe custom runtime."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "44a650c8-e5cc-4a2e-bebd-becd73944489",
-      "metadata": {},
-      "source": [
-        "---"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": ".venv",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.12"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a12d957a-c313-4e92-9578-44f6a48560d5",
+   "metadata": {},
+   "source": [
+    "<img src='data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxNzk2IDEwMCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMTc5NiAxMDA7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7ZmlsbDp1cmwoI1NWR0lEXzFfKTt9Cgkuc3Qxe2ZpbGw6bm9uZTtzdHJva2U6I0ZGRkZGRjtzdHJva2Utd2lkdGg6MjtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9Cgkuc3Qye2ZpbGw6bm9uZTtzdHJva2U6I0ZGRkZGRjtzdHJva2Utd2lkdGg6MS41O3N0cm9rZS1taXRlcmxpbWl0OjEwO30KCS5zdDN7ZmlsbDojRkZGRkZGO30KCS5zdDR7Zm9udC1mYW1pbHk6J0hlbHZldGljYSBOZXVlJywgQXJpYWwsIHNhbnMtc2VyaWY7fQoJLnN0NXtmb250LXNpemU6MzJweDt9Cgkuc3Q2e2ZpbGw6IzNEM0QzRDt9Cgkuc3Q3e2ZpbGw6IzkzOTU5ODt9Cgkuc3Q4e29wYWNpdHk6MC4yO2ZpbGw6dXJsKCNTVkdJRF8yXyk7ZW5hYmxlLWJhY2tncm91bmQ6bmV3O30KCS5zdDl7Zm9udC13ZWlnaHQ6NTAwO30KPC9zdHlsZT4KPHJlY3Qgd2lkdGg9IjE3OTYiIGhlaWdodD0iMTAwIiBmaWxsPSIjMTYxNjE2Ii8+CjxsaW5lYXJHcmFkaWVudCBpZD0iU1ZHSURfMV8iIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIiB4MT0iNDIuODYiIHkxPSI1MCIgeDI9Ijc5LjcxIiB5Mj0iNTAiPgoJPHN0b3Agb2Zmc2V0PSIwIiBzdHlsZT0ic3RvcC1jb2xvcjojRkY2QjZCIi8+Cgk8c3RvcCBvZmZzZXQ9IjAuMjEiIHN0eWxlPSJzdG9wLWNvbG9yOiNFRTAwMDAiLz4KCTxzdG9wIG9mZnNldD0iMC43NSIgc3R5bGU9InN0b3AtY29sb3I6I0NDMDAwMCIvPgoJPHN0b3Agb2Zmc2V0PSIxIiBzdHlsZT0ic3RvcC1jb2xvcjojQUEwMDAwIi8+CjwvbGluZWFyR3JhZGllbnQ+CjwhLS0gQXV0b01MIEljb24vTG9nbyBwbGFjZWhvbGRlciAtIHNpbXBsaWZpZWQgZ2VvbWV0cmljIHNoYXBlIC0tPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNTIuNCw0NS45YzAtMi4zLDEuOC00LjEsNC4xLTQuMXM0LjEsMS44LDQuMSw0LjFTNTguOCw1MCw1Ni41LDUwbDAsMGMtMi4yLDAuMS00LTEuNy00LjEtMy45CglDNTIuNCw0Niw1Mi40LDQ2LDUyLjQsNDUuOXogTTc3LjUsNTIuNWMtMC44LTEuMS0xLjQtMi4zLTEuOS0zLjVjMS4yLTQuNSwwLjctOC42LTEuOC0xMS45Yy0yLjktMy44LTguMi02LTE0LjUtNi4xCgljLTQuNS0wLjEtOC44LDEuNy0xMiw0LjhjLTMsMy00LjYsNy4yLTQuNSwxMS41Yy0wLjEsMi45LDAuOSw1LjgsMi43LDguMWMwLjgsMC44LDEuMywxLjksMS40LDN2NC41Yy0wLjgsMC41LTEuNCwxLjMtMS40LDIuMwoJYzAuMiwxLjUsMS41LDIuNiwzLDIuNGMxLjItMC4yLDIuMi0xLjEsMi40LTIuNGMwLTEtMC41LTEuOS0xLjQtMi4zdi00LjVjMC0yLTEtMy4zLTEuOS00LjZjLTEuNS0xLjktMi4yLTQuMi0yLjEtNi41CgljMC0zLjUsMS40LTYuOSwzLjgtOS40YzIuNy0yLjcsNi4zLTQuMSwxMC00LjFjNS41LDAsOS44LDEuOSwxMi4xLDVjMiwyLjgsMi41LDYuMywxLjQsOS42Yy0wLjQsMS4yLDAuNiwyLjcsMi4zLDUuNgoJYzAuNiwwLjksMS4yLDEuOSwxLjYsMi45Yy0wLjksMC43LTIsMS4yLTMuMSwxLjVjLTAuNSwwLjQtMC43LDAuOS0wLjgsMS41VjY1YzAsMC40LTAuMSwwLjgtMC40LDEuMWMtMC4zLDAuMi0wLjcsMC4zLTEuMSwwLjMKCWMtMS42LTAuMy0zLjQtMC43LTUuMi0xLjF2LTQuOGMwLjgtMC41LDEuNC0xLjQsMS40LTIuM2MwLTEuNS0xLjItMi43LTIuNy0yLjdzLTIuNywxLjItMi43LDIuN2MwLDEsMC41LDEuOSwxLjQsMi4zdjQuMQoJYy0wLjQtMC4xLTAuNy0wLjEtMS4xLTAuM2MtNC41LTEuMS00LjUtMi42LTQuNS0zLjR2LTguM2MzLjItMC43LDUuNC0zLjUsNS41LTYuN2MtMC4xLTMuOC0zLjMtNi43LTcuMS02LjZjLTMuNiwwLjEtNi40LDMtNi42LDYuNgoJYzAsMy4yLDIuMyw2LDUuNSw2Ljd2OC4zYzAsMiwwLjcsNC42LDYuNiw2LjFjMywwLjgsNiwxLjUsOS4xLDEuOWMwLjMsMCwwLjYsMC4xLDAuOCwwLjFjMSwwLDEuOS0wLjMsMi42LTEKCWMwLjktMC44LDEuNC0xLjksMS40LTMuMXYtNC41YzItMC44LDQuMS0yLDQuMS0zLjdDNzkuNyw1NS45LDc5LDU0LjYsNzcuNSw1Mi41eiIvPgo8Y2lyY2xlIGNsYXNzPSJzdDEiIGN4PSI1Ni41IiBjeT0iNDUuOSIgcj0iNS40Ii8+CjxjaXJjbGUgY2xhc3M9InN0MiIgY3g9IjQ4LjMiIGN5PSI2NSIgcj0iMS42Ii8+CjxjaXJjbGUgY2xhc3M9InN0MiIgY3g9IjY0LjgiIGN5PSI1OC4yIiByPSIxLjYiLz4KPHRleHQgdHJhbnNmb3JtPSJtYXRyaXgoMSAwIDAgMSAxMDEuMDIgNTkuMzMpIiBjbGFzcz0ic3QzIHN0NCBzdDUiPkF1dG9NTDwvdGV4dD4KPHJlY3QgeD0iMjMxLjEiIHk9IjM0IiBjbGFzcz0ic3Q2IiB3aWR0aD0iMSIgaGVpZ2h0PSIzMiIvPgo8dGV4dCB0cmFuc2Zvcm09Im1hdHJpeCgxIDAgMCAxIDI1Ni4yOSA1OS42NikiIGNsYXNzPSJzdDcgc3Q0IHN0NSI+UGFydCBvZiBSZWQgSGF0IE9wZW5TaGlmdCBBSTwvdGV4dD4KPGxpbmVhckdyYWRpZW50IGlkPSJTVkdJRF8yXyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiIHgxPSI3NzMuOCIgeTE9IjUwIiB4Mj0iMTc5NiIgeTI9IjUwIj4KCTxzdG9wIG9mZnNldD0iMCIgc3R5bGU9InN0b3AtY29sb3I6IzE2MTYxNiIvPgoJPHN0b3Agb2Zmc2V0PSIwLjUyIiBzdHlsZT0ic3RvcC1jb2xvcjojRkY2QjZCIi8+Cgk8c3RvcCBvZmZzZXQ9IjAuNjIiIHN0eWxlPSJzdG9wLWNvbG9yOiNFRTAwMDAiLz4KCTxzdG9wIG9mZnNldD0iMC44OCIgc3R5bGU9InN0b3AtY29sb3I6I0NDMDAwMCIvPgoJPHN0b3Agb2Zmc2V0PSIxIiBzdHlsZT0ic3RvcC1jb2xvcjojQUEwMDAwIi8+CjwvbGluZWFyR3JhZGllbnQ+CjxyZWN0IHg9Ijc3My44IiBjbGFzcz0ic3Q4IiB3aWR0aD0iMTAyMi4yIiBoZWlnaHQ9IjEwMCIvPgo8dGV4dCB0cmFuc2Zvcm09Im1hdHJpeCgxIDAgMCAxIDE0NDguMTY0MSA1OS40NikiIGNsYXNzPSJzdDMgc3Q0IHN0NSBzdDkiPlByZWRpY3RvciBOb3RlYm9vazwvdGV4dD4KPC9zdmc+Cg==' />"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "0e9aa72f",
+   "metadata": {},
+   "source": [
+    "## Notebook content\n",
+    "\n",
+    "This notebook is for **AutoGluon Time Series** models produced by the timeseries training pipeline. It helps you:\n",
+    "\n",
+    "- Load a refitted model artifact from S3 (same run as the pipeline).\n",
+    "- Inspect test metrics and predictor metadata.\n",
+    "- Run **`TimeSeriesPredictor.predict()`** to forecast the next `prediction_length` steps per time series.\n",
+    "\n",
+    "**Tips**\n",
+    "\n",
+    "- Configure S3 access (workbench secret or `.env`) so the notebook can download `model_artifact/.../<MODEL>_FULL/`.\n",
+    "- `model_name` must match the refitted model folder (e.g. `ETS_FULL`, `Naive_FULL`), as in the pipeline leaderboard.\n",
+    "- For `predict`, pass historical rows per `item_id` (target column + timestamps). The model forecasts after the last timestamp you provide—not a single “score row” like tabular classification.\n",
+    "\n",
+    "### Contents\n",
+    "\n",
+    "**[Setup](#setup)**  \n",
+    "**[Experiment run details](#experiment-run-details)**  \n",
+    "**[Download trained model](#download-trained-model)**  \n",
+    "**[Model insights](#model-insights)**  \n",
+    "**[Back-testing metrics](#back-testing-metrics)**  \n",
+    "**[Back-testing charts](#back-testing-charts)**  \n",
+    "**[Load the predictor](#load-the-predictor)**  \n",
+    "**[Refit training leaderboard](#refit-training-leaderboard)**  \n",
+    "**[Forecast (predict)](#predict-the-values)**  \n",
+    "**[Plot forecasted data](#plot-forecasted-data)**  \n",
+    "**[Summary and next steps](#summary-and-next-steps)**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7d9cf2b-18cc-4ac9-87af-a74f8bf60322",
+   "metadata": {},
+   "source": [
+    "<a id=\"setup\"></a>\n",
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5bacd972",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cec84205-8ee9-4aaf-a97e-4ef576e7b9da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"PIP_EXTRA_INDEX_URL\"] = (\n",
+    "    \"https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5-EA2/cpu-ubi9/simple/\"\n",
+    ")\n",
+    "\n",
+    "%pip install autogluon.timeseries==1.5.0+rhaiv.3 | tail -n 1\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8ff506e-f1a3-4990-a979-7790a5105251",
+   "metadata": {},
+   "source": [
+    "<a id=\"experiment-run-details\"></a>\n",
+    "## Experiment run details\n",
+    "\n",
+    "Set the pipeline name and run ID that identify the training run whose artifacts you want to load. These values are typically available from the pipeline run or workbench."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa7f736d-0b5c-4988-87a5-4d1a5cde0873",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline_name = \"<REPLACE_PIPELINE_NAME>\"\n",
+    "run_id = \"<REPLACE_RUN_ID>\"\n",
+    "model_name = \"<REPLACE_MODEL_NAME>\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54525a94-7799-41cc-822e-91bae88b3b78",
+   "metadata": {},
+   "source": [
+    "<a id=\"download-trained-model\"></a>\n",
+    "## Download trained model\n",
+    "\n",
+    " 📌 **Action:** Ensure the S3 connection is added to the workbench so the notebook can access the results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fba16ca7-b15f-4d7a-95b4-d3cf73163440",
+   "metadata": {},
+   "source": [
+    "Download the refitted model directory from S3: `predictor/`, `metrics/`, `notebooks/` under `models_artifact/<model_name>/`.\n",
+    "\n",
+    "The download cell lists objects under `<pipeline_name>/<run_id>/autogluon-timeseries-models-training/` and matches keys containing `models_artifact/<model_name>/`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e88370df-ecda-453d-913a-9524088ccc36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import os\n",
+    "import warnings\n",
+    "\n",
+    "from botocore.exceptions import SSLError\n",
+    "\n",
+    "required_env_vars = (\n",
+    "    \"AWS_S3_ENDPOINT\",\n",
+    "    \"AWS_ACCESS_KEY_ID\",\n",
+    "    \"AWS_SECRET_ACCESS_KEY\",\n",
+    "    \"AWS_S3_BUCKET\",\n",
+    ")\n",
+    "missing_vars = [name for name in required_env_vars if not os.environ.get(name, \"\").strip()]\n",
+    "\n",
+    "if missing_vars:\n",
+    "    raise ValueError(\n",
+    "        f\"Missing required environment variable(s): {', '.join(missing_vars)}. \"\n",
+    "        \"Attach your S3 connection to this notebook workbench and try again.\"\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def _get_s3_bucket(verify=True):\n",
+    "    return boto3.resource(\n",
+    "        \"s3\",\n",
+    "        endpoint_url=os.environ[\"AWS_S3_ENDPOINT\"],\n",
+    "        verify=verify,\n",
+    "    ).Bucket(os.environ[\"AWS_S3_BUCKET\"])\n",
+    "\n",
+    "\n",
+    "def _download_model(bucket):\n",
+    "    full_refit_prefix = os.path.join(pipeline_name, run_id, \"autogluon-timeseries-models-training\")\n",
+    "    best_model_subpath = os.path.join(\"models_artifact\", model_name)\n",
+    "    marker = best_model_subpath + \"/\"\n",
+    "    base_dir = os.path.abspath(model_name)\n",
+    "    for obj in bucket.objects.filter(Prefix=full_refit_prefix):\n",
+    "        if obj.key.endswith(\"/\") or marker not in obj.key:\n",
+    "            continue\n",
+    "        relative = obj.key.split(marker, 1)[1]\n",
+    "        relative = os.path.normpath(relative)\n",
+    "        if relative == \".\" or relative.startswith(\"..\") or os.path.isabs(relative):\n",
+    "            warnings.warn(f\"Skipping due to invalid path detected: {obj.key!r}\")\n",
+    "            continue\n",
+    "        target = os.path.join(model_name, relative)\n",
+    "        abs_target = os.path.abspath(target)\n",
+    "        if abs_target != base_dir and not abs_target.startswith(base_dir + os.sep):\n",
+    "            warnings.warn(f\"Skipping due to invalid path detected: {obj.key!r}\")\n",
+    "            continue\n",
+    "        parent = os.path.dirname(abs_target)\n",
+    "        if parent:\n",
+    "            os.makedirs(parent, exist_ok=True)\n",
+    "        bucket.download_file(obj.key, target)\n",
+    "    return model_name\n",
+    "\n",
+    "\n",
+    "try:\n",
+    "    best_model_path = _download_model(_get_s3_bucket())\n",
+    "except SSLError:\n",
+    "    warnings.warn(\"SSL error when accessing S3, retrying with verify=False\")\n",
+    "    best_model_path = _download_model(_get_s3_bucket(verify=False))\n",
+    "\n",
+    "print(\"Model artifact stored under\", best_model_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf53ddb3-14af-44e2-9c5d-6636095cb2b5",
+   "metadata": {},
+   "source": [
+    "<a id=\"model-insights\"></a>\n",
+    "## Model insights"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1df774b4",
+   "metadata": {},
+   "source": [
+    "### Metrics\n",
+    "\n",
+    "Metrics computed on the holdout test `TimeSeriesDataFrame` during pipeline refit (e.g. MASE, WQL). Signs may be flipped so higher is better, per AutoGluon convention."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f71f38c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "with open(os.path.join(best_model_path, \"metrics\", \"metrics.json\")) as f:\n",
+    "    metrics = pd.json_normalize(json.load(f))\n",
+    "\n",
+    "metrics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f766335",
+   "metadata": {},
+   "source": [
+    "<a id=\"back-testing-metrics\"></a>\n",
+    "### Back-testing metrics\n",
+    "\n",
+    "Rolling validation scores from ``metrics/back_testing.json`` (AutoGluon-style ``Cutoff …: MASE = …`` lines, per-window table, and overall mean). Scores are positive error values; AutoGluon ``evaluate()`` negates them interactively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "201fb693",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "<REPLACE_BACKTEST_PLOT_HELPERS>\n",
+    "\n",
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\n",
+    "if not back_testing_path.is_file():\n",
+    "    print(\"back_testing.json was not found for this model (older pipeline runs may omit it).\")\n",
+    "else:\n",
+    "    with back_testing_path.open(encoding=\"utf-8\") as f:\n",
+    "        back_testing = json.load(f)\n",
+    "    render_back_testing_metrics(back_testing)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4c8e2a1-backtest-charts",
+   "metadata": {},
+   "source": [
+    "<a id=\"back-testing-charts\"></a>\n",
+    "### Back-testing charts\n",
+    "\n",
+    "Best/worst series holdout forecasts from ``metrics/back_testing.json``. Run **Back-testing metrics** first (defines helpers). Uses **matplotlib** like tabular ROC/PR curves; no ``TimeSeriesPredictor`` required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7d9f3b2-backtest-plots",
+   "metadata": {},
+   "outputs": [],
+   "source": "back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\nif not back_testing_path.is_file():\n    print(\"Skipping backtest charts: back_testing.json not found.\")\nelif \"render_back_testing_forecast_charts\" not in globals():\n    print(\"Run the Back-testing metrics cell first.\")\nelif \"back_testing\" not in globals():\n    print(\"Run the Back-testing metrics cell first (defines back_testing variable).\")\nelse:\n    render_back_testing_forecast_charts(back_testing)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6686ef6f-3251-43fa-bc9d-a9e911c7908c",
+   "metadata": {},
+   "source": [
+    "<a id=\"load-the-predictor\"></a>\n",
+    "## Load the predictor\n",
+    "\n",
+    "Load a **`TimeSeriesPredictor`** from the downloaded `predictor/` directory (not `TabularPredictor`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "9ebc576f-17eb-49a7-8dcb-6b237dcc2218",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesPredictor\n",
+    "\n",
+    "predictor = TimeSeriesPredictor.load(os.path.join(best_model_path, \"predictor\"), require_version_match=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ts-leaderboard-md",
+   "metadata": {},
+   "source": [
+    "<a id=\"refit-training-leaderboard\"></a>\n",
+    "### Refit training leaderboard\n",
+    "\n",
+    "Run after **Load the predictor**. Shows models trained in this refit step (often one row)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ts-leaderboard-inspect",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Models in this refit predictor (refit often trains one model)\n",
+    "predictor.leaderboard()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57cc1e1a-707f-431f-9cb5-1d24e09d1249",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictor.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "064c76e4-1b44-4bba-8f2b-3178633a326a",
+   "metadata": {},
+   "source": [
+    "<a id=\"predict-the-values\"></a>\n",
+    "## Forecast (`predict`)\n",
+    "\n",
+    "Use the sample data below (embedded when this notebook was generated) as historical context for ``predict()``. When the model uses known covariates, future covariate values for the forecast horizon are included in the same payload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6955253-1891-4ff7-8b3e-ffa338d928f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "sample = <REPLACE_PREDICT_SAMPLE>\n",
+    "\n",
+    "history = pd.DataFrame(sample[\"history\"])\n",
+    "history[sample[\"timestamp_column\"]] = pd.to_datetime(history[sample[\"timestamp_column\"]])\n",
+    "\n",
+    "ts_df = TimeSeriesDataFrame.from_data_frame(\n",
+    "    history,\n",
+    "    id_column=sample[\"id_column\"],\n",
+    "    timestamp_column=sample[\"timestamp_column\"],\n",
+    ")\n",
+    "\n",
+    "known_covariates = None\n",
+    "if sample.get(\"known_covariates\"):\n",
+    "    known_covariates = pd.DataFrame(sample[\"known_covariates\"])\n",
+    "    known_covariates[\"timestamp\"] = pd.to_datetime(known_covariates[\"timestamp\"])\n",
+    "\n",
+    "ts_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f07e1d71-85e8-4484-877a-5af40547de4f",
+   "metadata": {},
+   "source": [
+    "Run **`predict`** to get quantile forecasts. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8441133b-2984-4ea9-92a1-4e427d25ee1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "forecasts = predictor.predict(\n",
+    "    ts_df,\n",
+    "    known_covariates=known_covariates,\n",
+    "    use_cache=False,\n",
+    ")\n",
+    "forecasts\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c1d5562",
+   "metadata": {},
+   "source": [
+    "<a id=\"plot-forecasted-data\"></a>\n",
+    "### Plot forecasted data\n",
+    "\n",
+    "Visualize historical values and the forecast distribution (mean and 10%/90% interval). Uses **matplotlib** with the same date-axis styling as back-testing charts (aligned with [AutoGluon ``predictor.plot()``](https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-quick-start.html)). When ``back_testing.json`` is available (run **Back-testing metrics** first), plots the same best/worst series as the backtest charts; otherwise uses the first series in the embedded sample."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65ad5642",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "available_item_ids = list(ts_df.item_ids)\n",
+    "plot_item_ids = available_item_ids[:4]\n",
+    "\n",
+    "back_testing_for_plot = globals().get(\"back_testing\")\n",
+    "if back_testing_for_plot is None:\n",
+    "    back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\n",
+    "    if back_testing_path.is_file():\n",
+    "        with back_testing_path.open(encoding=\"utf-8\") as f:\n",
+    "            back_testing_for_plot = json.load(f)\n",
+    "\n",
+    "if back_testing_for_plot and \"backtest_highlight_item_ids\" in globals():\n",
+    "    highlight_ids = backtest_highlight_item_ids(back_testing_for_plot, available_item_ids)\n",
+    "    if highlight_ids:\n",
+    "        plot_item_ids = highlight_ids\n",
+    "        print(\"Plotting backtest best/worst performers:\", plot_item_ids)\n",
+    "    else:\n",
+    "        print(\"Backtest performers not in sample; plotting first sample series.\")\n",
+    "elif back_testing_for_plot:\n",
+    "    print(\"Run Back-testing metrics first to align plot series with backtest charts.\")\n",
+    "\n",
+    "if isinstance(ts_df.index, pd.MultiIndex):\n",
+    "    history_limit = min(200, int(ts_df.groupby(level=0).size().min()))\n",
+    "else:\n",
+    "    history_limit = min(200, len(ts_df))\n",
+    "\n",
+    "if \"plot_timeseries_forecasts\" not in globals():\n",
+    "    print(\"Run Back-testing metrics first (defines plot helpers).\")\n",
+    "else:\n",
+    "    plot_timeseries_forecasts(\n",
+    "        data=ts_df,\n",
+    "        predictions=forecasts,\n",
+    "        item_ids=plot_item_ids,\n",
+    "        quantile_levels=[0.1, 0.9],\n",
+    "        max_history_length=history_limit,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ee6d313-4612-4fb9-bee2-b2dcc83772ef",
+   "metadata": {},
+   "source": [
+    "<a id=\"summary-and-next-steps\"></a>\n",
+    "## Summary and next steps\n",
+    "\n",
+    "**Summary:** Loaded an AutoGluon Time Series predictor from S3 and ran **`predict()`** to forecast `prediction_length` steps ahead per item.\n",
+    "\n",
+    "**Next steps:**\n",
+    "- Run predictions on your own data (ensure columns match the training schema).\n",
+    "- Optionally create the Predictor's online deployment using KServe custom runtime."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44a650c8-e5cc-4a2e-bebd-becd73944489",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/components/training/automl/shared/notebook_templates/timeseries_notebook.ipynb
+++ b/components/training/automl/shared/notebook_templates/timeseries_notebook.ipynb
@@ -33,6 +33,7 @@
         "**[Experiment run details](#experiment-run-details)**  \n",
         "**[Download trained model](#download-trained-model)**  \n",
         "**[Model insights](#model-insights)**  \n",
+        "**[Back-testing charts](#back-testing-charts)**  \n",
         "**[Load the predictor](#load-the-predictor)**  \n",
         "**[Forecast (predict)](#predict-the-values)**  \n",
         "**[Plot forecasted data](#plot-forecasted-data)**  \n",
@@ -266,6 +267,37 @@
         "        print(\"Worst performer:\", worst.get(\"item_id\"), worst.get(\"avg_metrics\"))\n",
         "else:\n",
         "    print(\"back_testing.json was not found for this model (older pipeline runs may omit it).\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b4c8e2a1-backtest-charts",
+      "metadata": {},
+      "source": [
+        "<a id=\"back-testing-charts\"></a>\n",
+        "### Back-testing charts\n",
+        "\n",
+        "Visualize precomputed rolling validation results from ``metrics/back_testing.json``. Per-window scores follow the AutoGluon backtest tutorial (``Cutoff …: MASE = …`` plus a table and overall mean across windows); scores are positive error values (AutoGluon ``evaluate()`` negates them interactively). Forecast panels use **matplotlib** like tabular ROC/PR curves. No ``TimeSeriesPredictor`` required."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c7d9f3b2-backtest-plots",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "<REPLACE_BACKTEST_PLOT_HELPERS>\n",
+        "\n",
+        "import json\n",
+        "from pathlib import Path\n",
+        "\n",
+        "back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\n",
+        "if not back_testing_path.is_file():\n",
+        "    print(\"Skipping backtest charts: back_testing.json not found.\")\n",
+        "else:\n",
+        "    with back_testing_path.open(encoding=\"utf-8\") as f:\n",
+        "        render_back_testing_charts(json.load(f))"
       ]
     },
     {

--- a/components/training/automl/shared/notebook_templates/timeseries_notebook.ipynb
+++ b/components/training/automl/shared/notebook_templates/timeseries_notebook.ipynb
@@ -33,8 +33,10 @@
         "**[Experiment run details](#experiment-run-details)**  \n",
         "**[Download trained model](#download-trained-model)**  \n",
         "**[Model insights](#model-insights)**  \n",
+        "**[Back-testing metrics](#back-testing-metrics)**  \n",
         "**[Back-testing charts](#back-testing-charts)**  \n",
         "**[Load the predictor](#load-the-predictor)**  \n",
+        "**[Refit training leaderboard](#refit-training-leaderboard)**  \n",
         "**[Forecast (predict)](#predict-the-values)**  \n",
         "**[Plot forecasted data](#plot-forecasted-data)**  \n",
         "**[Summary and next steps](#summary-and-next-steps)**"
@@ -233,57 +235,16 @@
       "id": "6f766335",
       "metadata": {},
       "source": [
-        "### Back-testing summary\n",
+        "<a id=\"back-testing-metrics\"></a>\n",
+        "### Back-testing metrics\n",
         "\n",
-        "Precomputed backtest results from pipeline training (`metrics/back_testing.json`). Includes per-window metrics and best/worst series forecast timelines when the file is present (OpenShift AI 3.5+)."
+        "Rolling validation scores from ``metrics/back_testing.json`` (AutoGluon-style ``Cutoff …: MASE = …`` lines, per-window table, and overall mean). Scores are positive error values; AutoGluon ``evaluate()`` negates them interactively."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "id": "201fb693",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import json\n",
-        "from pathlib import Path\n",
-        "\n",
-        "back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\n",
-        "if back_testing_path.is_file():\n",
-        "    with back_testing_path.open(encoding=\"utf-8\") as f:\n",
-        "        back_testing = json.load(f)\n",
-        "    print(\n",
-        "        f\"Windows: {back_testing.get('num_val_windows')} | \"\n",
-        "        f\"Eval metric: {back_testing.get('eval_metric')} | \"\n",
-        "        f\"Series evaluated: {back_testing.get('series_analysis', {}).get('num_series_evaluated')}\"\n",
-        "    )\n",
-        "    for window in back_testing.get(\"per_window_metrics\", []):\n",
-        "        print(f\"Window {window.get('window_id')}: {window.get('metrics')}\")\n",
-        "    best = back_testing.get(\"series_analysis\", {}).get(\"best_performer\")\n",
-        "    worst = back_testing.get(\"series_analysis\", {}).get(\"worst_performer\")\n",
-        "    if best:\n",
-        "        print(\"Best performer:\", best.get(\"item_id\"), best.get(\"avg_metrics\"))\n",
-        "    if worst:\n",
-        "        print(\"Worst performer:\", worst.get(\"item_id\"), worst.get(\"avg_metrics\"))\n",
-        "else:\n",
-        "    print(\"back_testing.json was not found for this model (older pipeline runs may omit it).\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b4c8e2a1-backtest-charts",
-      "metadata": {},
-      "source": [
-        "<a id=\"back-testing-charts\"></a>\n",
-        "### Back-testing charts\n",
-        "\n",
-        "Visualize precomputed rolling validation results from ``metrics/back_testing.json``. Per-window scores follow the AutoGluon backtest tutorial (``Cutoff …: MASE = …`` plus a table and overall mean across windows); scores are positive error values (AutoGluon ``evaluate()`` negates them interactively). Forecast panels use **matplotlib** like tabular ROC/PR curves. No ``TimeSeriesPredictor`` required."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "c7d9f3b2-backtest-plots",
       "metadata": {},
       "outputs": [],
       "source": [
@@ -294,10 +255,38 @@
         "\n",
         "back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\n",
         "if not back_testing_path.is_file():\n",
-        "    print(\"Skipping backtest charts: back_testing.json not found.\")\n",
+        "    print(\"back_testing.json was not found for this model (older pipeline runs may omit it).\")\n",
         "else:\n",
         "    with back_testing_path.open(encoding=\"utf-8\") as f:\n",
-        "        render_back_testing_charts(json.load(f))"
+        "        back_testing = json.load(f)\n",
+        "    render_back_testing_metrics(back_testing)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b4c8e2a1-backtest-charts",
+      "metadata": {},
+      "source": [
+        "<a id=\"back-testing-charts\"></a>\n",
+        "### Back-testing charts\n",
+        "\n",
+        "Best/worst series holdout forecasts from ``metrics/back_testing.json``. Run **Back-testing metrics** first (defines helpers). Uses **matplotlib** like tabular ROC/PR curves; no ``TimeSeriesPredictor`` required."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c7d9f3b2-backtest-plots",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\n",
+        "if not back_testing_path.is_file():\n",
+        "    print(\"Skipping backtest charts: back_testing.json not found.\")\n",
+        "elif \"render_back_testing_forecast_charts\" not in globals():\n",
+        "    print(\"Run the Back-testing metrics cell first.\")\n",
+        "else:\n",
+        "    render_back_testing_forecast_charts(back_testing)"
       ]
     },
     {
@@ -328,6 +317,7 @@
       "id": "ts-leaderboard-md",
       "metadata": {},
       "source": [
+        "<a id=\"refit-training-leaderboard\"></a>\n",
         "### Refit training leaderboard\n",
         "\n",
         "Run after **Load the predictor**. Shows models trained in this refit step (often one row)."
@@ -424,7 +414,7 @@
         "<a id=\"plot-forecasted-data\"></a>\n",
         "### Plot forecasted data\n",
         "\n",
-        "Quick chart of past values and forecast (mean line and optional quantile band) per `item_id`, using AutoGluon’s `predictor.plot()`. Adjust `max_history_length` / `max_num_item_ids` if you have many series or long histories."
+        "Visualize historical values and the forecast distribution (mean and 10%/90% interval). Uses **matplotlib** with the same date-axis styling as back-testing charts (aligned with [AutoGluon ``predictor.plot()``](https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-quick-start.html)). When ``back_testing.json`` is available (run **Back-testing metrics** first), plots the same best/worst series as the backtest charts; otherwise uses the first series in the embedded sample."
       ]
     },
     {
@@ -434,7 +424,44 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "predictor.plot(ts_df, forecasts, quantile_levels=[0.1, 0.9], max_history_length=50, max_num_item_ids=4);\n"
+        "import json\n",
+        "from pathlib import Path\n",
+        "\n",
+        "available_item_ids = list(ts_df.item_ids)\n",
+        "plot_item_ids = available_item_ids[:4]\n",
+        "\n",
+        "back_testing_for_plot = globals().get(\"back_testing\")\n",
+        "if back_testing_for_plot is None:\n",
+        "    back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\n",
+        "    if back_testing_path.is_file():\n",
+        "        with back_testing_path.open(encoding=\"utf-8\") as f:\n",
+        "            back_testing_for_plot = json.load(f)\n",
+        "\n",
+        "if back_testing_for_plot and \"backtest_highlight_item_ids\" in globals():\n",
+        "    highlight_ids = backtest_highlight_item_ids(back_testing_for_plot, available_item_ids)\n",
+        "    if highlight_ids:\n",
+        "        plot_item_ids = highlight_ids\n",
+        "        print(\"Plotting backtest best/worst performers:\", plot_item_ids)\n",
+        "    else:\n",
+        "        print(\"Backtest performers not in sample; plotting first sample series.\")\n",
+        "elif back_testing_for_plot:\n",
+        "    print(\"Run Back-testing metrics first to align plot series with backtest charts.\")\n",
+        "\n",
+        "if isinstance(ts_df.index, pd.MultiIndex):\n",
+        "    history_limit = min(200, int(ts_df.groupby(level=0).size().min()))\n",
+        "else:\n",
+        "    history_limit = min(200, len(ts_df))\n",
+        "\n",
+        "if \"plot_timeseries_forecasts\" not in globals():\n",
+        "    print(\"Run Back-testing metrics first (defines plot helpers).\")\n",
+        "else:\n",
+        "    plot_timeseries_forecasts(\n",
+        "        data=ts_df,\n",
+        "        predictions=forecasts,\n",
+        "        item_ids=plot_item_ids,\n",
+        "        quantile_levels=[0.1, 0.9],\n",
+        "        max_history_length=history_limit,\n",
+        "    )"
       ]
     },
     {

--- a/components/training/automl/shared/notebook_templates/timeseries_notebook.ipynb
+++ b/components/training/automl/shared/notebook_templates/timeseries_notebook.ipynb
@@ -279,7 +279,17 @@
    "id": "c7d9f3b2-backtest-plots",
    "metadata": {},
    "outputs": [],
-   "source": "back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\nif not back_testing_path.is_file():\n    print(\"Skipping backtest charts: back_testing.json not found.\")\nelif \"render_back_testing_forecast_charts\" not in globals():\n    print(\"Run the Back-testing metrics cell first.\")\nelif \"back_testing\" not in globals():\n    print(\"Run the Back-testing metrics cell first (defines back_testing variable).\")\nelse:\n    render_back_testing_forecast_charts(back_testing)"
+   "source": [
+    "back_testing_path = Path(best_model_path) / \"metrics\" / \"back_testing.json\"\n",
+    "if not back_testing_path.is_file():\n",
+    "    print(\"Skipping backtest charts: back_testing.json not found.\")\n",
+    "elif \"render_back_testing_forecast_charts\" not in globals():\n",
+    "    print(\"Run the Back-testing metrics cell first.\")\n",
+    "elif \"back_testing\" not in globals():\n",
+    "    print(\"Run the Back-testing metrics cell first (defines back_testing variable).\")\n",
+    "else:\n",
+    "    render_back_testing_forecast_charts(back_testing)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -344,7 +354,7 @@
     "<a id=\"predict-the-values\"></a>\n",
     "## Forecast (`predict`)\n",
     "\n",
-    "Use the sample data below (embedded when this notebook was generated) as historical context for ``predict()``. When the model uses known covariates, future covariate values for the forecast horizon are included in the same payload."
+    "Use the sample data below (embedded when this notebook was generated) as historical context for ``predict()``. When the model uses known covariates, values for the forecast horizon are rebuilt from ``predictor.make_future_data_frame()`` after parsing sample timestamps."
    ]
   },
   {
@@ -354,12 +364,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "<REPLACE_TIMESERIES_SAMPLE_HELPERS>\n",
+    "\n",
     "import pandas as pd\n",
     "\n",
     "sample = <REPLACE_PREDICT_SAMPLE>\n",
     "\n",
     "history = pd.DataFrame(sample[\"history\"])\n",
-    "history[sample[\"timestamp_column\"]] = pd.to_datetime(history[sample[\"timestamp_column\"]])\n",
+    "history = _coerce_sample_timestamps(history, sample[\"timestamp_column\"])\n",
     "\n",
     "ts_df = TimeSeriesDataFrame.from_data_frame(\n",
     "    history,\n",
@@ -368,9 +380,10 @@
     ")\n",
     "\n",
     "known_covariates = None\n",
-    "if sample.get(\"known_covariates\"):\n",
-    "    known_covariates = pd.DataFrame(sample[\"known_covariates\"])\n",
-    "    known_covariates[\"timestamp\"] = pd.to_datetime(known_covariates[\"timestamp\"])\n",
+    "covariate_names = sample.get(\"known_covariates_names\") or []\n",
+    "if covariate_names and all(col in history.columns for col in covariate_names):\n",
+    "    future_cov = predictor.make_future_data_frame(ts_df)\n",
+    "    known_covariates = fill_known_covariates_on_future_frame(future_cov, ts_df, covariate_names)\n",
     "\n",
     "ts_df.head()\n"
    ]

--- a/components/training/automl/shared/tests/test_back_testing.py
+++ b/components/training/automl/shared/tests/test_back_testing.py
@@ -175,6 +175,25 @@ class TestHoldoutHelpers:
         assert lower == "0.1"
         assert upper == "0.9"
 
+    def test_quantile_bounds_single_quantile_omits_upper(self):
+        """A lone quantile column is used only as the lower bound (no collapsed band)."""
+        from ..back_testing import _quantile_bounds
+
+        predictions = pd.DataFrame({"mean": [1.0], "0.5": [1.0]}, index=[0])
+        lower, upper = _quantile_bounds(predictions)
+        assert lower == "0.5"
+        assert upper is None
+
+    def test_quantile_bounds_picks_distinct_lower_and_upper(self):
+        """Lower and upper bounds are never the same quantile column."""
+        from ..back_testing import _quantile_bounds
+
+        predictions = pd.DataFrame({"0.1": [0.9], "0.5": [1.0], "0.9": [1.1]}, index=[0])
+        lower, upper = _quantile_bounds(predictions)
+        assert lower == "0.1"
+        assert upper == "0.9"
+        assert lower != upper
+
     def test_forecast_data_limits_to_holdout_horizon(self):
         """Forecast rows cover holdout steps only, not the full prediction window history."""
         timestamps = ["2025-01-01", "2025-01-02", "2025-01-03", "2025-01-04", "2025-01-05"]

--- a/components/training/automl/shared/tests/test_back_testing.py
+++ b/components/training/automl/shared/tests/test_back_testing.py
@@ -160,6 +160,20 @@ class TestHoldoutHelpers:
         assert rows[0]["predicted"] == 105.0
         assert rows[0]["lower_bound"] == 95.0
         assert rows[0]["upper_bound"] == 115.0
+        assert rows[0]["lower_quantile"] == 0.1
+        assert rows[0]["upper_quantile"] == 0.9
+
+    def test_quantile_bounds_prefer_p10_p90(self):
+        """P10/P90 quantiles are preferred over other levels when all are present."""
+        from ..back_testing import _quantile_bounds
+
+        predictions = pd.DataFrame(
+            {"mean": [1.0], "0.1": [0.5], "0.2": [0.6], "0.8": [1.4], "0.9": [1.5]},
+            index=[0],
+        )
+        lower, upper = _quantile_bounds(predictions)
+        assert lower == "0.1"
+        assert upper == "0.9"
 
     def test_forecast_data_limits_to_holdout_horizon(self):
         """Forecast rows cover holdout steps only, not the full prediction window history."""
@@ -418,6 +432,7 @@ class TestBuildBackTestingJson:
         assert payload["model_name"] == "DeepAR_FULL"
         assert payload["num_val_windows"] == 1
         assert payload["per_window_metrics"][0]["test_start"] == "2025-01-03"
+        assert payload["per_window_metrics"][0]["cutoff"] == -2
         assert payload["per_window_metrics"][0]["metrics"]["MASE"] == 0.42
         assert payload["series_analysis"]["num_series_evaluated"] == 2
         assert payload["series_analysis"]["best_performer"]["item_id"] == "good"

--- a/components/training/automl/shared/tests/test_back_testing_charts.py
+++ b/components/training/automl/shared/tests/test_back_testing_charts.py
@@ -3,19 +3,25 @@
 from __future__ import annotations
 
 import ast
+from typing import Any
 
+import pandas as pd
 import pytest
 
 from ..back_testing_charts import (
     _draw_forecast,
     _interval_label,
     _show_per_window_metrics,
+    backtest_highlight_item_ids,
     forecast_data_to_frame,
     mean_window_metric,
     notebook_backtest_charts_source,
     per_window_metrics_table,
     pick_window_metric,
+    plot_timeseries_forecasts,
     render_back_testing_charts,
+    render_back_testing_forecast_charts,
+    render_back_testing_metrics,
 )
 
 
@@ -141,6 +147,74 @@ class TestBackTestingCharts:
         """Notebook injection source is valid Python."""
         ast.parse(notebook_backtest_charts_source())
 
+    def test_backtest_highlight_item_ids_prefers_best_and_worst(self):
+        """Plot helper returns performers that exist in the sample history."""
+        payload = {
+            "series_analysis": {
+                "best_performer": {"item_id": "north"},
+                "worst_performer": {"item_id": "south"},
+            }
+        }
+        assert backtest_highlight_item_ids(payload, ["north", "south", "east"]) == ["north", "south"]
+
+    def test_backtest_highlight_item_ids_resolves_string_ids(self):
+        """Numeric JSON ids match string sample ids."""
+        payload = {"series_analysis": {"best_performer": {"item_id": 101}}}
+        assert backtest_highlight_item_ids(payload, ["101", "102"]) == ["101"]
+
+    def test_backtest_highlight_item_ids_deduplicates_same_performer(self):
+        """Single-series backtests do not duplicate plot panels."""
+        payload = {
+            "series_analysis": {
+                "best_performer": {"item_id": "A"},
+                "worst_performer": {"item_id": "A"},
+            }
+        }
+        assert backtest_highlight_item_ids(payload, ["A", "B"]) == ["A"]
+
+    def test_render_back_testing_metrics_prints_overall(self, capsys):
+        """Metrics entry point prints table output without plotting."""
+        payload = {
+            "eval_metric": "MASE",
+            "per_window_metrics": [
+                {"window_id": 0, "cutoff": -6, "metrics": {"MASE": 0.38}},
+                {"window_id": 1, "cutoff": -4, "metrics": {"MASE": 0.42}},
+            ],
+            "series_analysis": {"num_series_evaluated": 3},
+        }
+        render_back_testing_metrics(payload)
+        output = capsys.readouterr().out
+        assert "Cutoff -6: MASE = 0.38" in output
+        assert "Overall MASE (mean across 2 validation windows, all series): 0.4" in output
+
+    def test_render_back_testing_forecast_charts_runs(self):
+        """Forecast charts entry point renders matplotlib panels only."""
+        pytest.importorskip("matplotlib")
+        import matplotlib
+
+        matplotlib.use("Agg", force=True)
+        import matplotlib.pyplot as plt
+
+        payload = {
+            "eval_metric": "MASE",
+            "target": "sales",
+            "per_window_metrics": [{"window_id": 0, "test_start": "2025-01-03"}],
+            "series_analysis": {
+                "best_performer": {
+                    "item_id": "A",
+                    "windows": [
+                        {
+                            "window_id": 0,
+                            "metrics": {"MAPE": 5.0},
+                            "forecast_data": self._sample_forecast_rows(),
+                        },
+                    ],
+                },
+            },
+        }
+        render_back_testing_forecast_charts(payload)
+        plt.close("all")
+
     def test_render_back_testing_charts_runs(self):
         """Orchestrator renders charts for a minimal payload."""
         pytest.importorskip("matplotlib")
@@ -190,3 +264,52 @@ class TestBackTestingCharts:
         }
         render_back_testing_charts(payload)
         plt.close("all")
+
+    def test_plot_timeseries_forecasts_styles_date_axis(self):
+        """Forecast plot uses rotated short date ticks and marks forecast points."""
+        pytest.importorskip("matplotlib")
+        import matplotlib
+
+        matplotlib.use("Agg", force=True)
+        import matplotlib.pyplot as plt
+
+        history_rows = []
+        for offset in range(10):
+            day = f"2025-02-{15 + offset:02d}"
+            history_rows.append({"sales": 100.0 + offset, "timestamp": day})
+        history = pd.DataFrame(history_rows)
+        history["timestamp"] = pd.to_datetime(history["timestamp"])
+        ts_df = history.set_index("timestamp")
+
+        forecast_rows = []
+        for offset in range(2):
+            day = f"2025-02-{25 + offset:02d}"
+            forecast_rows.append({"mean": 110.0 + offset, "0.1": 105.0, "0.9": 115.0, "timestamp": day})
+        forecasts = pd.DataFrame(forecast_rows)
+        forecasts["timestamp"] = pd.to_datetime(forecasts["timestamp"])
+        forecasts = forecasts.set_index("timestamp")
+
+        captured: list[Any] = []
+
+        def capture_show() -> None:
+            captured.append(plt.gcf())
+            plt.close("all")
+
+        original_show = plt.show
+        plt.show = capture_show
+        try:
+            plot_timeseries_forecasts(ts_df, forecasts, quantile_levels=[0.1, 0.9])
+        finally:
+            plt.show = original_show
+
+        assert captured
+        axis = captured[0].axes[0]
+        from matplotlib.dates import DateFormatter
+
+        assert isinstance(axis.xaxis.get_major_formatter(), DateFormatter)
+        labels = [label.get_rotation() for label in axis.get_xticklabels()]
+        assert labels and labels[0] == 45
+
+        forecast_line = next(line for line in axis.lines if line.get_label() == "Forecast")
+        assert forecast_line.get_marker() == "s"
+        assert len(forecast_line.get_xdata()) == 2

--- a/components/training/automl/shared/tests/test_back_testing_charts.py
+++ b/components/training/automl/shared/tests/test_back_testing_charts.py
@@ -165,7 +165,9 @@ class TestBackTestingCharts:
             target="sales",
             cutoff_start="2025-01-03",
         )
-        cutoff_lines = [line for line in axis.lines if line.get_linestyle() == "--" and line.get_color() in {"gray", "0.5"}]
+        cutoff_lines = [
+            line for line in axis.lines if line.get_linestyle() == "--" and line.get_color() in {"gray", "0.5"}
+        ]
         assert cutoff_lines
         cutoff_ts = pd.Timestamp(cutoff_lines[0].get_xdata()[0], tz="UTC").tz_convert(None)
         assert cutoff_ts == pd.Timestamp("2025-01-03 14:00:00")

--- a/components/training/automl/shared/tests/test_back_testing_charts.py
+++ b/components/training/automl/shared/tests/test_back_testing_charts.py
@@ -1,0 +1,192 @@
+"""Tests for back_testing.json matplotlib charts."""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from ..back_testing_charts import (
+    _draw_forecast,
+    _interval_label,
+    _show_per_window_metrics,
+    forecast_data_to_frame,
+    mean_window_metric,
+    notebook_backtest_charts_source,
+    per_window_metrics_table,
+    pick_window_metric,
+    render_back_testing_charts,
+)
+
+
+class TestBackTestingCharts:
+    """Tests for backtest chart helpers."""
+
+    @staticmethod
+    def _sample_forecast_rows():
+        return [
+            {
+                "timestamp": "2025-01-03T00:00:00Z",
+                "actual": 100.0,
+                "predicted": 105.0,
+                "lower_bound": 95.0,
+                "upper_bound": 115.0,
+                "lower_quantile": 0.1,
+                "upper_quantile": 0.9,
+            },
+            {
+                "timestamp": "2025-01-04T00:00:00Z",
+                "actual": 110.0,
+                "predicted": 108.0,
+                "lower_bound": 98.0,
+                "upper_bound": 118.0,
+                "lower_quantile": 0.1,
+                "upper_quantile": 0.9,
+            },
+        ]
+
+    def test_per_window_metrics_table_includes_cutoff(self):
+        """Per-window table exposes AutoGluon-style cutoff identifiers."""
+        per_window = [
+            {
+                "window_id": 0,
+                "cutoff": -6,
+                "test_start": "2025-03-01",
+                "test_end": "2025-03-02",
+                "metrics": {"MASE": 0.38},
+            },
+            {
+                "window_id": 1,
+                "cutoff": -4,
+                "test_start": "2025-03-03",
+                "test_end": "2025-03-04",
+                "metrics": {"MASE": 0.45},
+            },
+        ]
+        table = per_window_metrics_table(per_window, "MASE")
+        assert list(table["cutoff"]) == [-6, -4]
+        assert list(table["MASE"]) == [0.38, 0.45]
+
+    def test_mean_window_metric_averages_finite_values(self):
+        """Overall summary uses the mean of per-window eval metric values."""
+        per_window = [
+            {"window_id": 0, "metrics": {"MASE": 0.38}},
+            {"window_id": 1, "metrics": {"MASE": 0.42}},
+        ]
+        assert mean_window_metric(per_window, "MASE") == pytest.approx(0.4)
+
+    def test_show_per_window_metrics_prints_cutoff_lines(self, capsys):
+        """Output matches AutoGluon tutorial print format."""
+        per_window = [
+            {
+                "window_id": 0,
+                "cutoff": -6,
+                "test_start": "2025-03-01",
+                "test_end": "2025-03-02",
+                "metrics": {"MASE": 0.38},
+            },
+        ]
+        _show_per_window_metrics(per_window, "MASE")
+        output = capsys.readouterr().out
+        assert "Cutoff -6: MASE = 0.38" in output
+
+    def test_show_per_window_metrics_prints_overall_summary(self, capsys):
+        """Overall line aggregates window scores across all series."""
+        per_window = [
+            {"window_id": 0, "cutoff": -6, "metrics": {"MASE": 0.38}},
+            {"window_id": 1, "cutoff": -4, "metrics": {"MASE": 0.42}},
+        ]
+        _show_per_window_metrics(per_window, "MASE", num_series_evaluated=12)
+        output = capsys.readouterr().out
+        assert "Overall MASE (mean across 2 validation windows, all series): 0.4" in output
+        assert "Series evaluated: 12" in output
+
+    def test_forecast_data_to_frame_parses_timestamps(self):
+        """Forecast rows are sorted by timestamp."""
+        frame = forecast_data_to_frame(self._sample_forecast_rows())
+        assert "lower_quantile" in frame.columns
+        assert frame["timestamp"].is_monotonic_increasing
+
+    def test_interval_label_uses_quantile_metadata(self):
+        """Interval legend matches AutoGluon-style P10-P90 labeling."""
+        frame = forecast_data_to_frame(self._sample_forecast_rows())
+        assert _interval_label(frame) == "10%-90% interval"
+
+    def test_draw_forecast_adds_cutoff_line(self):
+        """Cutoff vline is drawn at the validation window start."""
+        pytest.importorskip("matplotlib")
+        import matplotlib
+
+        matplotlib.use("Agg", force=True)
+        import matplotlib.pyplot as plt
+
+        figure, axis = plt.subplots()
+        _draw_forecast(
+            axis,
+            self._sample_forecast_rows(),
+            title="Window 0",
+            target="sales",
+            cutoff_start="2025-01-03",
+        )
+        assert any(line.get_linestyle() == "--" for line in axis.lines)
+        plt.close(figure)
+
+    def test_pick_window_metric_prefers_eval_metric(self):
+        """Metric lookup matches normalized eval metric names."""
+        metrics = {"MASE": 0.42, "MAPE": 5.0}
+        assert pick_window_metric(metrics, "MASE") == 0.42
+        assert pick_window_metric(metrics, "-MASE") == 0.42
+
+    def test_notebook_backtest_charts_source_compiles(self):
+        """Notebook injection source is valid Python."""
+        ast.parse(notebook_backtest_charts_source())
+
+    def test_render_back_testing_charts_runs(self):
+        """Orchestrator renders charts for a minimal payload."""
+        pytest.importorskip("matplotlib")
+        import matplotlib
+
+        matplotlib.use("Agg", force=True)
+        import matplotlib.pyplot as plt
+
+        payload = {
+            "eval_metric": "MASE",
+            "target": "sales",
+            "per_window_metrics": [
+                {
+                    "window_id": 0,
+                    "cutoff": -2,
+                    "test_start": "2025-01-01",
+                    "test_end": "2025-01-02",
+                    "metrics": {"MASE": 0.4},
+                },
+                {
+                    "window_id": 1,
+                    "cutoff": -4,
+                    "test_start": "2025-01-03",
+                    "test_end": "2025-01-04",
+                    "metrics": {"MASE": 0.5},
+                },
+            ],
+            "series_analysis": {
+                "num_series_evaluated": 5,
+                "best_performer": {
+                    "item_id": "A",
+                    "windows": [
+                        {
+                            "window_id": 0,
+                            "metrics": {"MAPE": 5.0},
+                            "forecast_data": self._sample_forecast_rows(),
+                        },
+                        {
+                            "window_id": 1,
+                            "metrics": {"MAPE": 6.0},
+                            "forecast_data": self._sample_forecast_rows(),
+                        },
+                    ],
+                },
+                "worst_performer": None,
+            },
+        }
+        render_back_testing_charts(payload)
+        plt.close("all")

--- a/components/training/automl/shared/tests/test_back_testing_charts.py
+++ b/components/training/automl/shared/tests/test_back_testing_charts.py
@@ -137,6 +137,40 @@ class TestBackTestingCharts:
         assert any(line.get_linestyle() == "--" for line in axis.lines)
         plt.close(figure)
 
+    def test_draw_forecast_cutoff_aligns_with_hourly_timestamps(self):
+        """Date-only test_start aligns to the first hourly forecast point."""
+        pytest.importorskip("matplotlib")
+        import matplotlib
+
+        matplotlib.use("Agg", force=True)
+        import matplotlib.pyplot as plt
+
+        hourly_rows = [
+            {
+                "timestamp": "2025-01-03T14:00:00Z",
+                "actual": 100.0,
+                "predicted": 105.0,
+            },
+            {
+                "timestamp": "2025-01-03T15:00:00Z",
+                "actual": 110.0,
+                "predicted": 108.0,
+            },
+        ]
+        figure, axis = plt.subplots()
+        _draw_forecast(
+            axis,
+            hourly_rows,
+            title="Window 0",
+            target="sales",
+            cutoff_start="2025-01-03",
+        )
+        cutoff_lines = [line for line in axis.lines if line.get_linestyle() == "--" and line.get_color() in {"gray", "0.5"}]
+        assert cutoff_lines
+        cutoff_ts = pd.Timestamp(cutoff_lines[0].get_xdata()[0], tz="UTC").tz_convert(None)
+        assert cutoff_ts == pd.Timestamp("2025-01-03 14:00:00")
+        plt.close(figure)
+
     def test_pick_window_metric_prefers_eval_metric(self):
         """Metric lookup matches normalized eval metric names."""
         metrics = {"MASE": 0.42, "MAPE": 5.0}
@@ -304,9 +338,6 @@ class TestBackTestingCharts:
 
         assert captured
         axis = captured[0].axes[0]
-        from matplotlib.dates import DateFormatter
-
-        assert isinstance(axis.xaxis.get_major_formatter(), DateFormatter)
         labels = [label.get_rotation() for label in axis.get_xticklabels()]
         assert labels and labels[0] == 45
 

--- a/components/training/automl/shared/tests/test_timeseries_notebook_utils.py
+++ b/components/training/automl/shared/tests/test_timeseries_notebook_utils.py
@@ -7,8 +7,10 @@ import ast
 import pandas as pd
 
 from ..timeseries_notebook_utils import (
+    _coerce_sample_timestamps,
     build_predict_sample_artifact,
     fill_known_covariates_on_future_frame,
+    notebook_timeseries_sample_helpers_source,
 )
 
 
@@ -131,6 +133,48 @@ class TestFillKnownCovariatesOnFutureFrame:
             assert "missing from ts_df" in str(exc)
         else:
             raise AssertionError("Expected ValueError for missing covariate column")
+
+
+class TestCoerceSampleTimestamps:
+    """Tests for epoch-millisecond timestamp parsing in notebook samples."""
+
+    def test_parses_positive_epoch_milliseconds(self):
+        """Post-1970 epoch ms values are parsed as UTC timestamps."""
+        frame = pd.DataFrame({"timestamp": [1704067200000, 1704070800000]})
+        result = _coerce_sample_timestamps(frame, "timestamp")
+        assert result["timestamp"].tolist() == [
+            pd.Timestamp("2024-01-01 00:00:00"),
+            pd.Timestamp("2024-01-01 01:00:00"),
+        ]
+
+    def test_parses_negative_epoch_milliseconds(self):
+        """Pre-1970 epoch ms values (fractional-year hourly data) are parsed correctly."""
+        frame = pd.DataFrame({"timestamp": [-6939997200000, -6939982800000]})
+        result = _coerce_sample_timestamps(frame, "timestamp")
+        assert result["timestamp"].tolist() == [
+            pd.Timestamp("1750-01-29 23:00:00"),
+            pd.Timestamp("1750-01-30 03:00:00"),
+        ]
+
+    def test_leaves_iso_strings_unchanged(self):
+        """ISO timestamp strings are parsed without treating them as epoch integers."""
+        frame = pd.DataFrame({"timestamp": ["2024-01-01T00:00:00", "2024-01-01T01:00:00"]})
+        result = _coerce_sample_timestamps(frame, "timestamp")
+        assert result["timestamp"].tolist() == [
+            pd.Timestamp("2024-01-01 00:00:00"),
+            pd.Timestamp("2024-01-01 01:00:00"),
+        ]
+
+
+class TestNotebookTimeseriesSampleHelpersSource:
+    """Tests for helper source embedded in generated notebooks."""
+
+    def test_embedded_source_includes_runtime_helpers(self):
+        """Notebook helper bundle exposes coercion and covariate fill helpers."""
+        source = notebook_timeseries_sample_helpers_source()
+        assert "def _coerce_sample_timestamps" in source
+        assert "def fill_known_covariates_on_future_frame" in source
+        assert "def build_predict_sample_artifact" not in source
 
 
 class TestBuildPredictSampleArtifact:

--- a/components/training/automl/shared/timeseries_notebook_utils.py
+++ b/components/training/automl/shared/timeseries_notebook_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -11,25 +12,42 @@ def _coerce_sample_timestamps(score_df: pd.DataFrame, timestamp_column: str) -> 
     """Parse sample-row timestamps written as epoch milliseconds by ``DataFrame.to_json``."""
     series = score_df[timestamp_column]
     if not pd.api.types.is_numeric_dtype(series):
-        return score_df
+        out = score_df.copy()
+        out[timestamp_column] = pd.to_datetime(series, errors="coerce")
+        return out
 
     numeric = pd.to_numeric(series, errors="coerce")
     if numeric.isna().any():
-        return score_df
+        out = score_df.copy()
+        out[timestamp_column] = pd.to_datetime(series, errors="coerce")
+        return out
 
-    if numeric.max() > 1e11:
+    if numeric.abs().max() > 1e11:
         out = score_df.copy()
         out[timestamp_column] = pd.to_datetime(numeric, unit="ms")
         return out
 
-    return score_df
+    out = score_df.copy()
+    out[timestamp_column] = pd.to_datetime(series, errors="coerce")
+    return out
+
+
+def _is_datetime_series(series: pd.Series) -> bool:
+    """Return whether a series holds datetime values (works with test pandas mocks)."""
+    dtype = getattr(series, "dtype", None)
+    if dtype is not None and str(dtype).startswith("datetime64"):
+        return True
+    api = getattr(pd, "api", None)
+    if api is not None:
+        return api.types.is_datetime64_any_dtype(series)
+    return False
 
 
 def _json_records(df: pd.DataFrame) -> list[dict[str, Any]]:
     """Convert a DataFrame to JSON-safe row dicts (ISO timestamps)."""
     out = df.copy()
     for col in out.columns:
-        if pd.api.types.is_datetime64_any_dtype(out[col]):
+        if _is_datetime_series(out[col]):
             out[col] = out[col].dt.strftime("%Y-%m-%dT%H:%M:%S.%f").str.rstrip("0").str.rstrip(".")
     return out.to_dict(orient="records")
 
@@ -141,3 +159,10 @@ def build_predict_sample_artifact(
         "history": _json_records(score_df),
         "known_covariates": known_covariates_records,
     }
+
+
+def notebook_timeseries_sample_helpers_source() -> str:
+    """Return sample/covariate helpers copied into generated inference notebooks."""
+    source = Path(__file__).read_text(encoding="utf-8")
+    end = source.index("\n\ndef build_predict_sample_artifact")
+    return source[:end]


### PR DESCRIPTION
**Description of your changes:**

**Description of your changes:**

The time series training pipeline already writes `metrics/back_testing.json`, but the generated inference notebook only printed raw JSON — no charts.

This PR adds offline matplotlib visualization aligned with the [AutoGluon backtesting tutorial](https://auto.gluon.ai/stable/tutorials/timeseries/forecasting-indepth.html):

- **`back_testing_charts.py`** — shared plotting module (`render_back_testing_charts()`)
  - Per-window scores: `Cutoff …: MASE = …` print lines + table (from existing `per_window_metrics`)
  - **Overall summary**: mean `eval_metric` across validation windows (cross-series aggregate, no JSON schema change)
  - Best/worst series forecast panels with P10–P90 band and gray cutoff vlines
  - Lazy `matplotlib` imports (same pattern as ROC/PR cells in tabular notebooks)
- **`timeseries_notebook.ipynb`** — new “Back-testing charts” section; helpers injected at notebook generation via `notebook_backtest_charts_source()`
- **`autogluon_timeseries_models_training`** — wires chart source into notebook placeholder substitution
- **`back_testing.py`** — cutoff in per-window metrics; P10/P90 quantile bounds in forecast data

No new runtime dependencies. Works from precomputed artifacts only (no `TimeSeriesPredictor` required in the notebook).

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [x] `metadata.yaml` includes fresh `lastVerified` timestamp
- [x] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [x] OWNERS file lists appropriate maintainers
- [x] README provides clear documentation with usage examples
- [x] Component follows `snake_case` naming convention
- [x] No security vulnerabilities in dependencies
- [x] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Back-testing metrics and charts are now embedded in generated notebooks, including per-window forecast comparisons and prediction intervals.
  * Notebook charts render automatically when the back-testing data and render helpers are available, with improved navigation and guidance.

* **Bug Fixes**
  * Improved quantile bound selection to better match P10/P90-style behavior.
  * Quantile rows now include explicit lower/upper quantile fields; per-window metrics now include the evaluation cutoff.

* **Documentation**
  * Updated back-testing README guidance and verification timestamps.

* **Tests**
  * Expanded unit and chart-rendering tests for quantile bounds, cutoff handling, chart/table helpers, and notebook helper source validity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->