### PR TITLE
fix(autorag): make component_status optional for notebook python_func calls

### DIFF
--- a/components/data_processing/autorag/documents_discovery/README.md
+++ b/components/data_processing/autorag/documents_discovery/README.md
@@ -13,12 +13,12 @@ Lists available documents from S3, performs sampling if applied and writes a JSO
 | Parameter | Type | Default | Description |
 | --------- | ---- | ------- | ----------- |
 | `input_data_bucket_name` | `str` | `None` | S3 (or compatible) bucket containing input data. |
-| `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking. |
 | `input_data_path` | `str` | `""` | Path to folder with input documents within the bucket. |
 | `test_data` | `dsl.Input[dsl.Artifact]` | `None` | Optional input artifact containing test data for sampling. |
 | `sampling_enabled` | `bool` | `True` | Whether to enable sampling or not. |
 | `sampling_max_size` | `float` | `1` | Maximum size of sampled documents (in gigabytes). |
 | `discovered_documents` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing the documents descriptor JSON file. |
+| `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking. |
 | `embedded_artifact` | `dsl.EmbeddedInput[dsl.Dataset]` | `None` | Embedded ``autorag.shared`` helpers injected by KFP at runtime. |
 
 ## Usage Examples 🧪

--- a/components/data_processing/autorag/documents_discovery/component.py
+++ b/components/data_processing/autorag/documents_discovery/component.py
@@ -13,12 +13,12 @@ _AUTORAG_SHARED = Path(__file__).parents[3] / "training" / "autorag" / "shared"
 )
 def documents_discovery(
     input_data_bucket_name: str,
-    component_status: dsl.Output[dsl.Artifact],
     input_data_path: str = "",
     test_data: dsl.Input[dsl.Artifact] = None,
     sampling_enabled: bool = True,
     sampling_max_size: float = 1,
     discovered_documents: dsl.Output[dsl.Artifact] = None,
+    component_status: dsl.Output[dsl.Artifact] = None,
     embedded_artifact: dsl.EmbeddedInput[dsl.Dataset] = None,
 ):
     """Documents discovery component.
@@ -77,17 +77,25 @@ def documents_discovery(
 
     from botocore.exceptions import SSLError
 
-    _embedded_path = Path(embedded_artifact.path)
-    _module_path = _embedded_path if _embedded_path.is_file() else _embedded_path / "component_status.py"
-    _spec = importlib.util.spec_from_file_location("_autorag_component_status", _module_path)
-    if _spec is None or _spec.loader is None:
-        raise ValueError(f"Cannot load embedded module from {_module_path}")
-    _status_module = importlib.util.module_from_spec(_spec)
-    _spec.loader.exec_module(_status_module)
-    status = _status_module.bootstrap_status_tracker(embedded_artifact, component_status, "documents_discovery")
+    if component_status is None:
+        from kfp_components.components.training.autorag.shared.component_status import (  # pyright: ignore[reportMissingImports]
+            null_component_status_tracker,
+        )
+
+        status = null_component_status_tracker()
+    else:
+        _embedded_path = Path(embedded_artifact.path)
+        _module_path = _embedded_path if _embedded_path.is_file() else _embedded_path / "component_status.py"
+        _spec = importlib.util.spec_from_file_location("_autorag_component_status", _module_path)
+        if _spec is None or _spec.loader is None:
+            raise ValueError(f"Cannot load embedded module from {_module_path}")
+        _status_module = importlib.util.module_from_spec(_spec)
+        _spec.loader.exec_module(_status_module)
+        status = _status_module.bootstrap_status_tracker(embedded_artifact, component_status, "documents_discovery")
     with status:
-        status.set_metadata(display_name="Documents Discovery Status")
-        component_status.metadata["display_name"] = "Documents Discovery Status"
+        if component_status is not None:
+            status.set_metadata(display_name="Documents Discovery Status")
+            component_status.metadata["display_name"] = "Documents Discovery Status"
         with status.stage("discover_documents"):
             s3_creds = {k: os.environ.get(k) for k in ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_S3_ENDPOINT"]}
             for k, v in s3_creds.items():

--- a/components/data_processing/autorag/documents_discovery/tests/test_component_unit.py
+++ b/components/data_processing/autorag/documents_discovery/tests/test_component_unit.py
@@ -104,6 +104,36 @@ class TestDocumentsDiscoveryUnitTests:
         assert payload["count"] == 2
         assert payload["total_size_bytes"] == 3000
 
+    @mock.patch.dict("os.environ", MOCKED_ENV_VARIABLES, clear=True)
+    def test_notebook_style_call_without_component_status(self, tmp_path):
+        """Direct python_func calls without component_status work (indexing notebook path)."""
+        mock_boto3 = mock.MagicMock()
+        mock_s3 = mock.MagicMock()
+        _configure_s3_paginator(mock_s3, [{"Key": "docs/a.pdf", "Size": 1000}])
+        mock_boto3.client.return_value = mock_s3
+        mock_botocore, mock_botocore_exceptions = _make_botocore_modules()
+
+        discovered = mock.MagicMock()
+        discovered.path = str(tmp_path / "descriptor")
+
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "boto3": mock_boto3,
+                "botocore": mock_botocore,
+                "botocore.exceptions": mock_botocore_exceptions,
+            },
+        ):
+            documents_discovery.python_func(
+                input_data_bucket_name="my-bucket",
+                input_data_path="docs/",
+                discovered_documents=discovered,
+                component_status=None,
+                sampling_enabled=False,
+            )
+
+        assert (tmp_path / "descriptor" / "documents_descriptor.json").is_file()
+
     @mock.patch.dict("os.environ", MOCKED_ENV_VARIABLES_NO_REGION, clear=True)
     def test_missing_region_is_allowed(self, tmp_path):
         """Component works when AWS_DEFAULT_REGION is not present."""

--- a/components/data_processing/autorag/test_data_loader/README.md
+++ b/components/data_processing/autorag/test_data_loader/README.md
@@ -14,9 +14,9 @@ The component reads S3-compatible credentials from environment variables (inject
 | --------- | ---- | ------- | ----------- |
 | `test_data_bucket_name` | `str` | `None` | S3 (or compatible) bucket that contains the test data file. |
 | `test_data_path` | `str` | `None` | S3 object key to the JSON test data file. |
-| `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking. |
 | `benchmark_sample_size` | `int` | `25` | Maximum number of records to keep from the test data. When the dataset exceeds this limit, a reproducible random sample is drawn (seed 42). Set to 0 to disable sampling and keep all records. |
 | `test_data` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact that receives the (possibly sampled) file. |
+| `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking. |
 | `embedded_artifact` | `dsl.EmbeddedInput[dsl.Dataset]` | `None` | Embedded ``autorag.shared`` helpers injected by KFP at runtime. |
 
 ## Usage Examples 🧪

--- a/components/data_processing/autorag/test_data_loader/component.py
+++ b/components/data_processing/autorag/test_data_loader/component.py
@@ -15,9 +15,9 @@ _AUTORAG_SHARED = Path(__file__).parents[3] / "training" / "autorag" / "shared"
 def test_data_loader(
     test_data_bucket_name: str,
     test_data_path: str,
-    component_status: dsl.Output[dsl.Artifact],
     benchmark_sample_size: int = 25,
     test_data: dsl.Output[dsl.Artifact] = None,
+    component_status: dsl.Output[dsl.Artifact] = None,
     embedded_artifact: dsl.EmbeddedInput[dsl.Dataset] = None,
 ):
     """Download test data JSON from S3 and sample it for benchmarking.
@@ -69,17 +69,25 @@ def test_data_loader(
 
     import importlib.util
 
-    _embedded_path = Path(embedded_artifact.path)
-    _module_path = _embedded_path if _embedded_path.is_file() else _embedded_path / "component_status.py"
-    _spec = importlib.util.spec_from_file_location("_autorag_component_status", _module_path)
-    if _spec is None or _spec.loader is None:
-        raise ValueError(f"Cannot load embedded module from {_module_path}")
-    _status_module = importlib.util.module_from_spec(_spec)
-    _spec.loader.exec_module(_status_module)
-    status = _status_module.bootstrap_status_tracker(embedded_artifact, component_status, "test_data_loader")
+    if component_status is None:
+        from kfp_components.components.training.autorag.shared.component_status import (  # pyright: ignore[reportMissingImports]
+            null_component_status_tracker,
+        )
+
+        status = null_component_status_tracker()
+    else:
+        _embedded_path = Path(embedded_artifact.path)
+        _module_path = _embedded_path if _embedded_path.is_file() else _embedded_path / "component_status.py"
+        _spec = importlib.util.spec_from_file_location("_autorag_component_status", _module_path)
+        if _spec is None or _spec.loader is None:
+            raise ValueError(f"Cannot load embedded module from {_module_path}")
+        _status_module = importlib.util.module_from_spec(_spec)
+        _spec.loader.exec_module(_status_module)
+        status = _status_module.bootstrap_status_tracker(embedded_artifact, component_status, "test_data_loader")
     with status:
-        status.set_metadata(display_name="Test Data Loader Status")
-        component_status.metadata["display_name"] = "Test Data Loader Status"
+        if component_status is not None:
+            status.set_metadata(display_name="Test Data Loader Status")
+            component_status.metadata["display_name"] = "Test Data Loader Status"
         with status.stage("load_benchmark"):
             if not test_data_bucket_name:
                 raise TypeError("test_data_bucket_name must be a non-empty string")

--- a/components/data_processing/autorag/text_extraction/component.py
+++ b/components/data_processing/autorag/text_extraction/component.py
@@ -15,7 +15,7 @@ _AUTORAG_SHARED = Path(__file__).parents[3] / "training" / "autorag" / "shared"
 def text_extraction(
     documents_descriptor: dsl.Input[dsl.Artifact],
     extracted_text: dsl.Output[dsl.Artifact],
-    component_status: dsl.Output[dsl.Artifact],
+    component_status: dsl.Output[dsl.Artifact] = None,
     embedded_artifact: dsl.EmbeddedInput[dsl.Dataset] = None,
     error_tolerance: Optional[float] = None,
     max_extraction_workers: Optional[int] = None,
@@ -348,17 +348,25 @@ def text_extraction(
 
     import importlib.util
 
-    _embedded_path = Path(embedded_artifact.path)
-    _module_path = _embedded_path if _embedded_path.is_file() else _embedded_path / "component_status.py"
-    _spec = importlib.util.spec_from_file_location("_autorag_component_status", _module_path)
-    if _spec is None or _spec.loader is None:
-        raise ValueError(f"Cannot load embedded module from {_module_path}")
-    _status_module = importlib.util.module_from_spec(_spec)
-    _spec.loader.exec_module(_status_module)
-    status = _status_module.bootstrap_status_tracker(embedded_artifact, component_status, "text_extraction")
+    if component_status is None:
+        from kfp_components.components.training.autorag.shared.component_status import (  # pyright: ignore[reportMissingImports]
+            null_component_status_tracker,
+        )
+
+        status = null_component_status_tracker()
+    else:
+        _embedded_path = Path(embedded_artifact.path)
+        _module_path = _embedded_path if _embedded_path.is_file() else _embedded_path / "component_status.py"
+        _spec = importlib.util.spec_from_file_location("_autorag_component_status", _module_path)
+        if _spec is None or _spec.loader is None:
+            raise ValueError(f"Cannot load embedded module from {_module_path}")
+        _status_module = importlib.util.module_from_spec(_spec)
+        _spec.loader.exec_module(_status_module)
+        status = _status_module.bootstrap_status_tracker(embedded_artifact, component_status, "text_extraction")
     with status:
-        status.set_metadata(display_name="Text Extraction Status")
-        component_status.metadata["display_name"] = "Text Extraction Status"
+        if component_status is not None:
+            status.set_metadata(display_name="Text Extraction Status")
+            component_status.metadata["display_name"] = "Text Extraction Status"
         descriptor_path = Path(documents_descriptor.path) / DOCUMENTS_DESCRIPTOR_FILENAME
 
         with status.stage("extract_documents"):

--- a/components/training/autorag/leaderboard_evaluation/README.md
+++ b/components/training/autorag/leaderboard_evaluation/README.md
@@ -15,9 +15,9 @@ search_mode ("hybrid" | "vector" per ai4rag), ranker_strategy, generation.model_
 | --------- | ---- | ------- | ----------- |
 | `rag_patterns` | `dsl.InputPath(dsl.Artifact)` | `None` | Path to the directory of RAG patterns; each subdir contains pattern.json (pattern_name, indexing_params, rag_params, scores, execution_time, final_score). |
 | `html_artifact` | `dsl.Output[dsl.HTML]` | `None` | Output HTML artifact; the leaderboard table is written to html_artifact.path (single file). |
-| `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking. |
 | `embedded_artifact` | `dsl.EmbeddedInput[dsl.Dataset]` | `None` | Embedded ``autorag.shared`` helpers injected by KFP at runtime. |
 | `optimization_metric` | `str` | `faithfulness` | Name of the metric used to rank patterns (e.g. faithfulness, answer_correctness, context_correctness). Shown in the leaderboard subtitle. Defaults to "faithfulness". |
+| `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking. |
 
 ## Usage Examples 🧪
 

--- a/components/training/autorag/leaderboard_evaluation/component.py
+++ b/components/training/autorag/leaderboard_evaluation/component.py
@@ -14,9 +14,9 @@ _AUTORAG_SHARED = Path(__file__).parents[1] / "shared"
 def leaderboard_evaluation(
     rag_patterns: dsl.InputPath(dsl.Artifact),
     html_artifact: dsl.Output[dsl.HTML],
-    component_status: dsl.Output[dsl.Artifact],
     embedded_artifact: dsl.EmbeddedInput[dsl.Dataset] = None,
     optimization_metric: str = "faithfulness",
+    component_status: dsl.Output[dsl.Artifact] = None,
 ):
     """Build an HTML leaderboard artifact from RAG pattern evaluation results.
 
@@ -329,17 +329,25 @@ def leaderboard_evaluation(
 
     import importlib.util
 
-    _embedded_path = Path(embedded_artifact.path)
-    _module_path = _embedded_path if _embedded_path.is_file() else _embedded_path / "component_status.py"
-    _spec = importlib.util.spec_from_file_location("_autorag_component_status", _module_path)
-    if _spec is None or _spec.loader is None:
-        raise ValueError(f"Cannot load embedded module from {_module_path}")
-    _status_module = importlib.util.module_from_spec(_spec)
-    _spec.loader.exec_module(_status_module)
-    status = _status_module.bootstrap_status_tracker(embedded_artifact, component_status, "leaderboard_evaluation")
+    if component_status is None:
+        from kfp_components.components.training.autorag.shared.component_status import (  # pyright: ignore[reportMissingImports]
+            null_component_status_tracker,
+        )
+
+        status = null_component_status_tracker()
+    else:
+        _embedded_path = Path(embedded_artifact.path)
+        _module_path = _embedded_path if _embedded_path.is_file() else _embedded_path / "component_status.py"
+        _spec = importlib.util.spec_from_file_location("_autorag_component_status", _module_path)
+        if _spec is None or _spec.loader is None:
+            raise ValueError(f"Cannot load embedded module from {_module_path}")
+        _status_module = importlib.util.module_from_spec(_spec)
+        _spec.loader.exec_module(_status_module)
+        status = _status_module.bootstrap_status_tracker(embedded_artifact, component_status, "leaderboard_evaluation")
     with status:
-        status.set_metadata(display_name="Leaderboard Evaluation Status")
-        component_status.metadata["display_name"] = "Leaderboard Evaluation Status"
+        if component_status is not None:
+            status.set_metadata(display_name="Leaderboard Evaluation Status")
+            component_status.metadata["display_name"] = "Leaderboard Evaluation Status"
         with status.stage("build_leaderboard"):
             if not rag_patterns_dir.is_dir():
                 raise FileNotFoundError("rag_patterns path is not a directory: %s" % rag_patterns_dir)

--- a/components/training/autorag/pytest_support.py
+++ b/components/training/autorag/pytest_support.py
@@ -27,11 +27,12 @@ def wrap_component_python_func(
     embed_root = embedded_path or str(shared_dir)
 
     def wrapper(*args, **kwargs):
-        if "embedded_artifact" in signature.parameters and kwargs.get("embedded_artifact") is None:
+        bound = signature.bind_partial(*args, **kwargs)
+        if "embedded_artifact" in signature.parameters and "embedded_artifact" not in bound.arguments:
             embedded = mock.MagicMock()
             embedded.path = embed_root
             kwargs["embedded_artifact"] = embedded
-        if "component_status" in signature.parameters and kwargs.get("component_status") is None:
+        if "component_status" in signature.parameters and "component_status" not in bound.arguments:
             status = mock.MagicMock()
             status.path = str(tmp_path / "component_status_out")
             status.metadata = {}

--- a/components/training/autorag/rag_templates_optimization/README.md
+++ b/components/training/autorag/rag_templates_optimization/README.md
@@ -18,10 +18,10 @@ Carries out the iterative RAG optimization process.
 | `rag_patterns` | `dsl.Output[dsl.Artifact]` | `None` | kfp-enforced argument specifying an output artifact. Provided by kfp backend automatically. |
 | `test_data_key` | `Optional[str]` | `None` | Path to the benchmark JSON file in object storage used by generated notebooks. |
 | `vector_io_provider_id` | `str` | `None` | Vector I/O provider identifier as registered in OGX. |
-| `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking. |
 | `embedded_artifact` | `dsl.EmbeddedInput[dsl.Dataset]` | `None` | Embedded ``autorag.shared`` helpers injected by KFP at runtime. |
 | `optimization_settings` | `Optional[dict]` | `None` | Additional settings customising the experiment. |
 | `input_data_key` | `Optional[str]` | `""` | A path to documents dir within a bucket used as an input to AI4RAG experiment. |
+| `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking. |
 
 ## Usage Examples 🧪
 

--- a/components/training/autorag/rag_templates_optimization/component.py
+++ b/components/training/autorag/rag_templates_optimization/component.py
@@ -431,9 +431,9 @@ def rag_templates_optimization(
         mapping["EMBEDDING_PARAMS"] = em.get("embedding_params", {"embedding_dimension": 768})
         mapping["DISTANCE_METRIC"] = em.get("distance_metric", "")
 
-        vs = settings.get("vector_store", {})
-        mapping["PROVIDER_ID"] = vs.get("datasource_type", "")
-        mapping["COLLECTION_NAME"] = vs.get("collection_name", "")
+        vs_binding = settings.get("vector_store_binding") or {}
+        mapping["PROVIDER_ID"] = vs_binding.get("provider_id", "")
+        mapping["COLLECTION_NAME"] = vs_binding.get("vector_store_id", "")
 
         ret = settings.get("retrieval", {})
         mapping["RETRIEVAL_METHOD"] = ret.get("method", "")

--- a/components/training/autorag/rag_templates_optimization/component.py
+++ b/components/training/autorag/rag_templates_optimization/component.py
@@ -19,10 +19,10 @@ def rag_templates_optimization(
     rag_patterns: dsl.Output[dsl.Artifact],
     test_data_key: Optional[str],
     vector_io_provider_id: str,
-    component_status: dsl.Output[dsl.Artifact],
     embedded_artifact: dsl.EmbeddedInput[dsl.Dataset] = None,
     optimization_settings: Optional[dict] = None,
     input_data_key: Optional[str] = "",
+    component_status: dsl.Output[dsl.Artifact] = None,
 ):
     """RAG Templates Optimization component.
 
@@ -531,13 +531,23 @@ def rag_templates_optimization(
 
     _embedded_path = Path(embedded_artifact.path)
     import_root = _embedded_path.parent if _embedded_path.is_file() else _embedded_path
-    _module_path = _embedded_path if _embedded_path.is_file() else _embedded_path / "component_status.py"
-    _spec = importlib.util.spec_from_file_location("_autorag_component_status", _module_path)
-    if _spec is None or _spec.loader is None:
-        raise ValueError(f"Cannot load embedded module from {_module_path}")
-    _status_module = importlib.util.module_from_spec(_spec)
-    _spec.loader.exec_module(_status_module)
-    status = _status_module.bootstrap_status_tracker(embedded_artifact, component_status, "rag_templates_optimization")
+
+    if component_status is None:
+        from kfp_components.components.training.autorag.shared.component_status import (  # pyright: ignore[reportMissingImports]
+            null_component_status_tracker,
+        )
+
+        status = null_component_status_tracker()
+    else:
+        _module_path = _embedded_path if _embedded_path.is_file() else _embedded_path / "component_status.py"
+        _spec = importlib.util.spec_from_file_location("_autorag_component_status", _module_path)
+        if _spec is None or _spec.loader is None:
+            raise ValueError(f"Cannot load embedded module from {_module_path}")
+        _status_module = importlib.util.module_from_spec(_spec)
+        _spec.loader.exec_module(_status_module)
+        status = _status_module.bootstrap_status_tracker(
+            embedded_artifact, component_status, "rag_templates_optimization"
+        )
     optimize_templates_steps = ["chunking", "embedding", "retrieval", "generation", "evaluation"]
 
     class OptimizationEventHandler(BaseEventHandler):
@@ -551,8 +561,9 @@ def rag_templates_optimization(
             pass
 
     with status:
-        status.set_metadata(display_name="RAG Templates Optimization Status")
-        component_status.metadata["display_name"] = "RAG Templates Optimization Status"
+        if component_status is not None:
+            status.set_metadata(display_name="RAG Templates Optimization Status")
+            component_status.metadata["display_name"] = "RAG Templates Optimization Status"
         with status.stage("optimize_templates", steps=optimize_templates_steps):
             if not ogx_client_base_url or not ogx_client_api_key:
                 raise ValueError(

--- a/components/training/autorag/search_space_preparation/README.md
+++ b/components/training/autorag/search_space_preparation/README.md
@@ -17,11 +17,11 @@ Generates a .yml-formatted report including results of this experiment's phase. 
 | `test_data` | `dsl.Input[dsl.Artifact]` | `None` | A path to a .json file containing questions and expected answers that can be retrieved from input documents. Necessary baseline for calculating quality metrics of RAG pipeline. |
 | `extracted_text` | `dsl.Input[dsl.Artifact]` | `None` | A path to either a single file or a folder of files. The document(s) will be sampled and used during the models selection process. |
 | `search_space_prep_report` | `dsl.Output[dsl.Artifact]` | `None` | kfp-enforced argument specifying an output artifact. Provided by kfp backend automatically. |
-| `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking. |
 | `embedded_artifact` | `dsl.EmbeddedInput[dsl.Dataset]` | `None` | Embedded ``autorag.shared`` helpers injected by KFP at runtime. |
 | `embedding_models` | `Optional[List]` | `None` | List of embedding model identifiers to try out in the experiment process. This list, if too long, will undergo models preselection (limiting). |
 | `generation_models` | `Optional[List]` | `None` | List of generation model identifiers to try out in the experiment process. This list, if too long, will undergo models preselection (limiting). |
 | `metric` | `str` | `None` | Quality metric to evaluate the intermediate RAG patterns. |
+| `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking. |
 
 ## Usage Examples 🧪
 

--- a/components/training/autorag/search_space_preparation/component.py
+++ b/components/training/autorag/search_space_preparation/component.py
@@ -17,11 +17,11 @@ def search_space_preparation(
     test_data: dsl.Input[dsl.Artifact],
     extracted_text: dsl.Input[dsl.Artifact],
     search_space_prep_report: dsl.Output[dsl.Artifact],
-    component_status: dsl.Output[dsl.Artifact],
     embedded_artifact: dsl.EmbeddedInput[dsl.Dataset] = None,
     embedding_models: Optional[List] = None,
     generation_models: Optional[List] = None,
     metric: str = None,
+    component_status: dsl.Output[dsl.Artifact] = None,
 ):
     """Runs an AutoRAG experiment's first phase which includes:
 
@@ -327,17 +327,27 @@ def search_space_preparation(
 
     import importlib.util
 
-    _embedded_path = Path(embedded_artifact.path)
-    _module_path = _embedded_path if _embedded_path.is_file() else _embedded_path / "component_status.py"
-    _spec = importlib.util.spec_from_file_location("_autorag_component_status", _module_path)
-    if _spec is None or _spec.loader is None:
-        raise ValueError(f"Cannot load embedded module from {_module_path}")
-    _status_module = importlib.util.module_from_spec(_spec)
-    _spec.loader.exec_module(_status_module)
-    status = _status_module.bootstrap_status_tracker(embedded_artifact, component_status, "search_space_preparation")
+    if component_status is None:
+        from kfp_components.components.training.autorag.shared.component_status import (  # pyright: ignore[reportMissingImports]
+            null_component_status_tracker,
+        )
+
+        status = null_component_status_tracker()
+    else:
+        _embedded_path = Path(embedded_artifact.path)
+        _module_path = _embedded_path if _embedded_path.is_file() else _embedded_path / "component_status.py"
+        _spec = importlib.util.spec_from_file_location("_autorag_component_status", _module_path)
+        if _spec is None or _spec.loader is None:
+            raise ValueError(f"Cannot load embedded module from {_module_path}")
+        _status_module = importlib.util.module_from_spec(_spec)
+        _spec.loader.exec_module(_status_module)
+        status = _status_module.bootstrap_status_tracker(
+            embedded_artifact, component_status, "search_space_preparation"
+        )
     with status:
-        status.set_metadata(display_name="Search Space Preparation Status")
-        component_status.metadata["display_name"] = "Search Space Preparation Status"
+        if component_status is not None:
+            status.set_metadata(display_name="Search Space Preparation Status")
+            component_status.metadata["display_name"] = "Search Space Preparation Status"
         with status.stage("prepare_search_space"):
             if not ogx_client_base_url or not ogx_client_api_key:
                 raise ValueError("OGX_CLIENT_BASE_URL and OGX_CLIENT_API_KEY environment variables must be set.")

--- a/components/training/autorag/shared/component_status.py
+++ b/components/training/autorag/shared/component_status.py
@@ -62,6 +62,34 @@ STATUS_COMPLETED = "completed"
 STATUS_FAILED = "failed"
 
 
+class NullComponentStatusTracker:
+    """No-op status tracker for notebook or direct ``python_func`` invocations."""
+
+    def set_metadata(self, **_metadata: Any) -> None:
+        """Ignore metadata updates."""
+
+    def record(self, *_args: Any, **_kwargs: Any) -> None:
+        """Ignore status records."""
+
+    def __enter__(self) -> NullComponentStatusTracker:
+        """Enter the no-op context."""
+        return self
+
+    def __exit__(self, _exc_type: type[BaseException] | None, _exc: BaseException | None, _tb: Any) -> bool:
+        """Exit the no-op context."""
+        return False
+
+    @contextmanager
+    def stage(self, _stage_id: str, **_start_metadata: Any) -> Iterator[None]:
+        """Yield without recording stage transitions."""
+        yield
+
+
+def null_component_status_tracker() -> NullComponentStatusTracker:
+    """Return a tracker that skips all status persistence."""
+    return NullComponentStatusTracker()
+
+
 class ComponentStatusTracker:
     """Track stage-level progress within a single AutoRAG component."""
 
@@ -246,13 +274,17 @@ def bootstrap_status_tracker(
     embedded_artifact: Any,
     component_status: Any,
     component_id: str,
-) -> ComponentStatusTracker:
+) -> ComponentStatusTracker | NullComponentStatusTracker:
     """Load this module from ``embedded_artifact`` and return a configured tracker."""
+    if component_status is None:
+        return null_component_status_tracker()
     status_module = load_embedded_component_status_module(embedded_artifact)
     return status_module.tracker_from_embedded(embedded_artifact, component_status, component_id)
 
 
-def component_status_tracker(component_status: Any, component_id: str) -> ComponentStatusTracker:
+def component_status_tracker(
+    component_status: Any, component_id: str
+) -> ComponentStatusTracker | NullComponentStatusTracker:
     """Build a tracker from a KFP component_status output artifact.
 
     Args:
@@ -260,8 +292,10 @@ def component_status_tracker(component_status: Any, component_id: str) -> Compon
         component_id: Unique component identifier.
 
     Returns:
-        Configured ComponentStatusTracker instance.
+        Configured ComponentStatusTracker instance, or a no-op tracker when ``component_status`` is None.
     """
+    if component_status is None:
+        return null_component_status_tracker()
     return ComponentStatusTracker(component_status.path, component_id)
 
 

--- a/components/training/autorag/shared/tests/test_component_status.py
+++ b/components/training/autorag/shared/tests/test_component_status.py
@@ -10,6 +10,7 @@ from kfp_components.components.training.autorag.shared.component_status import (
     COMPONENT_STATUS_FILENAME,
     ComponentStatusEncoder,
     ComponentStatusTracker,
+    NullComponentStatusTracker,
     bootstrap_status_tracker,
     load_component_status,
     load_embedded_component_status_module,
@@ -108,6 +109,15 @@ class TestEmbeddedStatusBootstrap:
         embedded = type("Embedded", (), {"path": str(module_path)})()
         module = load_embedded_component_status_module(embedded)
         assert hasattr(module, "bootstrap_status_tracker")
+
+    def test_bootstrap_status_tracker_returns_noop_when_component_status_is_none(self) -> None:
+        """Notebook-style invocations without component_status use a no-op tracker."""
+        embedded = type("Embedded", (), {"path": str(Path(__file__).resolve().parents[1])})()
+        status = bootstrap_status_tracker(embedded, None, "documents_discovery")
+        assert isinstance(status, NullComponentStatusTracker)
+        with status:
+            with status.stage("discover_documents"):
+                pass
 
 
 class TestComponentStatusTrackerStage:


### PR DESCRIPTION
**Description of your changes:**

## Summary

Fixes [RHOAIENG-69903](https://redhat.atlassian.net/browse/RHOAIENG-69903).

Commit d2f9dc7 made `component_status` a required output on AutoRAG components. Indexing and inference notebooks generated from pattern artifacts call `documents_discovery.python_func()` / `text_extraction.python_func()` directly and do not pass `component_status`, which caused an error.


**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [x] `metadata.yaml` includes fresh `lastVerified` timestamp
- [x] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [x] OWNERS file lists appropriate maintainers
- [x] README provides clear documentation with usage examples
- [x] Component follows `snake_case` naming convention
- [x] No security vulnerabilities in dependencies
- [x] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Pipeline components now support optional status tracking, allowing execution without a `component_status` artifact (including notebook-style direct calls).

* **Bug Fixes**
  * Stage display name/metadata updates are now only performed when status tracking is enabled.
  * Status tracking bootstrapping now falls back to a no-op tracker when `component_status` is absent.

* **Documentation**
  * Updated “Inputs” tables to reflect consistent parameter ordering across components.

* **Tests**
  * Added unit tests covering direct invocation with `component_status=None` and no-op tracker bootstrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->