### PR TITLE
feat(pipelines)[AutoML]: align metric names format between tabular timeseries

### DIFF
--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -34,7 +34,7 @@ Refit outputs for all selected models are written under one ``models_artifact``,
 | `prediction_length` | `int` | `1` | Forecast horizon (number of timesteps). |
 | `known_covariates_names` | `Optional[List[str]]` | `None` | Optional list of known covariate column names. |
 | `preset` | `str` | `speed` | Training quality tier. ``"speed"`` (default) or ``"balanced"`` (may run more than 2x longer). |
-| `eval_metric` | `str` | `MASE` | Metric for model ranking (e.g. ``"MASE"``, ``"WQL"``). Defaults to ``"MASE"``. |
+| `eval_metric` | `str` | `mean_absolute_scaled_error` | Metric for model ranking (e.g. ``"mean_absolute_scaled_error"``, ``"weighted_quantile_loss"``). Defaults to ``"mean_absolute_scaled_error"``. Legacy uppercase acronyms (e.g. ``"MASE"``) are accepted and normalized to snake_case. |
 
 ## Outputs 📤
 
@@ -112,7 +112,7 @@ def example_pipeline(
   - timeseries
   - automl
   - model-selection
-- **Last Verified**: 2026-06-10 12:00:00+00:00
+- **Last Verified**: 2026-07-08 12:00:00+00:00
 - **Owners**:
   - No Parent Owners: Yes
   - Approvers:
@@ -137,7 +137,7 @@ Inference notebooks are loaded from ``shared/notebook_templates/timeseries_noteb
 
 Under each ``{model_name}_FULL/metrics/`` directory:
 
-- **`metrics.json`**: Holdout test metrics from ``TimeSeriesPredictor.evaluate`` (finite values only). Uses AutoGluon's raw **higher-is-better** sign convention (error metrics such as MASE are negated) so the HTML leaderboard ranks models correctly.
+- **`metrics.json`**: Holdout test metrics from ``TimeSeriesPredictor.evaluate`` (finite values only). Uses AutoGluon's raw **higher-is-better** sign convention (error metrics such as ``mean_absolute_scaled_error`` are negated) so the HTML leaderboard ranks models correctly.
 - **`back_testing.json`**: Multi-window backtest with ``per_window_metrics`` and ``series_analysis``
   (best/worst forecast timelines). Window error metrics use **natural positive** signs via
   ``filter_finite_metrics``. Best-effort after refit; omitted if backtest APIs or history are

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -27,7 +27,7 @@ def autogluon_timeseries_models_training(
     prediction_length: int = 1,
     known_covariates_names: Optional[List[str]] = None,
     preset: str = "speed",
-    eval_metric: str = "MASE",
+    eval_metric: str = "mean_absolute_scaled_error",
 ) -> NamedTuple(
     "outputs",
     top_models=List[str],
@@ -67,7 +67,9 @@ def autogluon_timeseries_models_training(
         component_status: Output artifact containing stage-level progress tracking for this component.
         preset: Training quality tier. ``"speed"`` (default) or ``"balanced"``
             (may run more than 2x longer).
-        eval_metric: Metric for model ranking (e.g. ``"MASE"``, ``"WQL"``). Defaults to ``"MASE"``.
+        eval_metric: Metric for model ranking (e.g. ``"mean_absolute_scaled_error"``,
+            ``"weighted_quantile_loss"``). Defaults to ``"mean_absolute_scaled_error"``.
+            Legacy uppercase acronyms (e.g. ``"MASE"``) are accepted and normalized to snake_case.
 
     Returns:
         NamedTuple: top_models list, predictor_path, eval_metric, model_config.
@@ -79,7 +81,7 @@ def autogluon_timeseries_models_training(
 
     import pandas as pd
     from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesPredictor
-    from autogluon.timeseries.metrics import AVAILABLE_METRICS
+    from autogluon.timeseries.metrics import AVAILABLE_METRICS, METRIC_ALIASES
     from kfp_components.components.training.automl.shared.component_status import ComponentStatusTracker
     from kfp_components.components.training.automl.shared.run_status import shared_automl_dir
 
@@ -103,6 +105,10 @@ def autogluon_timeseries_models_training(
         PRESET_AG_NAMES = {"speed": "fast_training", "balanced": "medium_quality"}
         PRESET_TIME_LIMITS = {"speed": 10 * 60, "balanced": 60 * 60}
 
+        # Normalize eval_metric to snake_case; accept legacy uppercase acronyms (e.g. "MASE") for back-compat.
+        _acronym_to_snake = {acronym: snake for snake, acronym in METRIC_ALIASES.items()}
+        eval_metric = _acronym_to_snake.get(eval_metric, eval_metric)
+
         # Input validation
         if preset not in VALID_PRESETS:
             raise ValueError(f"preset must be one of {VALID_PRESETS}; got {preset!r}.")
@@ -116,8 +122,8 @@ def autogluon_timeseries_models_training(
         ):
             if not isinstance(value, str) or not value.strip():
                 raise TypeError(f"{param} must be a non-empty string.")
-        if eval_metric not in AVAILABLE_METRICS:
-            raise ValueError(f"eval_metric must be one of {sorted(AVAILABLE_METRICS)}; got {eval_metric!r}.")
+        if eval_metric not in METRIC_ALIASES:
+            raise ValueError(f"eval_metric must be one of {sorted(METRIC_ALIASES)}; got {eval_metric!r}.")
         if not isinstance(top_n, int):
             raise TypeError("top_n must be an integer.")
         if top_n <= 0 or top_n > TOP_N_MAX:
@@ -261,7 +267,6 @@ def autogluon_timeseries_models_training(
         }
 
         # Stage 2: Full refit of selected models on full train data (selection + extra).
-        from autogluon.timeseries.metrics import AVAILABLE_METRICS
         from autogluon.timeseries.models.ensemble import AbstractTimeSeriesEnsembleModel
 
         selection_ts_df = train_ts
@@ -339,12 +344,18 @@ def autogluon_timeseries_models_training(
                 # Keep raw AutoGluon evaluate() signs for metrics.json (higher-is-better / negated errors)
                 # so Phase C leaderboard sorting (ascending=False) stays correct.
                 # back_testing.json normalizes separately.
+                # Remap uppercase acronym keys (e.g. "MASE") to snake_case (e.g. "mean_absolute_scaled_error").
                 metrics_dict = {}
                 for k, v in metrics.items():
                     if hasattr(v, "item"):
                         v = float(v)
                     if isinstance(v, (int, float)) and math.isfinite(v):
-                        metrics_dict[k] = v
+                        normalized_key = _acronym_to_snake.get(k)
+                        if normalized_key is None:
+                            if k not in AVAILABLE_METRICS:
+                                logger.warning("Unrecognized metric key %r from evaluate(); storing as-is.", k)
+                            normalized_key = k
+                        metrics_dict[normalized_key] = v
 
                 if eval_metric not in metrics_dict:
                     raise ValueError(
@@ -473,7 +484,8 @@ def autogluon_timeseries_models_training(
                 }
             )
 
-        # AutoGluon negates error metrics (e.g. MASE -> -MASE) so descending = best model first.
+        # AutoGluon negates error metrics (e.g. mean_absolute_scaled_error -> negative)
+        # so descending = best model first.
         # Sort on raw (unrounded) values so close scores cannot flip rank after rounding.
         if not leaderboard_rows:
             raise RuntimeError("Leaderboard rows are empty; no models available for ranking.")

--- a/components/training/automl/autogluon_timeseries_models_training/metadata.yaml
+++ b/components/training/automl/autogluon_timeseries_models_training/metadata.yaml
@@ -10,4 +10,4 @@ tags:
   - timeseries
   - automl
   - model-selection
-lastVerified: 2026-06-10T12:00:00Z
+lastVerified: 2026-07-08T12:00:00Z

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -28,7 +28,24 @@ def isolated_sys_modules():
         # Mock additional autogluon submodules
         _metrics = mock.MagicMock()
         _metrics.AVAILABLE_METRICS = {
-            k: mock.MagicMock() for k in ("MASE", "MSE", "WQL", "RMSSE", "MAE", "RMSE", "SQL")
+            k: mock.MagicMock()
+            for k in (
+                "mean_absolute_scaled_error",
+                "mean_squared_error",
+                "weighted_quantile_loss",
+                "root_mean_squared_scaled_error",
+                "mean_absolute_error",
+                "root_mean_squared_error",
+                "sql",
+            )
+        }
+        _metrics.METRIC_ALIASES = {
+            "mean_absolute_scaled_error": "MASE",
+            "root_mean_squared_error": "RMSE",
+            "weighted_quantile_loss": "WQL",
+            "mean_squared_error": "MSE",
+            "mean_absolute_error": "MAE",
+            "root_mean_squared_scaled_error": "RMSSE",
         }
         _metrics.__spec__ = None
         mocked_modules["autogluon.timeseries.metrics"] = _metrics
@@ -135,6 +152,8 @@ class TestTimeseriesModelsTrainingUnitTests:
 
         # Mock refit predictor
         mock_refit_predictor = mock.MagicMock()
+        # AutoGluon returns uppercase acronym keys from evaluate() regardless of the
+        # metric names passed in; the component normalizes these via _acronym_to_snake.
         mock_refit_predictor.evaluate.return_value = {"MASE": 0.5, "MSE": 1.0}
 
         mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor, mock_refit_predictor]
@@ -185,7 +204,7 @@ class TestTimeseriesModelsTrainingUnitTests:
         assert concat_frames[1] is extra_ts
 
         assert result.top_models == ["DeepAR", "TFT"]
-        assert result.eval_metric == "MASE"
+        assert result.eval_metric == "mean_absolute_scaled_error"
         assert result.predictor_path == "/tmp/workspace/timeseries_predictor"
         assert result.model_config["prediction_length"] == 24
         assert result.model_config["presets"] == "speed"
@@ -737,7 +756,7 @@ class TestTimeseriesModelsTrainingUnitTests:
             )
 
     def test_unsupported_eval_metric_raises(self, mock_artifacts):  # noqa: F811
-        """eval_metric not in AVAILABLE_METRICS raises ValueError before training."""
+        """eval_metric not in METRIC_ALIASES raises ValueError before training."""
         models_artifact, extra_train_path, html_artifact = mock_artifacts
         test_data = mock.MagicMock()
         test_data.path = "/tmp/test.csv"
@@ -758,6 +777,86 @@ class TestTimeseriesModelsTrainingUnitTests:
                 html_artifact=html_artifact,
                 component_status=_DEFAULT_COMPONENT_STATUS,
             )
+
+    def test_sql_metric_not_in_metric_aliases_raises(self, mock_artifacts):  # noqa: F811
+        """'sql' is in AVAILABLE_METRICS but not METRIC_ALIASES; passes through normalization and fails validation."""
+        models_artifact, extra_train_path, html_artifact = mock_artifacts
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+        with pytest.raises(ValueError, match="eval_metric must be one of"):
+            autogluon_timeseries_models_training.python_func(
+                target="sales",
+                id_column="item_id",
+                timestamp_column="timestamp",
+                train_data_path="/tmp/train.csv",
+                test_data=test_data,
+                top_n=1,
+                workspace_path="/tmp/workspace",
+                pipeline_name="ts-pipeline-123",
+                run_id="run-123",
+                models_artifact=models_artifact,
+                extra_train_data_path=extra_train_path,
+                eval_metric="sql",
+                html_artifact=html_artifact,
+                component_status=_DEFAULT_COMPONENT_STATUS,
+            )
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_legacy_acronym_mase_normalized_to_snake_case(
+        self,
+        mock_predictor_cls,
+        mock_ts_df_cls,
+        mock_concat,
+        mock_read_csv,
+        mock_artifacts,  # noqa: F811
+    ):
+        """MASE (old default) is silently normalized to mean_absolute_scaled_error."""
+        models_artifact, extra_train_path, html_artifact = mock_artifacts
+
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        mock_refit_predictor = mock.MagicMock()
+        # AutoGluon returns uppercase acronym keys from evaluate() regardless of the
+        # metric names passed in; the component normalizes these via _acronym_to_snake.
+        mock_refit_predictor.evaluate.return_value = {"MASE": 0.5, "MSE": 1.0}
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
+        mock_ts_df_cls.from_data_frame.return_value = _mock_ts_df()
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = _mock_ts_df()
+        mock_concat.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        result = autogluon_timeseries_models_training.python_func(
+            target="sales",
+            id_column="item_id",
+            timestamp_column="timestamp",
+            train_data_path="/tmp/train.csv",
+            test_data=test_data,
+            top_n=1,
+            workspace_path="/tmp/workspace",
+            pipeline_name="ts-pipeline-123",
+            run_id="run-123",
+            models_artifact=models_artifact,
+            extra_train_data_path=extra_train_path,
+            eval_metric="MASE",
+            html_artifact=html_artifact,
+            component_status=_DEFAULT_COMPONENT_STATUS,
+        )
+
+        assert result.eval_metric == "mean_absolute_scaled_error"
+        assert result.model_config["eval_metric"] == "mean_absolute_scaled_error"
+        assert models_artifact.metadata["context"]["model_config"]["eval_metric"] == "mean_absolute_scaled_error"
+        for call in mock_predictor_cls.call_args_list:
+            assert call.kwargs["eval_metric"] == "mean_absolute_scaled_error"
 
     @mock.patch("pandas.read_csv")
     @mock.patch("pandas.concat")
@@ -780,6 +879,8 @@ class TestTimeseriesModelsTrainingUnitTests:
         mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
 
         mock_refit_predictor = mock.MagicMock()
+        # AutoGluon returns uppercase acronym keys from evaluate() regardless of the
+        # metric names passed in; the component normalizes these via _acronym_to_snake.
         mock_refit_predictor.evaluate.return_value = {"WQL": 0.3, "MASE": 0.5}
 
         mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
@@ -810,11 +911,11 @@ class TestTimeseriesModelsTrainingUnitTests:
         )
 
         for call in mock_predictor_cls.call_args_list:
-            assert call.kwargs["eval_metric"] == "WQL"
+            assert call.kwargs["eval_metric"] == "weighted_quantile_loss"
 
-        assert result.eval_metric == "WQL"
-        assert result.model_config["eval_metric"] == "WQL"
-        assert models_artifact.metadata["context"]["model_config"]["eval_metric"] == "WQL"
+        assert result.eval_metric == "weighted_quantile_loss"
+        assert result.model_config["eval_metric"] == "weighted_quantile_loss"
+        assert models_artifact.metadata["context"]["model_config"]["eval_metric"] == "weighted_quantile_loss"
 
 
 class TestMetricsJsonSignConvention:
@@ -844,6 +945,8 @@ class TestMetricsJsonSignConvention:
         mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
 
         mock_refit_predictor = mock.MagicMock()
+        # AutoGluon returns uppercase acronym keys from evaluate() regardless of the
+        # metric names passed in; the component normalizes these via _acronym_to_snake.
         mock_refit_predictor.evaluate.return_value = {"MASE": -0.42, "MSE": -1.0}
 
         mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
@@ -875,8 +978,8 @@ class TestMetricsJsonSignConvention:
         metrics_path = Path(models_artifact.path) / "DeepAR_FULL" / "metrics" / "metrics.json"
         with metrics_path.open(encoding="utf-8") as f:
             metrics = json.load(f)
-        assert metrics["MASE"] == -0.42
-        assert metrics["MSE"] == -1.0
+        assert metrics["mean_absolute_scaled_error"] == -0.42
+        assert metrics["mean_squared_error"] == -1.0
 
 
 class TestBackTestingArtifactFailure:
@@ -1017,7 +1120,7 @@ class TestLeaderboardPhase:
         # HTML file written to disk
         assert Path(html_artifact.path).exists()
         html_text = Path(html_artifact.path).read_text(encoding="utf-8")
-        assert "MASE" in html_text
+        assert "mean_absolute_scaled_error" in html_text
         assert "DeepAR_FULL" in html_text
 
         # best_model_name is the top-ranked model

--- a/components/training/automl/shared/back_testing.py
+++ b/components/training/automl/shared/back_testing.py
@@ -19,22 +19,34 @@ DEFAULT_NUM_VAL_WINDOWS = 3
 # This prevents multi-MB JSON files that would slow down KFP artifact rendering.
 MAX_FORECAST_POINTS_PER_WINDOW = 500
 # Point-forecast metrics computed per series; used internally for best/worst selection.
-_SERIES_POINT_METRICS = frozenset({"MAPE", "RMSE", "MAE"})
-_DEFAULT_SERIES_RANKING_METRIC = "MAPE"
+_SERIES_POINT_METRICS = frozenset({"mean_absolute_percentage_error", "root_mean_squared_error", "mean_absolute_error"})
+_DEFAULT_SERIES_RANKING_METRIC = "mean_absolute_percentage_error"
 
 # Metrics where lower values indicate better performance (AutoGluon time series defaults).
+# Includes both uppercase acronyms (AutoGluon evaluate() output) and snake_case names
+# (component-normalized keys used in series_analysis metrics).
 _LOWER_IS_BETTER = frozenset(
     {
         "MASE",
+        "mean_absolute_scaled_error",
         "MAPE",
+        "mean_absolute_percentage_error",
         "SMAPE",
+        "symmetric_mean_absolute_percentage_error",
         "MSE",
+        "mean_squared_error",
         "RMSE",
+        "root_mean_squared_error",
         "MAE",
+        "mean_absolute_error",
         "WQL",
+        "weighted_quantile_loss",
         "SQL",
+        "symmetric_quantile_loss",
         "RMSSE",
+        "root_mean_squared_scaled_error",
         "WAPE",
+        "weighted_absolute_percentage_error",
     }
 )
 
@@ -116,7 +128,8 @@ def _is_higher_better(eval_metric: str) -> bool:
     original = (eval_metric or "").strip()
     if original.startswith("-"):
         return True
-    return _normalize_metric_name(original) not in _LOWER_IS_BETTER
+    # Check raw name first (handles snake_case), then normalized uppercase (handles acronyms).
+    return original not in _LOWER_IS_BETTER and _normalize_metric_name(original) not in _LOWER_IS_BETTER
 
 
 def _mean_prediction_column(predictions: pd.DataFrame) -> str:
@@ -132,7 +145,7 @@ def _mean_prediction_column(predictions: pd.DataFrame) -> str:
         col = str(numeric_cols[0])
         logger.warning(
             "No 'mean' column found in predictions; using quantile column %r as point forecast. "
-            "Computed MAPE/RMSE/MAE may be biased.",
+            "Computed mean_absolute_percentage_error/root_mean_squared_error/mean_absolute_error may be biased.",
             col,
         )
         return col
@@ -253,7 +266,7 @@ def _forecast_data_for_item(
 def _point_errors(actual: np.ndarray, predicted: np.ndarray) -> dict[str, float | None]:
     mask = np.isfinite(actual) & np.isfinite(predicted)
     if not mask.any():
-        return {"MAPE": None, "RMSE": None, "MAE": None}
+        return {"mean_absolute_percentage_error": None, "root_mean_squared_error": None, "mean_absolute_error": None}
     actual_f = actual[mask]
     predicted_f = predicted[mask]
     mae = float(np.mean(np.abs(actual_f - predicted_f)))
@@ -264,7 +277,7 @@ def _point_errors(actual: np.ndarray, predicted: np.ndarray) -> dict[str, float 
         mape = float(np.mean(np.abs((actual_f[mape_mask] - predicted_f[mape_mask]) / actual_f[mape_mask]) * 100))
     else:
         mape = None
-    return {"MAPE": mape, "RMSE": rmse, "MAE": mae}
+    return {"mean_absolute_percentage_error": mape, "root_mean_squared_error": rmse, "mean_absolute_error": mae}
 
 
 def _compute_metrics_from_forecast_data(forecast_rows: list[dict[str, Any]]) -> dict[str, float]:
@@ -274,8 +287,8 @@ def _compute_metrics_from_forecast_data(forecast_rows: list[dict[str, Any]]) -> 
         forecast_rows: List of forecast dicts with "actual" and "predicted" keys
 
     Returns:
-        Dict of computed metrics (MAPE, RMSE, MAE) with None values filtered out
-    """
+        Dict of computed metrics (mean_absolute_percentage_error, root_mean_squared_error, mean_absolute_error) with None values filtered out
+    """  # noqa: E501
     paired = [r for r in forecast_rows if "actual" in r]
     if not paired:
         return {}
@@ -320,26 +333,25 @@ def _series_ranking_metric(eval_metric: str, series_averages: dict[Any, dict[str
         series_averages: Per-series averaged metrics (used to check availability)
 
     Returns:
-        Metric name to use for ranking (MAPE, RMSE, or MAE)
+        Metric name to use for ranking (mean_absolute_percentage_error, root_mean_squared_error, or mean_absolute_error)
 
-    Falls back through: eval_metric → MAPE → RMSE → MAE if metrics can't be computed.
-    This handles cases where MAPE fails due to zero denominators.
-    """
+    Falls back through: eval_metric → mean_absolute_percentage_error → root_mean_squared_error → mean_absolute_error
+    if metrics can't be computed. This handles cases where mean_absolute_percentage_error fails due to zero denominators.
+    """  # noqa: E501
     # Collect all available metrics across all series
     available_metrics: set[str] = set()
     for metrics in series_averages.values():
         available_metrics.update(metrics.keys())
 
-    normalized = _normalize_metric_name(eval_metric)
-    if normalized in _SERIES_POINT_METRICS and normalized in available_metrics:
-        return normalized
+    if eval_metric in _SERIES_POINT_METRICS and eval_metric in available_metrics:
+        return eval_metric
 
-    # Fallback chain: MAPE → RMSE → MAE
-    for fallback in ["MAPE", "RMSE", "MAE"]:
+    # Fallback chain: mean_absolute_percentage_error → root_mean_squared_error → mean_absolute_error
+    for fallback in ["mean_absolute_percentage_error", "root_mean_squared_error", "mean_absolute_error"]:
         if fallback in available_metrics:
             return fallback
 
-    # Last resort: return MAPE even if not available (will sort to infinity)
+    # Last resort: return mean_absolute_percentage_error even if not available (will sort to infinity)
     return _DEFAULT_SERIES_RANKING_METRIC
 
 

--- a/components/training/automl/shared/back_testing_charts.py
+++ b/components/training/automl/shared/back_testing_charts.py
@@ -26,6 +26,13 @@ def _matplotlib():
     return plt, mdates
 
 
+def _metric_display_name(metric: str) -> str:
+    """Return a short label for plot titles (abbreviates snake_case to initials)."""
+    if "_" not in metric:
+        return metric
+    return "".join(w[0] for w in metric.split("_") if w).upper()
+
+
 def _normalize_metric(metric: str) -> str:
     return (metric or "").strip().lstrip("-").upper()
 
@@ -359,7 +366,7 @@ def _draw_forecast(
 
 def render_back_testing_metrics(back_testing: dict[str, Any]) -> None:
     """Print per-window backtest scores and summary table (no plots)."""
-    eval_metric = back_testing.get("eval_metric", "MASE")
+    eval_metric = back_testing.get("eval_metric", "mean_absolute_scaled_error")
     per_window = back_testing.get("per_window_metrics") or []
     series_analysis = back_testing.get("series_analysis") or {}
     num_series = series_analysis.get("num_series_evaluated")
@@ -372,7 +379,7 @@ def render_back_testing_metrics(back_testing: dict[str, Any]) -> None:
 
 def render_back_testing_forecast_charts(back_testing: dict[str, Any]) -> None:
     """Render best/worst holdout forecast matplotlib panels."""
-    eval_metric = back_testing.get("eval_metric", "MASE")
+    eval_metric = back_testing.get("eval_metric", "mean_absolute_scaled_error")
     target = back_testing.get("target", "target")
     per_window = back_testing.get("per_window_metrics") or []
     series_analysis = back_testing.get("series_analysis") or {}
@@ -403,7 +410,8 @@ def render_back_testing_forecast_charts(back_testing: dict[str, Any]) -> None:
             axis = axes[0, index]
             window_id = window.get("window_id", index)
             metric_value = pick_window_metric(window.get("metrics") or {}, eval_metric)
-            metric_text = f"{eval_metric}={metric_value:.3g}" if metric_value is not None else eval_metric
+            metric_label = _metric_display_name(eval_metric)
+            metric_text = f"{metric_label}={metric_value:.3g}" if metric_value is not None else metric_label
             try:
                 _draw_forecast(
                     axis,

--- a/components/training/automl/shared/notebook_templates/timeseries_notebook.ipynb
+++ b/components/training/automl/shared/notebook_templates/timeseries_notebook.ipynb
@@ -206,11 +206,7 @@
    "cell_type": "markdown",
    "id": "1df774b4",
    "metadata": {},
-   "source": [
-    "### Metrics\n",
-    "\n",
-    "Metrics computed on the holdout test `TimeSeriesDataFrame` during pipeline refit (e.g. MASE, WQL). Signs may be flipped so higher is better, per AutoGluon convention."
-   ]
+   "source": "### Metrics\n\nMetrics computed on the holdout test `TimeSeriesDataFrame` during pipeline refit (e.g. mean_absolute_scaled_error, weighted_quantile_loss). Signs may be flipped so higher is better, per AutoGluon convention."
   },
   {
    "cell_type": "code",
@@ -234,12 +230,7 @@
    "cell_type": "markdown",
    "id": "6f766335",
    "metadata": {},
-   "source": [
-    "<a id=\"back-testing-metrics\"></a>\n",
-    "### Back-testing metrics\n",
-    "\n",
-    "Rolling validation scores from ``metrics/back_testing.json`` (AutoGluon-style ``Cutoff …: MASE = …`` lines, per-window table, and overall mean). Scores are positive error values; AutoGluon ``evaluate()`` negates them interactively."
-   ]
+   "source": "### Back-testing metrics\n\nRolling validation scores from ``metrics/back_testing.json`` (AutoGluon-style ``Cutoff …: mean_absolute_scaled_error = …`` lines, per-window table, and overall mean). Scores are positive error values; AutoGluon ``evaluate()`` negates them interactively."
   },
   {
    "cell_type": "code",

--- a/components/training/automl/shared/tests/test_back_testing.py
+++ b/components/training/automl/shared/tests/test_back_testing.py
@@ -147,8 +147,8 @@ class TestHoldoutHelpers:
             index=targets.index,
         )
         metrics = _item_window_metrics(predictions, targets, "A", "target", prediction_length=2)
-        assert "MAPE" in metrics
-        assert metrics["MAPE"] == pytest.approx(10.0)
+        assert "mean_absolute_percentage_error" in metrics
+        assert metrics["mean_absolute_percentage_error"] == pytest.approx(10.0)
 
     def test_forecast_data_includes_actual_and_predicted(self):
         """Forecast rows include actual, predicted, and optional quantile bounds."""
@@ -255,25 +255,37 @@ class TestSeriesRanking:
 
     def test_series_ranking_metric_uses_eval_metric_when_available(self):
         """Uses eval_metric when it's a point metric and available."""
-        series_averages = {"A": {"MAPE": 5.0, "RMSE": 10.0}, "B": {"MAPE": 8.0, "RMSE": 12.0}}
-        assert _series_ranking_metric("MAPE", series_averages) == "MAPE"
-        assert _series_ranking_metric("RMSE", series_averages) == "RMSE"
+        series_averages = {
+            "A": {"mean_absolute_percentage_error": 5.0, "root_mean_squared_error": 10.0},
+            "B": {"mean_absolute_percentage_error": 8.0, "root_mean_squared_error": 12.0},
+        }
+        assert (
+            _series_ranking_metric("mean_absolute_percentage_error", series_averages)
+            == "mean_absolute_percentage_error"
+        )
+        assert _series_ranking_metric("root_mean_squared_error", series_averages) == "root_mean_squared_error"
 
     def test_series_ranking_metric_falls_back_when_mape_unavailable(self):
-        """Falls back to RMSE when MAPE can't be computed (zero denominators)."""
-        # MAPE missing due to zero denominators
-        series_averages = {"A": {"RMSE": 10.0, "MAE": 5.0}, "B": {"RMSE": 12.0, "MAE": 6.0}}
-        assert _series_ranking_metric("MAPE", series_averages) == "RMSE"
+        """Falls back to root_mean_squared_error when mean_absolute_percentage_error can't be computed (zero denominators)."""  # noqa: E501
+        # mean_absolute_percentage_error missing due to zero denominators
+        series_averages = {
+            "A": {"root_mean_squared_error": 10.0, "mean_absolute_error": 5.0},
+            "B": {"root_mean_squared_error": 12.0, "mean_absolute_error": 6.0},
+        }
+        assert _series_ranking_metric("mean_absolute_percentage_error", series_averages) == "root_mean_squared_error"
 
     def test_series_ranking_metric_uses_mae_as_last_resort(self):
-        """Uses MAE when both MAPE and RMSE unavailable."""
-        series_averages = {"A": {"MAE": 5.0}, "B": {"MAE": 6.0}}
-        assert _series_ranking_metric("MAPE", series_averages) == "MAE"
+        """Uses mean_absolute_error when both mean_absolute_percentage_error and root_mean_squared_error unavailable."""
+        series_averages = {"A": {"mean_absolute_error": 5.0}, "B": {"mean_absolute_error": 6.0}}
+        assert _series_ranking_metric("mean_absolute_percentage_error", series_averages) == "mean_absolute_error"
 
     def test_series_ranking_metric_defaults_to_mape_for_non_point_metrics(self):
-        """For non-point metrics (MASE, WQL), falls back to MAPE if available."""
-        series_averages = {"A": {"MAPE": 5.0, "MASE": 0.5}, "B": {"MAPE": 8.0, "MASE": 0.7}}
-        assert _series_ranking_metric("MASE", series_averages) == "MAPE"
+        """For non-point metrics (mean_absolute_scaled_error, weighted_quantile_loss), falls back to mean_absolute_percentage_error if available."""  # noqa: E501
+        series_averages = {
+            "A": {"mean_absolute_percentage_error": 5.0},
+            "B": {"mean_absolute_percentage_error": 8.0},
+        }
+        assert _series_ranking_metric("mean_absolute_scaled_error", series_averages) == "mean_absolute_percentage_error"
 
 
 class TestSeriesAnalysis:
@@ -292,17 +304,17 @@ class TestSeriesAnalysis:
         targets = _make_panel(["A"], timestamps, [100.0, float("nan")])
         predictions = pd.DataFrame({"mean": [105.0, 180.0]}, index=targets.index)
         metrics = _item_window_metrics(predictions, targets, "A", "target", prediction_length=2)
-        # Should compute MAPE on the 1 valid point (100 → 105), not silently return {}
-        assert "MAPE" in metrics
-        assert metrics["MAPE"] == pytest.approx(5.0)
+        # Should compute mean_absolute_percentage_error on the 1 valid point (100 → 105), not silently return {}
+        assert "mean_absolute_percentage_error" in metrics
+        assert metrics["mean_absolute_percentage_error"] == pytest.approx(5.0)
 
     def test_select_best_worst_missing_value_ranks_as_worst(self):
         """A series with no metric value is ranked worst regardless of metric direction."""
         from ..back_testing import _select_best_worst
 
-        # Test with lower-is-better metric (MAPE)
-        series_averages_lower = {"A": {"MAPE": 5.0}, "B": {}}  # B has no MAPE
-        best, worst = _select_best_worst(series_averages_lower, "MAPE")
+        # Test with lower-is-better metric (mean_absolute_percentage_error)
+        series_averages_lower = {"A": {"mean_absolute_percentage_error": 5.0}, "B": {}}
+        best, worst = _select_best_worst(series_averages_lower, "mean_absolute_percentage_error")
         assert best == "A"
         assert worst == "B"
 
@@ -313,8 +325,11 @@ class TestSeriesAnalysis:
         assert worst == "B"
 
         # Missing lower-is-better metric still ranks as worst
-        series_averages_empty = {"A": {"MAPE": 5.0, "RMSE": 10.0}, "B": {"MAPE": 8.0}}
-        best, worst = _select_best_worst(series_averages_empty, "RMSE")
+        series_averages_empty = {
+            "A": {"mean_absolute_percentage_error": 5.0, "root_mean_squared_error": 10.0},
+            "B": {"mean_absolute_percentage_error": 8.0},
+        }
+        best, worst = _select_best_worst(series_averages_empty, "root_mean_squared_error")
         assert best == "A"
         assert worst == "B"
 
@@ -339,7 +354,7 @@ class TestSeriesAnalysis:
                 [window_targets],
                 target="target",
                 prediction_length=2,
-                eval_metric="MAPE",
+                eval_metric="mean_absolute_percentage_error",
             )
 
             # _forecast_data_for_item should be called exactly once per (item, window) pair
@@ -482,7 +497,7 @@ class TestBuildBackTestingJson:
             model_name="DeepAR",
             model_name_full="DeepAR_FULL",
             train_data=train_data,
-            eval_metric="RMSE",
+            eval_metric="root_mean_squared_error",
             target="target",
             id_column="item_id",
             timestamp_column="timestamp",

--- a/components/training/automl/shared/tests/test_back_testing_charts.py
+++ b/components/training/automl/shared/tests/test_back_testing_charts.py
@@ -241,7 +241,7 @@ class TestBackTestingCharts:
                     "windows": [
                         {
                             "window_id": 0,
-                            "metrics": {"MAPE": 5.0},
+                            "metrics": {"mean_absolute_percentage_error": 5.0},
                             "forecast_data": self._sample_forecast_rows(),
                         },
                     ],
@@ -285,12 +285,12 @@ class TestBackTestingCharts:
                     "windows": [
                         {
                             "window_id": 0,
-                            "metrics": {"MAPE": 5.0},
+                            "metrics": {"mean_absolute_percentage_error": 5.0},
                             "forecast_data": self._sample_forecast_rows(),
                         },
                         {
                             "window_id": 1,
-                            "metrics": {"MAPE": 6.0},
+                            "metrics": {"mean_absolute_percentage_error": 6.0},
                             "forecast_data": self._sample_forecast_rows(),
                         },
                     ],

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -39,7 +39,7 @@ to a single combined ``models_artifact``.
 | `known_covariates_names` | `List[str]` | `[]` | Column names known in advance for the forecast horizon (e.g. holidays, promotions). Defaults to ``[]`` (no known covariates). See :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`. |
 | `prediction_length` | `int` | `1` | Number of time steps to forecast (horizon length). Positive integer (default: 1). |
 | `top_n` | `int` | `3` | Number of top models to select for the leaderboard and output (default: 3). |
-| `eval_metric` | `str` | `MASE` | Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or snake_case form. Defaults to ``"MASE"``. |
+| `eval_metric` | `str` | `mean_absolute_scaled_error` | Metric for model ranking in snake_case (e.g. ``"mean_absolute_scaled_error"``, ``"weighted_quantile_loss"``) or legacy uppercase acronym form. Defaults to ``"mean_absolute_scaled_error"``. |
 | `preset` | `str` | `speed` | Training quality tier. ``"speed"`` (default, 4 vCPU / 16 GiB) or ``"balanced"`` (may run more than 2x longer, 8 vCPU / 32 GiB). |
 
 ## Metadata 🗂️
@@ -56,7 +56,7 @@ to a single combined ``models_artifact``.
   - pipeline
   - automl
   - autogluon-timeseries-training-pipeline
-- **Last Verified**: 2026-06-25 12:00:00+00:00
+- **Last Verified**: 2026-07-08 12:00:00+00:00
 - **Owners**:
   - No Parent Owners: Yes
   - Approvers:

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/metadata.yaml
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/metadata.yaml
@@ -13,4 +13,4 @@ tags:
   - pipeline
   - automl
   - autogluon-timeseries-training-pipeline
-lastVerified: 2026-06-25T12:00:00Z
+lastVerified: 2026-07-08T12:00:00Z

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
@@ -43,7 +43,7 @@ def autogluon_timeseries_training_pipeline(
     known_covariates_names: List[str] = [],
     prediction_length: int = 1,
     top_n: int = 3,
-    eval_metric: str = "MASE",
+    eval_metric: str = "mean_absolute_scaled_error",
     preset: str = "speed",
 ):
     """AutoGluon time series training pipeline.
@@ -100,8 +100,9 @@ def autogluon_timeseries_training_pipeline(
         prediction_length: Number of time steps to forecast (horizon length). Positive integer
             (default: 1).
         top_n: Number of top models to select for the leaderboard and output (default: 3).
-        eval_metric: Metric for model ranking in acronym (e.g. ``"MASE"``, ``"WQL"``) or
-            snake_case form. Defaults to ``"MASE"``.
+        eval_metric: Metric for model ranking in snake_case (e.g. ``"mean_absolute_scaled_error"``,
+            ``"weighted_quantile_loss"``) or legacy uppercase acronym form. Defaults to
+            ``"mean_absolute_scaled_error"``.
         preset: Training quality tier. ``"speed"`` (default, 4 vCPU / 16 GiB) or
             ``"balanced"`` (may run more than 2x longer, 8 vCPU / 32 GiB).
 

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
@@ -64,7 +64,7 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
         assert inputs["top_n"].default == 3
         assert inputs["known_covariates_names"].default == []
         assert inputs["preset"].default == "speed"
-        assert inputs["eval_metric"].default == "MASE"
+        assert inputs["eval_metric"].default == "mean_absolute_scaled_error"
 
     def test_compiled_pipeline_has_expected_inputs(self):
         """Test that compiled pipeline YAML contains expected pipeline input names."""


### PR DESCRIPTION
**Description of your changes:**
## Summary

- Change the default `eval_metric` for the timeseries training component and pipeline from the legacy uppercase acronym (`"MASE"`) to snake_case (`"mean_absolute_scaled_error"`), matching the naming convention already used by the tabular AutoML pipeline.
- Add backward-compatible normalization: legacy uppercase acronyms (e.g. `"MASE"`, `"WQL"`) passed by callers are automatically mapped to their snake_case equivalents via `METRIC_ALIASES` at component entry — no breaking change for existing pipelines.
- Remap metric keys in `metrics.json` from AutoGluon's internal uppercase acronym form to snake_case, so downstream consumers (leaderboard, notebooks) always see consistent snake_case keys regardless of the AutoGluon version.
- Switch `eval_metric` input validation from `AVAILABLE_METRICS` to `METRIC_ALIASES` (the snake_case → acronym mapping), which is the canonical set of supported metrics.

## Changed files

| File | Change |
|---|---|
| `autogluon_timeseries_models_training/component.py` | Import `METRIC_ALIASES`; normalize input metric; remap `metrics.json` keys; update validation and docstring |
| `autogluon_timeseries_models_training/README.md` | Update `eval_metric` default and accepted values; bump Last Verified |
| `autogluon_timeseries_models_training/metadata.yaml` | Bump `lastVerified` |
| `autogluon_timeseries_models_training/tests/test_component_unit.py` | Update mocked `AVAILABLE_METRICS`/`METRIC_ALIASES`; update all metric name assertions to snake_case |
| `autogluon_timeseries_training_pipeline/pipeline.py` | Change default `eval_metric` to `"mean_absolute_scaled_error"`; update docstring |
| `autogluon_timeseries_training_pipeline/README.md` | Update `eval_metric` description and default; bump Last Verified |
| `autogluon_timeseries_training_pipeline/metadata.yaml` | Bump `lastVerified` |
| `autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py` | Update default assertion to snake_case |

## Backward compatibility

Callers passing uppercase acronyms (`"MASE"`, `"WQL"`, etc.) continue to work — the component silently normalizes them to snake_case before any validation or use. No pipeline YAML changes are required for existing deployments.

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Changed the default time-series evaluation metric to `mean_absolute_scaled_error`.
  - Added automatic normalization for legacy uppercase metric acronyms (e.g., `MASE`) to standard snake_case.
  - Updated backtesting, ranking/selection, charts, and persisted metrics (including `metrics.json`) to consistently use normalized metric identifiers and correct leaderboard sign behavior.
- **Documentation**
  - Updated component, pipeline, and notebook guidance for snake_case metric names and legacy support.
  - Refreshed “last verified” timestamps.
- **Tests**
  - Updated/expanded unit tests to validate normalization, persistence, validation, and chart/ranking expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->