### PR TITLE
chore: Use test Red Hat index URLs in requirements files

### DIFF
--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
@@ -7,7 +7,8 @@ COPY pyproject.toml __init__.py /tmp/kfp-src/
 COPY components/ /tmp/kfp-src/components/
 COPY pipelines/ /tmp/kfp-src/pipelines/
 COPY utils/ /tmp/kfp-src/utils/
-RUN pip install --no-cache-dir setuptools==80.10.2 && \             # Using default RH index from the BASE_IMAGE
+# Using default RH index from the BASE_IMAGE
+RUN pip install --no-cache-dir setuptools==80.10.2 && \
     pip wheel --no-deps --no-build-isolation -w /tmp/dist /tmp/kfp-src/
 
 FROM ${BASE_IMAGE}

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
@@ -7,7 +7,7 @@ COPY pyproject.toml __init__.py /tmp/kfp-src/
 COPY components/ /tmp/kfp-src/components/
 COPY pipelines/ /tmp/kfp-src/pipelines/
 COPY utils/ /tmp/kfp-src/utils/
-RUN pip install --no-cache-dir --index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple setuptools==80.10.2 && \
+RUN pip install --no-cache-dir setuptools==80.10.2 && \             # Using default RH index from the BASE_IMAGE
     pip wheel --no-deps --no-build-isolation -w /tmp/dist /tmp/kfp-src/
 
 FROM ${BASE_IMAGE}

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
@@ -1,4 +1,4 @@
---index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple
+--index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9-test/simple
 
 absl-py==2.4.0
 accelerate==1.13.0
@@ -81,6 +81,7 @@ Jinja2==3.1.6
 jmespath==1.1.0
 joblib==1.5.3
 kfp==2.16.1
+kfp-kubernetes==2.16.1  # required by kfp-components (installed --no-deps)
 kfp-pipeline-spec==2.16.1
 kfp-server-api==2.16.1
 kiwisolver==1.5.0
@@ -118,7 +119,7 @@ preshed==3.0.13
 prompt-toolkit==3.0.52
 propcache==0.4.1
 proto-plus==1.28.0
-protobuf==6.33.6
+protobuf==6.31.1
 psutil==7.1.3
 ptyprocess==0.7.0
 pure-eval==0.2.3

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
@@ -81,7 +81,6 @@ Jinja2==3.1.6
 jmespath==1.1.0
 joblib==1.5.3
 kfp==2.16.1
-kfp-kubernetes==2.16.1  # required by kfp-components (installed --no-deps)
 kfp-pipeline-spec==2.16.1
 kfp-server-api==2.16.1
 kiwisolver==1.5.0
@@ -119,7 +118,7 @@ preshed==3.0.13
 prompt-toolkit==3.0.52
 propcache==0.4.1
 proto-plus==1.28.0
-protobuf==6.31.1
+protobuf==6.33.6
 psutil==7.1.3
 ptyprocess==0.7.0
 pure-eval==0.2.3

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/Containerfile
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/Containerfile
@@ -11,7 +11,7 @@ FROM ${BASE_IMAGE}
 COPY pipelines/training/autorag/documents_rag_optimization_pipeline/requirements.txt /tmp/
 
 ## TODO: Ensure build isolation
-RUN pip install --index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple --no-cache-dir -r /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Docling models for offline text extraction (RHAI modelcar images; /models/ -> docling-project--* layout).
 # Must match DOCLING_ARTIFACTS_PATH. Do not use /opt/docling-artifacts on aipcc: non-root RUN cannot mkdir there.

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/requirements.txt
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/requirements.txt
@@ -1,3 +1,5 @@
+--index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9-test/simple
+
 accelerate==1.13.0
 ai4rag==0.8.1
 aiohappyeyeballs==2.6.2

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/requirements.txt
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/requirements.txt
@@ -1,5 +1,3 @@
---index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple
-
 accelerate==1.13.0
 ai4rag==0.8.1
 aiohappyeyeballs==2.6.2


### PR DESCRIPTION


**Description of your changes:**

The index URL is already configured in the AIPCC base images, so it was explicitly removed from the Containerfiles.

The index URL in the requirements.txt files has been changed to ubi-9-test, as recommended by the AIPCC team for downstream hermetic builds.

Notebook templates retain their index URLs because they run in user environments that may lack the base image configuration.


**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated training environment package source settings to rely more consistently on the base image’s default configuration.
  * Adjusted package repository targets for training builds to use the latest approved test endpoints.
  * Simplified dependency installation steps in one optimization pipeline while keeping existing model setup unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->