### PR TITLE
fix(pipelines, AutoML, CVE): add assert on pip version

### DIFF
--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/Containerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE="quay.io/aipcc/base-images/cpu:3.5.0"
 
 ## Build stage: build a kfp-components wheel from the local source tree
 FROM ${BASE_IMAGE} AS builder
+## CVE-2026-8643: require pip >= 26.1.2 before any pip install (path traversal via wheel entry points)
+RUN python -c "import pip, sys; from packaging.version import Version; v = Version(pip.__version__); sys.exit(f'pip {v} < 26.1.2 (CVE-2026-8643)') if v < Version('26.1.2') else None"
 RUN mkdir /tmp/kfp-src /tmp/dist
 COPY pyproject.toml __init__.py /tmp/kfp-src/
 COPY components/ /tmp/kfp-src/components/
@@ -12,6 +14,9 @@ RUN pip install --no-cache-dir setuptools==80.10.2 && \
     pip wheel --no-deps --no-build-isolation -w /tmp/dist /tmp/kfp-src/
 
 FROM ${BASE_IMAGE}
+
+## CVE-2026-8643: require pip >= 26.1.2 before any pip install (path traversal via wheel entry points)
+RUN python -c "import pip, sys; from packaging.version import Version; v = Version(pip.__version__); sys.exit(f'pip {v} < 26.1.2 (CVE-2026-8643)') if v < Version('26.1.2') else None"
 
 COPY --from=builder /tmp/dist/kfp_components-*.whl /tmp/
 RUN pip install --no-cache-dir --no-deps /tmp/kfp_components-*.whl


### PR DESCRIPTION
**Description of your changes:**
The goal of the changes is to assert that the pip version on the base image has fix for CVE-2026-8643
**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security / Bug Fixes**
  * Added a build-time validation to ensure the runtime environment uses a sufficiently recent `pip` version (at least 26.1.2).
  * The build will stop if the requirement isn’t met, helping prevent using a `pip` version affected by the referenced vulnerability.
  * Improves reliability and safety of dependency installation during environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->