### PR TITLE
build(automl): upgrade autogluon to 1.5.0+rhaiv.5

### DIFF
--- a/components/training/automl/shared/notebook_templates/classification_notebook.ipynb
+++ b/components/training/automl/shared/notebook_templates/classification_notebook.ipynb
@@ -68,7 +68,7 @@
     "os.environ[\"PIP_EXTRA_INDEX_URL\"] = (\n",
     "    \"https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9-test/simple/\"\n",
     ")\n",
-    "%pip install autogluon.tabular[lightgbm,xgboost,tabm,fastai]==1.5.0+rhaiv.4 | tail -n 1"
+    "%pip install autogluon.tabular[lightgbm,xgboost,tabm,fastai]==1.5.0+rhaiv.5 | tail -n 1"
    ]
   },
   {

--- a/components/training/automl/shared/notebook_templates/regression_notebook.ipynb
+++ b/components/training/automl/shared/notebook_templates/regression_notebook.ipynb
@@ -68,7 +68,7 @@
     "    \"https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9-test/simple/\"\n",
     ")\n",
     "\n",
-    "%pip install autogluon.tabular[lightgbm,xgboost,tabm,fastai]==1.5.0+rhaiv.4 | tail -n 1"
+    "%pip install autogluon.tabular[lightgbm,xgboost,tabm,fastai]==1.5.0+rhaiv.5 | tail -n 1"
    ]
   },
   {

--- a/components/training/automl/shared/notebook_templates/timeseries_notebook.ipynb
+++ b/components/training/automl/shared/notebook_templates/timeseries_notebook.ipynb
@@ -76,7 +76,7 @@
     "    \"https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9-test/simple/\"\n",
     ")\n",
     "\n",
-    "%pip install autogluon.timeseries==1.5.0+rhaiv.4 | tail -n 1\n"
+    "%pip install autogluon.timeseries==1.5.0+rhaiv.5 | tail -n 1\n"
    ]
   },
   {
@@ -206,7 +206,11 @@
    "cell_type": "markdown",
    "id": "1df774b4",
    "metadata": {},
-   "source": "### Metrics\n\nMetrics computed on the holdout test `TimeSeriesDataFrame` during pipeline refit (e.g. mean_absolute_scaled_error, weighted_quantile_loss). Signs may be flipped so higher is better, per AutoGluon convention."
+   "source": [
+    "### Metrics\n",
+    "\n",
+    "Metrics computed on the holdout test `TimeSeriesDataFrame` during pipeline refit (e.g. mean_absolute_scaled_error, weighted_quantile_loss). Signs may be flipped so higher is better, per AutoGluon convention."
+   ]
   },
   {
    "cell_type": "code",
@@ -230,7 +234,11 @@
    "cell_type": "markdown",
    "id": "6f766335",
    "metadata": {},
-   "source": "### Back-testing metrics\n\nRolling validation scores from ``metrics/back_testing.json`` (AutoGluon-style ``Cutoff …: mean_absolute_scaled_error = …`` lines, per-window table, and overall mean). Scores are positive error values; AutoGluon ``evaluate()`` negates them interactively."
+   "source": [
+    "### Back-testing metrics\n",
+    "\n",
+    "Rolling validation scores from ``metrics/back_testing.json`` (AutoGluon-style ``Cutoff …: mean_absolute_scaled_error = …`` lines, per-window table, and overall mean). Scores are positive error values; AutoGluon ``evaluate()`` negates them interactively."
+   ]
   },
   {
    "cell_type": "code",

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.in
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.in
@@ -1,7 +1,7 @@
 --index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9-test/simple
 
-autogluon.tabular[lightgbm,xgboost,tabm,fastai]==1.5.0+rhaiv.4
-autogluon.timeseries==1.5.0+rhaiv.4
+autogluon.tabular[lightgbm,xgboost,tabm,fastai]==1.5.0+rhaiv.5
+autogluon.timeseries==1.5.0+rhaiv.5
 boto3
 pandas==2.2.3
 ipython

--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
@@ -55,30 +55,30 @@ asttokens==3.0.2 \
 attrs==26.1.0 \
     --hash=sha256:72a7cd6c5cd0ba459eec87d0cff40ba06839196b8355a01450ea1db9f6ab6a3d
     # via aiohttp
-autogluon-common==1.5.0+rhaiv.4 \
-    --hash=sha256:05061d70230b005d29980aeaf98303430b3ae1705b56313c60d942063df16001
+autogluon-common==1.5.0+rhaiv.5 \
+    --hash=sha256:479d0a9367d2c5c6e4dc0e66a94734d65e806988b362a32ac7f5c76fa1552f18
     # via
     #   autogluon-core
     #   autogluon-features
     #   autogluon-timeseries
-autogluon-core==1.5.0+rhaiv.4 \
-    --hash=sha256:6803d49d894b62d89f3d5fb622de2eadbedbd0a13b90ca720de7a48494ee5c9e
+autogluon-core==1.5.0+rhaiv.5 \
+    --hash=sha256:59d70751efeb384b113a92bcf01a6a48eb98306a8e893ec4cd5e9751920897c9
     # via
     #   autogluon-tabular
     #   autogluon-timeseries
-autogluon-features==1.5.0+rhaiv.4 \
-    --hash=sha256:c57c76765980d2e440256dc533dce7688f18aa26d318c79f3da5985e48980809
+autogluon-features==1.5.0+rhaiv.5 \
+    --hash=sha256:1568faee500c2d7ba2dcdc68f6e12932a39d811d71546f9f1206f8a751b255fc
     # via
     #   autogluon-tabular
     #   autogluon-timeseries
-autogluon-tabular[fastai,lightgbm,tabm,xgboost]==1.5.0+rhaiv.4 \
-    --hash=sha256:6d6bd81a9bbd0c4e072a31a61e89889c5dc3bbc5083018ab58fefeacedbef476
+autogluon-tabular[fastai,lightgbm,tabm,xgboost]==1.5.0+rhaiv.5 \
+    --hash=sha256:dbfe5e5f0a59fe969f6da2d68958b0f748260dd2c23764428bf107e524292fe9
     # via
     #   -r requirements.in
     #   autogluon-tabular
     #   autogluon-timeseries
-autogluon-timeseries==1.5.0+rhaiv.4 \
-    --hash=sha256:60085f6af0f94e515bacdf6aed7fbe815b65e8c2fcaaf0dcce87bde64adb9895
+autogluon-timeseries==1.5.0+rhaiv.5 \
+    --hash=sha256:fd454bde4ebe575481a814cb199e15df838821b4a0f3e9627f367b9dcedb525f
     # via -r requirements.in
 beartype==0.22.9 \
     --hash=sha256:7e0e03f04547689224dd1fb5471f9f0080426e8227b34a6d7d1eefd4c190a6a6
@@ -92,14 +92,14 @@ blis==1.3.3 \
     --hash=sha256:80c8d5f0e51831694734105d9a047193aebf7918c05c865923abe52b56785910 \
     --hash=sha256:c1ae9d426e7345eb936fda81639a7dddcaaf479bffc948da7c0c4018fe18103b
     # via thinc
-boto3==1.43.49 \
-    --hash=sha256:05dcd8fd1dc5291702dfc335c25824c5ea7294ad1f8d16d1128378307242a431
+boto3==1.43.50 \
+    --hash=sha256:00c080260af44da1faaed39ed97e3d37762e9414426eed89cc9137e7e8ae96a9
     # via
     #   -r requirements.in
     #   autogluon-common
     #   autogluon-core
-botocore==1.43.49 \
-    --hash=sha256:f65e2e5df3298a444b99f348ab3f39de98253f02a042ccf3ae7c602f6fc216d2
+botocore==1.43.50 \
+    --hash=sha256:a202e00c75172a292d6cd3f5d217b7c27333c496ef854ead607ea6b3d7b6bb2d
     # via
     #   boto3
     #   s3transfer
@@ -210,10 +210,11 @@ executing==2.2.1 \
 fastai==2.8.7 \
     --hash=sha256:807e2f12314d88cf73e04bd5aa56b09b3894de1ceadfd0147dd06d27d082bbb5
     # via autogluon-tabular
-fastcore==2.1.0 \
-    --hash=sha256:33427ae92966f59d25af2a8537ee9a0c3fcf943ee110588ac5182516c7f5447e
+fastcore==1.14.5 \
+    --hash=sha256:ab8c11e4104cec183f8909c5bdf6feeb1571c624bb0f894109107db291d64be8
     # via
     #   apswutils
+    #   autogluon-tabular
     #   fastai
     #   fastdownload
     #   fastlite
@@ -234,8 +235,8 @@ fastprogress==1.1.6 \
 fasttransform==0.0.2 \
     --hash=sha256:84a8ea9d5e91f85b0e3d6f03f864dbdf02d6706c073a5034f7bf541e69e93e80
     # via fastai
-filelock==3.29.7 \
-    --hash=sha256:23543cc34a61918869874773bcc0340e77a3b5281205c84340214d541d9d106e
+filelock==3.30.2 \
+    --hash=sha256:3876bce9fb39cd4dc9dc025336708416b2159bd96c5b4ca2d77dd14c9c7600ba
     # via
     #   huggingface-hub
     #   torch
@@ -267,8 +268,8 @@ fugue==0.9.7 \
 gluonts==0.16.3 \
     --hash=sha256:98d72abffe165f7501114e5ff6be009e3adc56708af4ef087229b052e96c2a0d
     # via autogluon-timeseries
-google-api-core==2.31.0 \
-    --hash=sha256:2975c76ecb910406ff6f71c62ed09848d0db421b27986413c448cb8766fc827e
+google-api-core==2.32.0 \
+    --hash=sha256:3e21a1d0f5bb3cc135e11f816a83f22bc77f6fecb32d8bc0474e1cecfd923e3d
     # via
     #   google-cloud-core
     #   google-cloud-storage
@@ -315,11 +316,11 @@ h11==0.16.0 \
     #   httpcore
     #   httpcore2
     #   uvicorn
-hf-xet==1.5.1 \
-    --hash=sha256:1c81a2bf52de7fce806473afeae8822ebabbb806cc45d6e7df906a8ebf25fcbc \
-    --hash=sha256:236938f6e7b607bba83e3c69f706a88c04ac98ae40185b7993d2252c27c31512 \
-    --hash=sha256:5072f2dcc3fb7d66700b2b14af25f534623b2b71166f4a6566dac091da387936 \
-    --hash=sha256:e0b14eda87d8109be4ca52aa5daef4897ed046ff2e558f363be65008c048149e
+hf-xet==1.5.2 \
+    --hash=sha256:0b7172fa11d8bcaf9b5c6233b74ea2afead2ac2f06daf6dc6fc9997d6f7811d2 \
+    --hash=sha256:547bf863d0d837702295719ddc13cf1f5f8a7e30c1921d937ce5696148c546ad \
+    --hash=sha256:7a31f51b7d81506ad4c7b8b915fc83d241c10292c56987d322274ef3a7fa0abb \
+    --hash=sha256:87162129170863c936dfc8abb220797e5d418e3a9bba83d53a2eb3fd02a415d3
     # via huggingface-hub
 httpcore==1.0.9 \
     --hash=sha256:fc0ea63671089523efc6fe94ec49d0b10c9660460cbca6172fc972c1c5f9c0ac
@@ -732,8 +733,8 @@ python-dateutil==2.9.0.post0 \
 python-dotenv==1.2.2 \
     --hash=sha256:b380203de11ab7a5b422fa6f9f377fe1ae1e1daa8559474a0518b6ca10f7aec5
     # via uvicorn
-python-fasthtml==0.14.6 \
-    --hash=sha256:cf2085f7606ae5f1db4fd43a463218839b99b9f4f65c817f2c38d86a915095d9
+python-fasthtml==0.14.5 \
+    --hash=sha256:94a8a5642b8cf17eb21d71990cfd33fe354ae60849773793fbe493dfc0734fc3
     # via fastprogress
 python-multipart==0.0.32 \
     --hash=sha256:61e4a190f7cd947a7aebc96a97976e628210851d66f7a25a6ddc3dab2305e6b4
@@ -990,8 +991,8 @@ traitlets==5.15.1 \
     # via
     #   ipython
     #   matplotlib-inline
-transformers[sentencepiece]==5.14.0 \
-    --hash=sha256:4c41d78778e174bc4b46fa0578d975393c9df13d0e583aedab267202074542f5
+transformers[sentencepiece]==5.14.1 \
+    --hash=sha256:3e917182ca1be0140cac8411afb52e0df0999e106c4eea2e81a052b6b5015a8d
     # via
     #   autogluon-timeseries
     #   chronos-forecasting


### PR DESCRIPTION
**Description of your changes:**
 
 - Bump AutoGluon packages (autogluon.tabular, autogluon.timeseries, and all transitive autogluon-* subpackages) from 1.5.0+rhaiv.4 to 1.5.0+rhaiv.5
  - Update notebook templates (classification, regression, time-series) to install the new version
  - Regenerate `requirements.txt` lockfile for the tabular training pipeline (includes hash updates for autogluon packages and minor transitive bumps: boto3, fastcore, filelock, google-api-core, hf-xet, transformers, etc.)
  - Fix minor notebook formatting: split long markdown cells into arrays and add trailing newline in timeseries_notebook.ipynb

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-78137

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [x] `metadata.yaml` includes fresh `lastVerified` timestamp
- [x] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [x] OWNERS file lists appropriate maintainers
- [x] README provides clear documentation with usage examples
- [x] Component follows `snake_case` naming convention
- [x] No security vulnerabilities in dependencies
- [x] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated AutoGluon tabular and time-series training notebooks to use the latest `rhaiv.5` builds.
  * Refreshed the training environment’s pinned package versions and integrity hashes.
  * Improved formatting for time-series notebook metrics sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->