### PR TITLE
fix(automl): skip runtime kfp install on AutoML image

### DIFF
--- a/components/data_processing/automl/tabular_data_loader/component.py
+++ b/components/data_processing/automl/tabular_data_loader/component.py
@@ -6,6 +6,7 @@ from kfp_components.utils.consts import AUTOML_IMAGE  # pyright: ignore[reportMi
 
 @dsl.component(
     base_image=AUTOML_IMAGE,  # noqa: E501
+    install_kfp_package=False,
 )
 def automl_data_loader(  # noqa: D417
     file_key: str,

--- a/components/data_processing/automl/timeseries_data_loader/component.py
+++ b/components/data_processing/automl/timeseries_data_loader/component.py
@@ -6,6 +6,7 @@ from kfp_components.utils.consts import AUTOML_IMAGE  # pyright: ignore[reportMi
 
 @dsl.component(
     base_image=AUTOML_IMAGE,  # noqa: E501
+    install_kfp_package=False,
 )
 def timeseries_data_loader(
     file_key: str,

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -6,6 +6,7 @@ from kfp_components.utils.consts import AUTOML_IMAGE  # pyright: ignore[reportMi
 
 @dsl.component(
     base_image=AUTOML_IMAGE,  # noqa: E501
+    install_kfp_package=False,
 )
 def autogluon_models_training(
     label_column: str,

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -6,6 +6,7 @@ from kfp_components.utils.consts import AUTOML_IMAGE  # pyright: ignore[reportMi
 
 @dsl.component(
     base_image=AUTOML_IMAGE,  # noqa: E501
+    install_kfp_package=False,
 )
 def autogluon_timeseries_models_training(
     target: str,

--- a/components/training/automl/component_stage_map_publisher/component.py
+++ b/components/training/automl/component_stage_map_publisher/component.py
@@ -10,6 +10,7 @@ from kfp_components.utils.consts import AUTOML_IMAGE  # pyright: ignore[reportMi
 
 @dsl.component(
     base_image=AUTOML_IMAGE,
+    install_kfp_package=False,
 )
 def publish_component_stage_map(
     pipeline_id: str,


### PR DESCRIPTION
**Description of your changes:**
Avoid Permission denied when pip tries to overwrite kfp in the non-writable /opt/app-root site-packages; use the baked-in SDK instead.

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-79011

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pipeline components to avoid installing the KFP package at runtime.
  * Preserved existing data loading, model training, validation, outputs, and publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->