### PR TITLE
feat(automl): Add inference block (input_data_schema + sample_payload) to model.json 

### DIFF
--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -10,8 +10,7 @@ Expects pre-cleaned CSV data from the tabular data loader (infinite values repla
 
 This component combines the model selection and full-refit stages into a single step. It trains a TabularPredictor on sampled data, ranks all models on the test set, then refits each of the top N models on the full training data in a single ``refit_full`` call. Post-refit work (predict, evaluate,
 feature importance, confusion matrix (via evaluate_predictions detailed_report), classification curves, notebook generation) runs concurrently across all top-N models via ``ThreadPoolExecutor``. The deployment clone (``set_model_best`` + ``clone_for_deployment``) is serialized afterward because it
-mutates predictor state. All artifacts are written under a single output artifact so the pipeline does not require a ParallelFor loop. Each model directory contains a ``model.json`` file with model metadata (name, location, metrics,
-and an optional ``inference`` block for KServe scoring payloads).
+mutates predictor state. All artifacts are written under a single output artifact so the pipeline does not require a ParallelFor loop. Each model directory contains a ``model.json`` file with model metadata (name, location, metrics).
 
 ## Inputs 📥
 
@@ -247,6 +246,7 @@ Each entry in **`context.models`** contains:
 | `name` | `str` | Model name with `_FULL` suffix (e.g. `"LightGBM_BAG_L1_FULL"`). |
 | `location` | `dict` | Paths relative to `models_artifact.path`: `model_directory`, `predictor`, `notebook`, `metrics`. |
 | `metrics` | `dict` | `test_data` — evaluation results dict from `evaluate_predictions` (metric names → values). |
+| `inference` | `dict` (optional) | Same `input_data_schema` + `sample_payload` object as in that model’s `model.json`. Omitted when feature metadata cannot be read. |
 
 Example:
 
@@ -272,6 +272,20 @@ Example:
         },
         "metrics": {
           "test_data": {"root_mean_squared_error": 0.42, "r2": 0.85}
+        },
+        "inference": {
+          "input_data_schema": {
+            "protocol": "v1_json",
+            "instances": {
+              "required": true,
+              "fields": [
+                {"name": "bedrooms", "datatype": "integer", "shape": [-1], "role": "feature", "required": true}
+              ]
+            }
+          },
+          "sample_payload": {
+            "instances": [{"bedrooms": ["<integer>"]}]
+          }
         }
       },
       {

--- a/components/training/automl/autogluon_models_training/README.md
+++ b/components/training/automl/autogluon_models_training/README.md
@@ -10,7 +10,8 @@ Expects pre-cleaned CSV data from the tabular data loader (infinite values repla
 
 This component combines the model selection and full-refit stages into a single step. It trains a TabularPredictor on sampled data, ranks all models on the test set, then refits each of the top N models on the full training data in a single ``refit_full`` call. Post-refit work (predict, evaluate,
 feature importance, confusion matrix (via evaluate_predictions detailed_report), classification curves, notebook generation) runs concurrently across all top-N models via ``ThreadPoolExecutor``. The deployment clone (``set_model_best`` + ``clone_for_deployment``) is serialized afterward because it
-mutates predictor state. All artifacts are written under a single output artifact so the pipeline does not require a ParallelFor loop. Each model directory contains a ``model.json`` file with model metadata (name, location, metrics).
+mutates predictor state. All artifacts are written under a single output artifact so the pipeline does not require a ParallelFor loop. Each model directory contains a ``model.json`` file with model metadata (name, location, metrics,
+and an optional ``inference`` block for KServe scoring payloads).
 
 ## Inputs 📥
 
@@ -152,7 +153,7 @@ One `<ModelName>_FULL/` directory is created for each of the top N selected mode
 
 ### `model.json`
 
-Each model directory contains a `model.json` file with the model's metadata, matching the corresponding entry in `context.models`:
+Each model directory contains a `model.json` file with the model's metadata, matching the corresponding entry in `context.models`. When predictor feature metadata is available, an ``inference`` block is also written so consumers can build KServe AutoGluon ``:predict`` bodies without loading AutoGluon:
 
 ```json
 {
@@ -165,11 +166,60 @@ Each model directory contains a `model.json` file with the model's metadata, mat
   },
   "metrics": {
     "test_data": {"root_mean_squared_error": 0.42, "r2": 0.85}
+  },
+  "inference": {
+    "input_data_schema": {
+      "protocol": "v1_json",
+      "instances": {
+        "required": true,
+        "fields": [
+          {"name": "bedrooms", "datatype": "integer", "shape": [-1], "role": "feature", "required": true},
+          {"name": "sqft", "datatype": "number", "shape": [-1], "role": "feature", "required": true},
+          {"name": "location", "datatype": "string", "shape": [-1], "role": "feature", "required": true}
+        ]
+      }
+    },
+    "sample_payload": {
+      "instances": [
+        {
+          "bedrooms": ["<integer>"],
+          "sqft": ["<number>"],
+          "location": ["<string>"]
+        }
+      ]
+    }
   }
 }
 ```
 
 This file allows downstream consumers to read model metadata directly from the filesystem without relying on artifact metadata propagation.
+
+#### `inference` block (KServe AutoGluon tabular)
+
+Aligned with the [KServe AutoGluon server](https://github.com/kserve/kserve/tree/master/python/autogluonserver) tabular path (`modelFormat: autogluon`):
+
+| Field | Meaning |
+| ----- | ------- |
+| `protocol: v1_json` | Use `POST /v1/models/{name}:predict` with a JSON body. |
+| `instances` fields | One named feature per column; values are **lists** (columnar batch), not row-wise scalars. |
+| `shape: [-1]` | **Variable batch size** for that feature’s list length. Same convention as AutoGluonServer v2 model metadata (`shape: [-1]` per feature). **Not a placeholder** — leave it as `-1`; do not replace it when scoring. |
+| `sample_payload` | Template for `:predict`. Replace `"<integer>"` / `"<number>"` / `"<string>"` / `"<boolean>"` with real values. Extend each feature list to the same length for multi-row batches. |
+
+Example real request body derived from `sample_payload`:
+
+```json
+{
+  "instances": [
+    {
+      "bedrooms": [3, 4],
+      "sqft": [1200.0, 1500.0],
+      "location": ["urban", "suburban"]
+    }
+  ]
+}
+```
+
+If feature metadata cannot be read, `inference` is omitted (training still succeeds).
 
 ### `models_artifact` metadata fields
 

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -345,6 +345,46 @@ def autogluon_models_training(
                 return confusion_matrix_res
             raise TypeError(f"Unexpected confusion_matrix type: {type(confusion_matrix_res)!r}")
 
+        _AG_TYPE_TO_DATATYPE: dict[str, str] = {
+            "bool": "boolean",
+            "boolean": "boolean",
+        }
+
+        def _ag_type_to_datatype(ag_type: str) -> str:
+            t = ag_type.lower()
+            if t in _AG_TYPE_TO_DATATYPE:
+                return _AG_TYPE_TO_DATATYPE[t]
+            if "int" in t:
+                return "integer"
+            if "float" in t:
+                return "number"
+            return "string"
+
+        def _build_tabular_inference_block(pred) -> dict[str, Any] | None:
+            try:
+                features = pred.features()
+                type_map = pred.feature_metadata.type_map_raw
+            except Exception:
+                logger.warning("Could not read predictor features/metadata; skipping inference block.")
+                return None
+
+            fields = []
+            sample_row: dict[str, list[str]] = {}
+            for feat in features:
+                dt = _ag_type_to_datatype(type_map.get(feat, "object"))
+                fields.append(
+                    {"name": feat, "datatype": dt, "shape": [-1], "role": "feature", "required": True}
+                )
+                sample_row[feat] = [f"<{dt}>"]
+
+            return {
+                "input_data_schema": {
+                    "protocol": "v1_json",
+                    "instances": {"required": True, "fields": fields},
+                },
+                "sample_payload": {"instances": [sample_row]},
+            }
+
         def _serialize_curve_array(values: Any) -> list[float]:
             return [float(v) for v in np.asarray(values).tolist()]
 
@@ -632,6 +672,7 @@ def autogluon_models_training(
         shutil.rmtree(work_path, ignore_errors=True)
 
         # Build ordered models_metadata (preserves top-N ranking order).
+        inference_block = _build_tabular_inference_block(predictor_clone)
         models_metadata = []
         for model_name_full in model_names_full:
             eval_results = eval_results_by_model[model_name_full]
@@ -647,6 +688,8 @@ def autogluon_models_training(
                     "test_data": eval_results,
                 },
             }
+            if inference_block is not None:
+                model_metadata["inference"] = inference_block
             models_metadata.append(model_metadata)
             with (Path(models_artifact.path) / model_name_full / "model.json").open("w", encoding="utf-8") as f:
                 json.dump(model_metadata, f, indent=2)

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -374,6 +374,9 @@ def autogluon_models_training(
             sample_row: dict[str, list[str]] = {}
             for feat in features:
                 dt = _ag_type_to_datatype(type_map.get(feat, "object"))
+                # shape [-1] = variable batch size for this feature's value list.
+                # Matches KServe AutoGluonServer v1 columnar instances and v2 per-feature
+                # tensor metadata (shape [batch]). Do not treat -1 as a user placeholder.
                 fields.append({"name": feat, "datatype": dt, "shape": [-1], "role": "feature", "required": True})
                 sample_row[feat] = [f"<{dt}>"]
 

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -362,8 +362,10 @@ def autogluon_models_training(
 
         def _build_tabular_inference_block(pred) -> dict[str, Any] | None:
             try:
+                # features() / feature_metadata_in describe original predict-time
+                # columns. feature_metadata is post-FE and can omit or rename them.
                 features = pred.features()
-                type_map = pred.feature_metadata.type_map_raw
+                type_map = pred.feature_metadata_in.type_map_raw
             except Exception:
                 logger.warning("Could not read predictor features/metadata; skipping inference block.")
                 return None

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -366,8 +366,8 @@ def autogluon_models_training(
                 # columns. feature_metadata is post-FE and can omit or rename them.
                 features = pred.features()
                 type_map = pred.feature_metadata_in.type_map_raw
-            except Exception:
-                logger.warning("Could not read predictor features/metadata; skipping inference block.")
+            except Exception as e:
+                logger.warning("Could not read predictor features/metadata; skipping inference block: %s", e)
                 return None
 
             fields = []

--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -372,9 +372,7 @@ def autogluon_models_training(
             sample_row: dict[str, list[str]] = {}
             for feat in features:
                 dt = _ag_type_to_datatype(type_map.get(feat, "object"))
-                fields.append(
-                    {"name": feat, "datatype": dt, "shape": [-1], "role": "feature", "required": True}
-                )
+                fields.append({"name": feat, "datatype": dt, "shape": [-1], "role": "feature", "required": True})
                 sample_row[feat] = [f"<{dt}>"]
 
             return {

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -1869,7 +1869,7 @@ class TestInferenceBlock:
         mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f1": 0.5})
         mock_predictor_clone.predict.return_value = mock.MagicMock()
         mock_predictor_clone.features.return_value = ["bedrooms", "sqft", "location"]
-        mock_predictor_clone.feature_metadata.type_map_raw = {
+        mock_predictor_clone.feature_metadata_in.type_map_raw = {
             "bedrooms": "int64",
             "sqft": "float64",
             "location": "object",
@@ -1967,7 +1967,7 @@ class TestInferenceBlock:
         mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
         mock_predictor_clone.predict.return_value = mock.MagicMock()
         mock_predictor_clone.features.return_value = ["flag", "cat_col"]
-        mock_predictor_clone.feature_metadata.type_map_raw = {"flag": "bool", "cat_col": "category"}
+        mock_predictor_clone.feature_metadata_in.type_map_raw = {"flag": "bool", "cat_col": "category"}
 
         mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame(), _mock_csv_frame()]
         workspace_path = str(tmp_path / "ws")

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -1885,23 +1885,31 @@ class TestInferenceBlock:
         mock_models_artifact.metadata = {}
 
         autogluon_models_training.python_func(
-            **_base_call_kwargs(
-                workspace_path, mock_models_artifact, mock.MagicMock(path="/tmp/test.csv"), tmp_path
-            ),
+            **_base_call_kwargs(workspace_path, mock_models_artifact, mock.MagicMock(path="/tmp/test.csv"), tmp_path),
         )
 
-        model_json = json.loads(
-            (Path(models_output_dir) / "LightGBM_BAG_L1_FULL" / "model.json").read_text()
-        )
+        model_json = json.loads((Path(models_output_dir) / "LightGBM_BAG_L1_FULL" / "model.json").read_text())
         assert "inference" in model_json
         schema = model_json["inference"]["input_data_schema"]
         assert schema["protocol"] == "v1_json"
         fields = schema["instances"]["fields"]
         assert schema["instances"]["required"] is True
         assert len(fields) == 3
-        assert fields[0] == {"name": "bedrooms", "datatype": "integer", "shape": [-1], "role": "feature", "required": True}
+        assert fields[0] == {
+            "name": "bedrooms",
+            "datatype": "integer",
+            "shape": [-1],
+            "role": "feature",
+            "required": True,
+        }
         assert fields[1] == {"name": "sqft", "datatype": "number", "shape": [-1], "role": "feature", "required": True}
-        assert fields[2] == {"name": "location", "datatype": "string", "shape": [-1], "role": "feature", "required": True}
+        assert fields[2] == {
+            "name": "location",
+            "datatype": "string",
+            "shape": [-1],
+            "role": "feature",
+            "required": True,
+        }
 
         payload = model_json["inference"]["sample_payload"]
         assert payload == {"instances": [{"bedrooms": ["<integer>"], "sqft": ["<number>"], "location": ["<string>"]}]}
@@ -1937,14 +1945,10 @@ class TestInferenceBlock:
         mock_models_artifact.metadata = {}
 
         autogluon_models_training.python_func(
-            **_base_call_kwargs(
-                workspace_path, mock_models_artifact, mock.MagicMock(path="/tmp/test.csv"), tmp_path
-            ),
+            **_base_call_kwargs(workspace_path, mock_models_artifact, mock.MagicMock(path="/tmp/test.csv"), tmp_path),
         )
 
-        model_json = json.loads(
-            (Path(models_output_dir) / "LightGBM_BAG_L1_FULL" / "model.json").read_text()
-        )
+        model_json = json.loads((Path(models_output_dir) / "LightGBM_BAG_L1_FULL" / "model.json").read_text())
         assert "inference" not in model_json
 
     @mock.patch("pandas.read_csv")
@@ -1975,14 +1979,10 @@ class TestInferenceBlock:
         mock_models_artifact.metadata = {}
 
         autogluon_models_training.python_func(
-            **_base_call_kwargs(
-                workspace_path, mock_models_artifact, mock.MagicMock(path="/tmp/test.csv"), tmp_path
-            ),
+            **_base_call_kwargs(workspace_path, mock_models_artifact, mock.MagicMock(path="/tmp/test.csv"), tmp_path),
         )
 
-        model_json = json.loads(
-            (Path(models_output_dir) / "LightGBM_BAG_L1_FULL" / "model.json").read_text()
-        )
+        model_json = json.loads((Path(models_output_dir) / "LightGBM_BAG_L1_FULL" / "model.json").read_text())
         fields = model_json["inference"]["input_data_schema"]["instances"]["fields"]
         assert fields[0]["datatype"] == "boolean"
         assert fields[1]["datatype"] == "string"

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -1850,6 +1850,144 @@ class TestAutogluonModelsTrainingUnitTests:
         assert context["best_model_name"] == "LightGBM_BAG_L1_FULL"
 
 
+class TestInferenceBlock:
+    """Verify model.json includes inference.input_data_schema and sample_payload."""
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_model_json_includes_inference_block(self, mock_predictor_class, mock_read_csv, tmp_path):
+        """Regression model.json contains inference with correct fields from feature metadata."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        mock_predictor.eval_metric = "r2"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"r2": 0.9}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f1": 0.5})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_predictor_clone.features.return_value = ["bedrooms", "sqft", "location"]
+        mock_predictor_clone.feature_metadata.type_map_raw = {
+            "bedrooms": "int64",
+            "sqft": "float64",
+            "location": "object",
+        }
+
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame(), _mock_csv_frame()]
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        autogluon_models_training.python_func(
+            **_base_call_kwargs(
+                workspace_path, mock_models_artifact, mock.MagicMock(path="/tmp/test.csv"), tmp_path
+            ),
+        )
+
+        model_json = json.loads(
+            (Path(models_output_dir) / "LightGBM_BAG_L1_FULL" / "model.json").read_text()
+        )
+        assert "inference" in model_json
+        schema = model_json["inference"]["input_data_schema"]
+        assert schema["protocol"] == "v1_json"
+        fields = schema["instances"]["fields"]
+        assert schema["instances"]["required"] is True
+        assert len(fields) == 3
+        assert fields[0] == {"name": "bedrooms", "datatype": "integer", "shape": [-1], "role": "feature", "required": True}
+        assert fields[1] == {"name": "sqft", "datatype": "number", "shape": [-1], "role": "feature", "required": True}
+        assert fields[2] == {"name": "location", "datatype": "string", "shape": [-1], "role": "feature", "required": True}
+
+        payload = model_json["inference"]["sample_payload"]
+        assert payload == {"instances": [{"bedrooms": ["<integer>"], "sqft": ["<number>"], "location": ["<string>"]}]}
+
+        # inference block also present in context["models"]
+        context_model = mock_models_artifact.metadata["context"]["models"][0]
+        assert context_model["inference"] == model_json["inference"]
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_inference_block_skipped_on_missing_metadata(self, mock_predictor_class, mock_read_csv, tmp_path):
+        """model.json omits inference when predictor metadata is unavailable."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        mock_predictor.eval_metric = "r2"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"r2": 0.9}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_predictor_clone.features.side_effect = AttributeError("no features")
+
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame(), _mock_csv_frame()]
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        autogluon_models_training.python_func(
+            **_base_call_kwargs(
+                workspace_path, mock_models_artifact, mock.MagicMock(path="/tmp/test.csv"), tmp_path
+            ),
+        )
+
+        model_json = json.loads(
+            (Path(models_output_dir) / "LightGBM_BAG_L1_FULL" / "model.json").read_text()
+        )
+        assert "inference" not in model_json
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_inference_boolean_type_mapping(self, mock_predictor_class, mock_read_csv, tmp_path):
+        """Boolean AutoGluon types map to 'boolean' schema datatype."""
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        mock_predictor.eval_metric = "r2"
+        _mock_leaderboard_top_models(mock_predictor, ["LightGBM_BAG_L1"])
+        mock_predictor_clone.evaluate_predictions.return_value = {"r2": 0.9}
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+        mock_predictor_clone.features.return_value = ["flag", "cat_col"]
+        mock_predictor_clone.feature_metadata.type_map_raw = {"flag": "bool", "cat_col": "category"}
+
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame(), _mock_csv_frame()]
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.metadata = {}
+
+        autogluon_models_training.python_func(
+            **_base_call_kwargs(
+                workspace_path, mock_models_artifact, mock.MagicMock(path="/tmp/test.csv"), tmp_path
+            ),
+        )
+
+        model_json = json.loads(
+            (Path(models_output_dir) / "LightGBM_BAG_L1_FULL" / "model.json").read_text()
+        )
+        fields = model_json["inference"]["input_data_schema"]["instances"]["fields"]
+        assert fields[0]["datatype"] == "boolean"
+        assert fields[1]["datatype"] == "string"
+
+
 class TestComponentStatusOutput:
     """Verify the component writes meaningful component_status.json content."""
 

--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -141,9 +141,9 @@ Each refitted model directory includes ``model.json``. When schema construction 
 | ----- | ------- |
 | `protocol: v1_json` | Use `POST /v1/models/{name}:predict`. |
 | `prediction_length` | Forecast horizon; size known-covariate horizon rows accordingly. |
-| `instances.fields` | History rows as **objects with scalar values** (long format): id, timestamp, target (+ history covariates when trained). |
-| `known_covariates` | Present only if the model was trained with known covariates; horizon rows with id, timestamp, and covariate columns. |
-| `sample_payload` | Template request. Replace `"<string>"` / `"<number>"` placeholders with real values. |
+| `instances.fields` | Always exactly three history fields: id, timestamp, and target (roles `id` / `timestamp` / `target`). History rows are **objects with scalar values** (long format). Known covariates are **not** included here. |
+| `known_covariates` | Present only if the model was trained with known covariates. Horizon rows with id, timestamp, and one field per covariate (`role: known_covariate`). Covariate `datatype` is inferred from training dtypes (`integer` / `number` / `boolean` / `string`). |
+| `sample_payload` | Template request. Replace placeholders such as `"<string>"`, `"<number>"`, `"<integer>"`, or `"<boolean>"` with real values (datatype-dependent for covariates). |
 
 ### Model insight artifacts (per refitted model)
 

--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -133,6 +133,18 @@ Artifact metadata display name: **Timeseries Models Training Status**.
 
 Inference notebooks are loaded from ``shared/notebook_templates/timeseries_notebook.ipynb`` at runtime (same shared package data as tabular training).
 
+### `model.json` inference block (KServe AutoGluon time series)
+
+Each refitted model directory includes ``model.json``. When schema construction succeeds, an ``inference`` block is added for the [KServe AutoGluon server](https://github.com/kserve/kserve/tree/master/python/autogluonserver) time-series path (**REST v1 JSON only**):
+
+| Field | Meaning |
+| ----- | ------- |
+| `protocol: v1_json` | Use `POST /v1/models/{name}:predict`. |
+| `prediction_length` | Forecast horizon; size known-covariate horizon rows accordingly. |
+| `instances.fields` | History rows as **objects with scalar values** (long format): id, timestamp, target (+ history covariates when trained). |
+| `known_covariates` | Present only if the model was trained with known covariates; horizon rows with id, timestamp, and covariate columns. |
+| `sample_payload` | Template request. Replace `"<string>"` / `"<number>"` placeholders with real values. |
+
 ### Model insight artifacts (per refitted model)
 
 Under each ``{model_name}_FULL/metrics/`` directory:

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -352,7 +352,11 @@ def autogluon_timeseries_models_training(
                     ]
                     sample_cov = {id_column: "<string>", timestamp_column: "<string>"}
                     for col in covariates:
-                        dt = _dtype_to_datatype(full_train_ts_df[col].dtype) if col in full_train_ts_df.columns else "string"
+                        dt = (
+                            _dtype_to_datatype(full_train_ts_df[col].dtype)
+                            if col in full_train_ts_df.columns
+                            else "string"
+                        )
                         cov_fields.append({"name": col, "datatype": dt, "role": "known_covariate", "required": True})
                         sample_cov[col] = f"<{dt}>"
                     schema["known_covariates"] = {"required": True, "fields": cov_fields}

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -314,6 +314,57 @@ def autogluon_timeseries_models_training(
                 cell["source"] = new_source
             return notebook
 
+        def _dtype_to_datatype(dtype) -> str:
+            name = str(dtype).lower()
+            if "bool" in name:
+                return "boolean"
+            if "int" in name:
+                return "integer"
+            if "float" in name:
+                return "number"
+            return "string"
+
+        def _build_timeseries_inference_block():
+            try:
+                instance_fields = [
+                    {"name": id_column, "datatype": "string", "role": "id", "required": True},
+                    {"name": timestamp_column, "datatype": "string", "role": "timestamp", "required": True},
+                    {"name": target, "datatype": "number", "role": "target", "required": True},
+                ]
+                sample_instance = {
+                    id_column: "<string>",
+                    timestamp_column: "<string>",
+                    target: "<number>",
+                }
+
+                schema = {
+                    "protocol": "v1_json",
+                    "prediction_length": prediction_length,
+                    "instances": {"required": True, "fields": instance_fields},
+                }
+                payload = {"instances": [sample_instance]}
+
+                covariates = known_covariates_names or []
+                if covariates:
+                    cov_fields = [
+                        {"name": id_column, "datatype": "string", "role": "id", "required": True},
+                        {"name": timestamp_column, "datatype": "string", "role": "timestamp", "required": True},
+                    ]
+                    sample_cov = {id_column: "<string>", timestamp_column: "<string>"}
+                    for col in covariates:
+                        dt = _dtype_to_datatype(full_train_ts_df[col].dtype) if col in full_train_ts_df.columns else "string"
+                        cov_fields.append({"name": col, "datatype": dt, "role": "known_covariate", "required": True})
+                        sample_cov[col] = f"<{dt}>"
+                    schema["known_covariates"] = {"required": True, "fields": cov_fields}
+                    payload["known_covariates"] = [sample_cov]
+
+                return {"input_data_schema": schema, "sample_payload": payload}
+            except Exception:
+                logger.warning("Could not build inference block; skipping.")
+                return None
+
+        ts_inference_block = _build_timeseries_inference_block()
+
         for model_name in top_models:
             try:
                 model_name_full = f"{model_name}_FULL"
@@ -435,6 +486,8 @@ def autogluon_timeseries_models_training(
                         "test_data": metrics_dict,
                     },
                 }
+                if ts_inference_block is not None:
+                    model_metadata["inference"] = ts_inference_block
                 with (output_path / "model.json").open("w", encoding="utf-8") as f:
                     json.dump(model_metadata, f, indent=2)
 

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -363,8 +363,8 @@ def autogluon_timeseries_models_training(
                     payload["known_covariates"] = [sample_cov]
 
                 return {"input_data_schema": schema, "sample_payload": payload}
-            except Exception:
-                logger.warning("Could not build inference block; skipping.")
+            except Exception as e:
+                logger.warning("Could not build inference block; skipping: %s", e)
                 return None
 
         ts_inference_block = _build_timeseries_inference_block()

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -1346,3 +1346,59 @@ class TestTimeseriesInferenceBlock:
         assert payload["known_covariates"] == [
             {"product_id": "<string>", "date": "<string>", "promo": "<integer>", "temperature": "<number>"}
         ]
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_inference_block_skipped_on_metadata_failure(
+        self, mock_predictor_cls, mock_ts_df_cls, mock_concat, mock_read_csv, mock_artifacts
+    ):
+        """model.json omits inference when covariate dtype lookup fails during schema build."""
+        models_artifact, extra_train_path, html_artifact = mock_artifacts
+
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        mock_refit_predictor = mock.MagicMock()
+        mock_refit_predictor.evaluate.return_value = {"MASE": 0.5}
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
+
+        full_train_ts = _mock_ts_df()
+        full_train_ts.columns = ["sales", "promo"]
+        full_train_ts.__getitem__ = mock.MagicMock(side_effect=RuntimeError("dtype lookup failed"))
+        mock_ts_df_cls.from_data_frame.return_value = _mock_ts_df()
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = full_train_ts
+        mock_concat.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        autogluon_timeseries_models_training.python_func(
+            target="sales",
+            id_column="product_id",
+            timestamp_column="date",
+            train_data_path="/tmp/train.csv",
+            test_data=test_data,
+            top_n=1,
+            workspace_path="/tmp/workspace",
+            pipeline_name="ts-pipeline-123",
+            run_id="run-123",
+            models_artifact=models_artifact,
+            extra_train_data_path=extra_train_path,
+            prediction_length=7,
+            known_covariates_names=["promo"],
+            html_artifact=html_artifact,
+            component_status=_DEFAULT_COMPONENT_STATUS,
+        )
+
+        model_json_path = Path(models_artifact.path) / "DeepAR_FULL" / "model.json"
+        assert model_json_path.exists()
+        model_json = json.loads(model_json_path.read_text())
+        assert "inference" not in model_json
+        assert model_json["name"] == "DeepAR_FULL"

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -1192,3 +1192,152 @@ class TestLeaderboardPhase:
         context = models_artifact.metadata["context"]
         assert "best_model_name" in context
         assert context["best_model_name"] == result.best_model_name
+
+
+class TestTimeseriesInferenceBlock:
+    """Verify model.json includes inference.input_data_schema and sample_payload."""
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_model_json_includes_inference_block(
+        self, mock_predictor_cls, mock_ts_df_cls, mock_concat, mock_read_csv, mock_artifacts
+    ):
+        """model.json contains inference with instances fields for id, timestamp, target."""
+        models_artifact, extra_train_path, html_artifact = mock_artifacts
+
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        mock_refit_predictor = mock.MagicMock()
+        mock_refit_predictor.evaluate.return_value = {"MASE": 0.5}
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
+
+        full_train_ts = _mock_ts_df()
+        full_train_ts.columns = ["sales"]
+        mock_ts_df_cls.from_data_frame.return_value = _mock_ts_df()
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = full_train_ts
+        mock_concat.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        autogluon_timeseries_models_training.python_func(
+            target="sales",
+            id_column="product_id",
+            timestamp_column="date",
+            train_data_path="/tmp/train.csv",
+            test_data=test_data,
+            top_n=1,
+            workspace_path="/tmp/workspace",
+            pipeline_name="ts-pipeline-123",
+            run_id="run-123",
+            models_artifact=models_artifact,
+            extra_train_data_path=extra_train_path,
+            prediction_length=7,
+            html_artifact=html_artifact,
+            component_status=_DEFAULT_COMPONENT_STATUS,
+        )
+
+        model_json_path = Path(models_artifact.path) / "DeepAR_FULL" / "model.json"
+        assert model_json_path.exists()
+        model_json = json.loads(model_json_path.read_text())
+
+        assert "inference" in model_json
+        schema = model_json["inference"]["input_data_schema"]
+        assert schema["protocol"] == "v1_json"
+        assert schema["prediction_length"] == 7
+        assert schema["instances"]["required"] is True
+
+        fields = schema["instances"]["fields"]
+        assert len(fields) == 3
+        assert fields[0] == {"name": "product_id", "datatype": "string", "role": "id", "required": True}
+        assert fields[1] == {"name": "date", "datatype": "string", "role": "timestamp", "required": True}
+        assert fields[2] == {"name": "sales", "datatype": "number", "role": "target", "required": True}
+
+        assert "known_covariates" not in schema
+
+        payload = model_json["inference"]["sample_payload"]
+        assert payload == {"instances": [{"product_id": "<string>", "date": "<string>", "sales": "<number>"}]}
+        assert "known_covariates" not in payload
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_inference_block_with_known_covariates(
+        self, mock_predictor_cls, mock_ts_df_cls, mock_concat, mock_read_csv, mock_artifacts
+    ):
+        """Inference block includes known_covariates when model has covariate columns."""
+        models_artifact, extra_train_path, html_artifact = mock_artifacts
+
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        mock_refit_predictor = mock.MagicMock()
+        mock_refit_predictor.evaluate.return_value = {"MASE": 0.5}
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
+
+        full_train_ts = _mock_ts_df()
+        full_train_ts.columns = ["sales", "promo", "temperature"]
+        promo_col = mock.MagicMock()
+        promo_col.dtype = "int64"
+        temp_col = mock.MagicMock()
+        temp_col.dtype = "float64"
+        full_train_ts.__getitem__ = lambda self, key: promo_col if key == "promo" else temp_col
+        full_train_ts.__contains__ = lambda self, key: key in ("promo", "temperature", "sales")
+        mock_ts_df_cls.from_data_frame.return_value = _mock_ts_df()
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = full_train_ts
+        mock_concat.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        autogluon_timeseries_models_training.python_func(
+            target="sales",
+            id_column="product_id",
+            timestamp_column="date",
+            train_data_path="/tmp/train.csv",
+            test_data=test_data,
+            top_n=1,
+            workspace_path="/tmp/workspace",
+            pipeline_name="ts-pipeline-123",
+            run_id="run-123",
+            models_artifact=models_artifact,
+            extra_train_data_path=extra_train_path,
+            prediction_length=7,
+            known_covariates_names=["promo", "temperature"],
+            html_artifact=html_artifact,
+            component_status=_DEFAULT_COMPONENT_STATUS,
+        )
+
+        model_json_path = Path(models_artifact.path) / "DeepAR_FULL" / "model.json"
+        model_json = json.loads(model_json_path.read_text())
+
+        schema = model_json["inference"]["input_data_schema"]
+        assert "known_covariates" in schema
+        cov = schema["known_covariates"]
+        assert cov["required"] is True
+        cov_fields = cov["fields"]
+        assert len(cov_fields) == 4
+        assert cov_fields[0] == {"name": "product_id", "datatype": "string", "role": "id", "required": True}
+        assert cov_fields[1] == {"name": "date", "datatype": "string", "role": "timestamp", "required": True}
+        assert cov_fields[2] == {"name": "promo", "datatype": "integer", "role": "known_covariate", "required": True}
+        assert cov_fields[3] == {"name": "temperature", "datatype": "number", "role": "known_covariate", "required": True}
+
+        payload = model_json["inference"]["sample_payload"]
+        assert "known_covariates" in payload
+        assert payload["known_covariates"] == [
+            {"product_id": "<string>", "date": "<string>", "promo": "<integer>", "temperature": "<number>"}
+        ]

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -1334,7 +1334,12 @@ class TestTimeseriesInferenceBlock:
         assert cov_fields[0] == {"name": "product_id", "datatype": "string", "role": "id", "required": True}
         assert cov_fields[1] == {"name": "date", "datatype": "string", "role": "timestamp", "required": True}
         assert cov_fields[2] == {"name": "promo", "datatype": "integer", "role": "known_covariate", "required": True}
-        assert cov_fields[3] == {"name": "temperature", "datatype": "number", "role": "known_covariate", "required": True}
+        assert cov_fields[3] == {
+            "name": "temperature",
+            "datatype": "number",
+            "role": "known_covariate",
+            "required": True,
+        }
 
         payload = model_json["inference"]["sample_payload"]
         assert "known_covariates" in payload


### PR DESCRIPTION
Assisted-by: Cursor

**Description of your changes:**
- Add inference block (input_data_schema + sample_payload) to model.json in both tabular and timeseries AutoML training components
- Enables consumers to build valid KServe :predict / v2 infer request bodies offline, without loading AutoGluon


Tabular (autogluon_models_training):
  - Schema derived from predictor.features() and feature_metadata.type_map_raw
  - Maps AutoGluon types to JSON schema datatypes: int* → integer, float* → number, bool → boolean, everything else → string
  - sample_payload uses one-element list placeholders per field (v1 convention)
  - Best-effort: gracefully skipped if predictor metadata is unavailable

  Timeseries (autogluon_timeseries_models_training):
  - Schema built from component params (target, id_column, timestamp_column, prediction_length)
  - known_covariates block included when model was trained with covariates; covariate datatypes inferred from training data dtypes
  - sample_payload uses bare scalar placeholders (timeseries v1 convention) 
  - Includes prediction_length in schema for sizing future covariate rows


**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `inference` metadata (input schema + sample payload) to AutoGluon tabular and time-series `model.json` artifacts.
  * Time-series schemas now include prediction length, required instance fields, and optional known covariates when available.
* **Bug Fixes**
  * `inference` metadata is omitted when required predictor feature metadata cannot be read.
* **Tests**
  * Added unit tests covering `model.json` inference serialization, datatype mappings, sample payload contents, and known covariates behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->