### PR TITLE
feat(automl): Restore predictor_metadata.json in timeseries training

### DIFF
--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -364,6 +364,21 @@ def autogluon_timeseries_models_training(
                         "and was dropped from metrics. Cannot produce a valid leaderboard entry."
                     )
 
+                # Save additional metadata about the selected model
+                predictor_metadata = {
+                    "model_name": model_name_full,
+                    "base_model": model_name,
+                    "prediction_length": prediction_length,
+                    "eval_metric": eval_metric,
+                    "target": target,
+                    "id_column": id_column,
+                    "timestamp_column": timestamp_column,
+                    "known_covariates_names": known_covariates_names or [],
+                }
+                predictor_output.mkdir(parents=True, exist_ok=True)
+                with (predictor_output / "predictor_metadata.json").open("w", encoding="utf-8") as f:
+                    json.dump(predictor_metadata, f, indent=2)
+
                 metrics_path = output_path / "metrics"
                 metrics_path.mkdir(parents=True, exist_ok=True)
                 with (metrics_path / "metrics.json").open("w", encoding="utf-8") as f:

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -1192,3 +1192,117 @@ class TestLeaderboardPhase:
         context = models_artifact.metadata["context"]
         assert "best_model_name" in context
         assert context["best_model_name"] == result.best_model_name
+
+
+class TestPredictorMetadata:
+    """Verify predictor_metadata.json is written for each refit model."""
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_predictor_metadata_json_written(
+        self, mock_predictor_cls, mock_ts_df_cls, mock_concat, mock_read_csv, mock_artifacts
+    ):
+        """predictor/predictor_metadata.json exists and captures selected-model config."""
+        models_artifact, extra_train_path, html_artifact = mock_artifacts
+
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        mock_refit_predictor = mock.MagicMock()
+        mock_refit_predictor.evaluate.return_value = {"MASE": 0.5}
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
+        mock_ts_df_cls.from_data_frame.return_value = _mock_ts_df()
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = _mock_ts_df()
+        mock_concat.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        autogluon_timeseries_models_training.python_func(
+            target="sales",
+            id_column="product_id",
+            timestamp_column="date",
+            train_data_path="/tmp/train.csv",
+            test_data=test_data,
+            top_n=1,
+            workspace_path="/tmp/workspace",
+            pipeline_name="ts-pipeline-123",
+            run_id="run-123",
+            models_artifact=models_artifact,
+            extra_train_data_path=extra_train_path,
+            prediction_length=7,
+            eval_metric="MASE",
+            html_artifact=html_artifact,
+            component_status=_DEFAULT_COMPONENT_STATUS,
+        )
+
+        metadata_path = Path(models_artifact.path) / "DeepAR_FULL" / "predictor" / "predictor_metadata.json"
+        assert metadata_path.exists()
+        metadata = json.loads(metadata_path.read_text())
+        assert metadata == {
+            "model_name": "DeepAR_FULL",
+            "base_model": "DeepAR",
+            "prediction_length": 7,
+            "eval_metric": "mean_absolute_scaled_error",
+            "target": "sales",
+            "id_column": "product_id",
+            "timestamp_column": "date",
+            "known_covariates_names": [],
+        }
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_predictor_metadata_includes_known_covariates(
+        self, mock_predictor_cls, mock_ts_df_cls, mock_concat, mock_read_csv, mock_artifacts
+    ):
+        """predictor_metadata.json records the covariate columns the model was trained with."""
+        models_artifact, extra_train_path, html_artifact = mock_artifacts
+
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        mock_refit_predictor = mock.MagicMock()
+        mock_refit_predictor.evaluate.return_value = {"MASE": 0.5}
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
+        mock_ts_df_cls.from_data_frame.return_value = _mock_ts_df()
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = _mock_ts_df()
+        mock_concat.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        autogluon_timeseries_models_training.python_func(
+            target="sales",
+            id_column="product_id",
+            timestamp_column="date",
+            train_data_path="/tmp/train.csv",
+            test_data=test_data,
+            top_n=1,
+            workspace_path="/tmp/workspace",
+            pipeline_name="ts-pipeline-123",
+            run_id="run-123",
+            models_artifact=models_artifact,
+            extra_train_data_path=extra_train_path,
+            prediction_length=7,
+            known_covariates_names=["promo", "temperature"],
+            html_artifact=html_artifact,
+            component_status=_DEFAULT_COMPONENT_STATUS,
+        )
+
+        metadata_path = Path(models_artifact.path) / "DeepAR_FULL" / "predictor" / "predictor_metadata.json"
+        metadata = json.loads(metadata_path.read_text())
+        assert metadata["known_covariates_names"] == ["promo", "temperature"]


### PR DESCRIPTION
**Description of your changes:**

Regenerate predictor_metadata.json per refit model in autogluon_timeseries_models_training; it was dropped by mistake when the standalone full_refit component was removed. Adds unit tests for the file contents and the covariate case.

Fixes [RHOAIENG-79954](https://redhat.atlassian.net/browse/RHOAIENG-79954)

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


[RHOAIENG-79954]: https://redhat.atlassian.net/browse/RHOAIENG-79954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refitted time-series models now include a `predictor_metadata.json` file with model configuration, prediction settings, data columns, evaluation metric, and known covariates.
  * Metadata is saved alongside each predictor artifact for easier inspection and reuse.

* **Tests**
  * Added coverage to verify metadata is created and contains the expected configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->