### PR TITLE
feat(automl-timeseries): add two-column dataset support with synthetic item ID

### DIFF
--- a/components/data_processing/automl/timeseries_data_loader/README.md
+++ b/components/data_processing/automl/timeseries_data_loader/README.md
@@ -14,16 +14,6 @@ The test set is written to S3 artifact, while train CSVs are written to the PVC 
 
 After cleansing, at least **100** valid records must remain; otherwise the component fails with a clear error so downstream AutoGluon training does not run on datasets too small to split reliably.
 
-### Two-column (timestamp + target) dataset support
-
-When `id_column=""` (empty string), the component operates in **two-column mode**:
-- Dataset must have exactly 2 columns: `timestamp_column` and `target`
-- A synthetic item ID column (`__synthetic_item_id`) is automatically injected with value `item_0`
-- The `effective_id_column` output returns `"__synthetic_item_id"` (used by downstream training)
-- All output CSVs include the synthetic column for AutoGluon compatibility
-
-This mode enables single-item time series forecasting without requiring users to manually add an item ID column. For datasets with 3+ columns or multi-item forecasting, provide an explicit `id_column` value.
-
 ## Inputs 📥
 
 | Parameter | Type | Default | Description |
@@ -35,19 +25,14 @@ This mode enables single-item time series forecasting without requiring users to
 | `timestamp_column` | `str` | `None` | Name of the timestamp/datetime column. |
 | `sampled_test_dataset` | `dsl.Output[dsl.Dataset]` | `None` | Output dataset artifact for the test split. |
 | `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking for this component. |
-| `id_column` | `str` | `""` | Name of the column identifying each time series. Empty string (`""`) activates two-column mode with synthetic ID injection. |
+| `id_column` | `str` | `""` | Name of the column identifying each time series (item_id). Pass an empty string ("") for single-series two-column datasets (timestamp + target only); the loader will inject a synthetic ID column (__synthetic_item_id) with value "item_0". |
 | `selection_train_size` | `float` | `0.3` | Fraction of train portion for model selection (default: 0.3). |
 
 ## Outputs 📤
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `sample_config` | `dict` | Sampling metadata (method, total_rows_loaded). |
-| `split_config` | `dict` | Split parameters (test_size, selection_train_size). |
-| `sample_rows` | `str` | JSON array of 5 sample rows from the loaded data. |
-| `models_selection_train_data_path` | `str` | Path to selection train CSV (for model selection phase). |
-| `extra_train_data_path` | `str` | Path to extra train CSV (for final refit phase). |
-| `effective_id_column` | `str` | Actual item ID column name used in output CSVs. Returns `"__synthetic_item_id"` in two-column mode, otherwise returns the input `id_column` value. |
+| Output | `NamedTuple('outputs', sample_config=dict, split_config=dict, sample_rows=str, models_selection_train_data_path=str, extra_train_data_path=str, effective_id_column=str)` | sample_config, split_config, sample_rows, models_selection_train_data_path, extra_train_data_path. |
 
 ## Usage Examples 🧪
 

--- a/components/data_processing/automl/timeseries_data_loader/README.md
+++ b/components/data_processing/automl/timeseries_data_loader/README.md
@@ -14,6 +14,16 @@ The test set is written to S3 artifact, while train CSVs are written to the PVC 
 
 After cleansing, at least **100** valid records must remain; otherwise the component fails with a clear error so downstream AutoGluon training does not run on datasets too small to split reliably.
 
+### Two-column (timestamp + target) dataset support
+
+When `id_column=""` (empty string), the component operates in **two-column mode**:
+- Dataset must have exactly 2 columns: `timestamp_column` and `target`
+- A synthetic item ID column (`__synthetic_item_id`) is automatically injected with value `item_0`
+- The `effective_id_column` output returns `"__synthetic_item_id"` (used by downstream training)
+- All output CSVs include the synthetic column for AutoGluon compatibility
+
+This mode enables single-item time series forecasting without requiring users to manually add an item ID column. For datasets with 3+ columns or multi-item forecasting, provide an explicit `id_column` value.
+
 ## Inputs 📥
 
 | Parameter | Type | Default | Description |
@@ -25,14 +35,19 @@ After cleansing, at least **100** valid records must remain; otherwise the compo
 | `timestamp_column` | `str` | `None` | Name of the timestamp/datetime column. |
 | `sampled_test_dataset` | `dsl.Output[dsl.Dataset]` | `None` | Output dataset artifact for the test split. |
 | `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking for this component. |
-| `id_column` | `str` | `""` | Name of the column identifying each time series (item_id). |
+| `id_column` | `str` | `""` | Name of the column identifying each time series. Empty string (`""`) activates two-column mode with synthetic ID injection. |
 | `selection_train_size` | `float` | `0.3` | Fraction of train portion for model selection (default: 0.3). |
 
 ## Outputs 📤
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| Output | `NamedTuple('outputs', sample_config=dict, split_config=dict, sample_rows=str, models_selection_train_data_path=str, extra_train_data_path=str, effective_id_column=str)` | sample_config, split_config, sample_rows, models_selection_train_data_path, extra_train_data_path. |
+| `sample_config` | `dict` | Sampling metadata (method, total_rows_loaded). |
+| `split_config` | `dict` | Split parameters (test_size, selection_train_size). |
+| `sample_rows` | `str` | JSON array of 5 sample rows from the loaded data. |
+| `models_selection_train_data_path` | `str` | Path to selection train CSV (for model selection phase). |
+| `extra_train_data_path` | `str` | Path to extra train CSV (for final refit phase). |
+| `effective_id_column` | `str` | Actual item ID column name used in output CSVs. Returns `"__synthetic_item_id"` in two-column mode, otherwise returns the input `id_column` value. |
 
 ## Usage Examples 🧪
 

--- a/components/data_processing/automl/timeseries_data_loader/README.md
+++ b/components/data_processing/automl/timeseries_data_loader/README.md
@@ -22,17 +22,17 @@ After cleansing, at least **100** valid records must remain; otherwise the compo
 | `bucket_name` | `str` | `None` | S3 bucket name containing the file. |
 | `workspace_path` | `str` | `None` | PVC workspace directory where train CSVs will be written. |
 | `target` | `str` | `None` | Name of the target column to forecast. |
-| `id_column` | `str` | `None` | Name of the column identifying each time series (item_id). |
 | `timestamp_column` | `str` | `None` | Name of the timestamp/datetime column. |
 | `sampled_test_dataset` | `dsl.Output[dsl.Dataset]` | `None` | Output dataset artifact for the test split. |
 | `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking for this component. |
+| `id_column` | `str` | `""` | Name of the column identifying each time series (item_id). |
 | `selection_train_size` | `float` | `0.3` | Fraction of train portion for model selection (default: 0.3). |
 
 ## Outputs 📤
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| Output | `NamedTuple('outputs', sample_config=dict, split_config=dict, sample_rows=str, models_selection_train_data_path=str, extra_train_data_path=str)` | sample_config, split_config, sample_rows, models_selection_train_data_path, extra_train_data_path. |
+| Output | `NamedTuple('outputs', sample_config=dict, split_config=dict, sample_rows=str, models_selection_train_data_path=str, extra_train_data_path=str, effective_id_column=str)` | sample_config, split_config, sample_rows, models_selection_train_data_path, extra_train_data_path. |
 
 ## Usage Examples 🧪
 

--- a/components/data_processing/automl/timeseries_data_loader/README.md
+++ b/components/data_processing/automl/timeseries_data_loader/README.md
@@ -32,7 +32,7 @@ After cleansing, at least **100** valid records must remain; otherwise the compo
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| Output | `NamedTuple('outputs', sample_config=dict, split_config=dict, sample_rows=str, models_selection_train_data_path=str, extra_train_data_path=str, effective_id_column=str)` | sample_config, split_config, sample_rows, models_selection_train_data_path, extra_train_data_path. |
+| Output | `NamedTuple('outputs', sample_config=dict, split_config=dict, sample_rows=str, models_selection_train_data_path=str, extra_train_data_path=str, effective_id_column=str, uses_synthetic_id=bool)` | sample_config, split_config, sample_rows, models_selection_train_data_path, extra_train_data_path. |
 
 ## Usage Examples 🧪
 

--- a/components/data_processing/automl/timeseries_data_loader/component.py
+++ b/components/data_processing/automl/timeseries_data_loader/component.py
@@ -53,7 +53,9 @@ def timeseries_data_loader(
         bucket_name: S3 bucket name containing the file.
         workspace_path: PVC workspace directory where train CSVs will be written.
         target: Name of the target column to forecast.
-        id_column: Name of the column identifying each time series (item_id).
+        id_column: Name of the column identifying each time series (item_id). Pass an empty
+            string ("") for single-series two-column datasets (timestamp + target only);
+            the loader will inject a synthetic ID column (__synthetic_item_id) with value "item_0".
         timestamp_column: Name of the timestamp/datetime column.
         sampled_test_dataset: Output dataset artifact for the test split.
         component_status: Output artifact containing stage-level progress tracking for this component.
@@ -94,7 +96,9 @@ def timeseries_data_loader(
     if not isinstance(id_column, str):
         raise ValueError("id_column must be a string.")
     if id_column and not id_column.strip():
-        raise ValueError("id_column must be an empty string or a non-empty column name (whitespace-only values are not allowed).")
+        raise ValueError(
+            "id_column must be an empty string or a non-empty column name (whitespace-only values are not allowed)."
+        )
     if selection_train_size <= 0 or selection_train_size >= 1:
         raise ValueError("selection_train_size must be in a range 0 to 1.")
 

--- a/components/data_processing/automl/timeseries_data_loader/component.py
+++ b/components/data_processing/automl/timeseries_data_loader/component.py
@@ -108,12 +108,19 @@ def timeseries_data_loader(
     if file_key.startswith("/") or file_key.endswith("/") or "//" in file_key:
         raise ValueError("file_key must be a valid S3 object key and must not start/end with '/' or contain '//'.")
 
-    # Constrain workspace_path to prevent path traversal
-    if ".." in Path(workspace_path).parts:
-        raise ValueError(f"workspace_path must not contain '..' components; got {workspace_path!r}")
-    workspace_path_resolved = Path(workspace_path).resolve()
-    if not workspace_path_resolved.is_absolute():
+    # Validate workspace_path to prevent path traversal
+    workspace_path_obj = Path(workspace_path)
+    if not workspace_path_obj.is_absolute():
         raise ValueError(f"workspace_path must be an absolute path; got {workspace_path!r}")
+
+    workspace_path_resolved = workspace_path_obj.resolve()
+    try:
+        workspace_path_resolved.relative_to(workspace_path_obj)
+    except ValueError:
+        raise ValueError(
+            f"workspace_path resolves outside the trusted workspace boundary: "
+            f"{workspace_path!r} -> {workspace_path_resolved}"
+        )
 
     from kfp_components.components.training.automl.shared.component_status import ComponentStatusTracker
 
@@ -323,6 +330,17 @@ def timeseries_data_loader(
         )
         df = load_timeseries_data_truncate(bucket_name, file_key, MAX_SIZE_BYTES, PANDAS_CHUNK_SIZE)
 
+        # Reject collision with reserved synthetic-ID column (CWE-20)
+        # Check if any user-specified column uses the reserved name before we try to inject it.
+        reserved_columns = {timestamp_column, target}
+        if id_column:
+            reserved_columns.add(id_column)
+        if SYNTHETIC_ITEM_ID_COLUMN in reserved_columns:
+            raise ValueError(
+                f"Column name {SYNTHETIC_ITEM_ID_COLUMN!r} is reserved for synthetic ID injection. "
+                f"Please rename your timestamp, target, or id_column to avoid collision."
+            )
+
         uses_synthetic_id = False
         if id_column == "":
             # Two-column mode: dataset must have exactly timestamp + target columns.
@@ -337,6 +355,12 @@ def timeseries_data_loader(
                     f"When id_column is not provided, the dataset must have exactly 2 columns "
                     f"(timestamp + target), but found {len(df.columns)} columns: {list(df.columns)}. "
                     f"Provide id_column to identify the series column for datasets with more than 2 columns."
+                )
+            # Check for collision with existing columns in the dataset
+            if SYNTHETIC_ITEM_ID_COLUMN in df.columns:
+                raise ValueError(
+                    f"Dataset already contains a column named {SYNTHETIC_ITEM_ID_COLUMN!r}. "
+                    f"This name is reserved for synthetic ID injection. Please rename the existing column."
                 )
             df[SYNTHETIC_ITEM_ID_COLUMN] = SYNTHETIC_ITEM_ID_VALUE
             id_column = SYNTHETIC_ITEM_ID_COLUMN
@@ -373,8 +397,8 @@ def timeseries_data_loader(
         status.record("prepare_data", "completed", rows=n_valid)
         status.record("split_and_export", "started")
 
-        # Create workspace datasets directory
-        datasets_dir = Path(workspace_path) / "datasets"
+        # Create workspace datasets directory (use validated resolved path)
+        datasets_dir = workspace_path_resolved / "datasets"
         datasets_dir.mkdir(parents=True, exist_ok=True)
 
         # Stable ordering for downstream I/O (redundant if cleanse already sorted; kept for clarity)

--- a/components/data_processing/automl/timeseries_data_loader/component.py
+++ b/components/data_processing/automl/timeseries_data_loader/component.py
@@ -26,6 +26,7 @@ def timeseries_data_loader(
     models_selection_train_data_path=str,
     extra_train_data_path=str,
     effective_id_column=str,
+    uses_synthetic_id=bool,
 ):
     """Load and split timeseries data from S3 for AutoGluon training.
 
@@ -95,7 +96,9 @@ def timeseries_data_loader(
             raise ValueError(f"{param} must be a non-empty string.")
     if not isinstance(id_column, str):
         raise ValueError("id_column must be a string.")
-    if id_column and not id_column.strip():
+    if id_column == "":
+        pass  # Empty string is valid for two-column datasets
+    elif not id_column.strip():
         raise ValueError(
             "id_column must be an empty string or a non-empty column name (whitespace-only values are not allowed)."
         )
@@ -104,6 +107,13 @@ def timeseries_data_loader(
 
     if file_key.startswith("/") or file_key.endswith("/") or "//" in file_key:
         raise ValueError("file_key must be a valid S3 object key and must not start/end with '/' or contain '//'.")
+
+    # Constrain workspace_path to prevent path traversal
+    if ".." in Path(workspace_path).parts:
+        raise ValueError(f"workspace_path must not contain '..' components; got {workspace_path!r}")
+    workspace_path_resolved = Path(workspace_path).resolve()
+    if not workspace_path_resolved.is_absolute():
+        raise ValueError(f"workspace_path must be an absolute path; got {workspace_path!r}")
 
     from kfp_components.components.training.automl.shared.component_status import ComponentStatusTracker
 
@@ -313,6 +323,7 @@ def timeseries_data_loader(
         )
         df = load_timeseries_data_truncate(bucket_name, file_key, MAX_SIZE_BYTES, PANDAS_CHUNK_SIZE)
 
+        uses_synthetic_id = False
         if id_column == "":
             # Two-column mode: dataset must have exactly timestamp + target columns.
             required_columns = {timestamp_column, target}
@@ -329,6 +340,7 @@ def timeseries_data_loader(
                 )
             df[SYNTHETIC_ITEM_ID_COLUMN] = SYNTHETIC_ITEM_ID_VALUE
             id_column = SYNTHETIC_ITEM_ID_COLUMN
+            uses_synthetic_id = True
             logger.info(
                 "Two-column dataset detected; injected synthetic item ID column %r with value %r.",
                 SYNTHETIC_ITEM_ID_COLUMN,
@@ -480,6 +492,7 @@ def timeseries_data_loader(
             models_selection_train_data_path=str,
             extra_train_data_path=str,
             effective_id_column=str,
+            uses_synthetic_id=bool,
         )(
             sample_config=sample_config,
             split_config=split_config,
@@ -487,6 +500,7 @@ def timeseries_data_loader(
             models_selection_train_data_path=str(selection_path),
             extra_train_data_path=str(extra_path),
             effective_id_column=id_column,
+            uses_synthetic_id=uses_synthetic_id,
         )
 
 

--- a/components/data_processing/automl/timeseries_data_loader/component.py
+++ b/components/data_processing/automl/timeseries_data_loader/component.py
@@ -13,10 +13,10 @@ def timeseries_data_loader(
     bucket_name: str,
     workspace_path: str,
     target: str,
-    id_column: str,
     timestamp_column: str,
     sampled_test_dataset: dsl.Output[dsl.Dataset],
     component_status: dsl.Output[dsl.Artifact],
+    id_column: str = "",
     selection_train_size: float = 0.3,
 ) -> NamedTuple(
     "outputs",
@@ -25,6 +25,7 @@ def timeseries_data_loader(
     sample_rows=str,
     models_selection_train_data_path=str,
     extra_train_data_path=str,
+    effective_id_column=str,
 ):
     """Load and split timeseries data from S3 for AutoGluon training.
 
@@ -77,17 +78,21 @@ def timeseries_data_loader(
     PANDAS_CHUNK_SIZE = 10000  # Rows per batch for streaming read
     DEFAULT_TEST_SIZE = 0.2
 
+    SYNTHETIC_ITEM_ID_COLUMN = "__synthetic_item_id"
+    SYNTHETIC_ITEM_ID_VALUE = "item_0"
+
     # Input validation
     for param, value in (
         ("bucket_name", bucket_name),
         ("file_key", file_key),
         ("workspace_path", workspace_path),
         ("target", target),
-        ("id_column", id_column),
         ("timestamp_column", timestamp_column),
     ):
         if not isinstance(value, str) or not value.strip():
             raise ValueError(f"{param} must be a non-empty string.")
+    if not isinstance(id_column, str):
+        raise ValueError("id_column must be a string.")
     if selection_train_size <= 0 or selection_train_size >= 1:
         raise ValueError("selection_train_size must be in a range 0 to 1.")
 
@@ -302,17 +307,39 @@ def timeseries_data_loader(
         )
         df = load_timeseries_data_truncate(bucket_name, file_key, MAX_SIZE_BYTES, PANDAS_CHUNK_SIZE)
 
-        required_columns = {id_column, timestamp_column, target}
-        missing_columns = required_columns - set(df.columns)
-        if missing_columns:
-            raise ValueError(
-                f"Missing required columns in dataset: {missing_columns}. Available columns: {list(df.columns)}"
+        if not id_column.strip():
+            # Two-column mode: dataset must have exactly timestamp + target columns.
+            required_columns = {timestamp_column, target}
+            missing_columns = required_columns - set(df.columns)
+            if missing_columns:
+                raise ValueError(
+                    f"Missing required columns in dataset: {missing_columns}. Available columns: {list(df.columns)}"
+                )
+            if len(df.columns) != 2:
+                raise ValueError(
+                    f"When id_column is not provided, the dataset must have exactly 2 columns "
+                    f"(timestamp + target), but found {len(df.columns)} columns: {list(df.columns)}. "
+                    f"Provide id_column to identify the series column for datasets with more than 2 columns."
+                )
+            df[SYNTHETIC_ITEM_ID_COLUMN] = SYNTHETIC_ITEM_ID_VALUE
+            id_column = SYNTHETIC_ITEM_ID_COLUMN
+            logger.info(
+                "Two-column dataset detected; injected synthetic item ID column %r with value %r.",
+                SYNTHETIC_ITEM_ID_COLUMN,
+                SYNTHETIC_ITEM_ID_VALUE,
             )
+        else:
+            required_columns = {id_column, timestamp_column, target}
+            missing_columns = required_columns - set(df.columns)
+            if missing_columns:
+                raise ValueError(
+                    f"Missing required columns in dataset: {missing_columns}. Available columns: {list(df.columns)}"
+                )
 
         if len(df) == 0:
             raise ValueError(
                 "The loaded dataset has no data rows. Provide at least one row per time series "
-                f"with columns {sorted(required_columns)}."
+                f"with columns {sorted({id_column, timestamp_column, target})}."
             )
 
         df = _clean_timeseries_dataframe(df, id_column, timestamp_column, logger)
@@ -446,12 +473,14 @@ def timeseries_data_loader(
             sample_rows=str,
             models_selection_train_data_path=str,
             extra_train_data_path=str,
+            effective_id_column=str,
         )(
             sample_config=sample_config,
             split_config=split_config,
             sample_rows=sample_rows,
             models_selection_train_data_path=str(selection_path),
             extra_train_data_path=str(extra_path),
+            effective_id_column=id_column,
         )
 
 

--- a/components/data_processing/automl/timeseries_data_loader/component.py
+++ b/components/data_processing/automl/timeseries_data_loader/component.py
@@ -93,6 +93,8 @@ def timeseries_data_loader(
             raise ValueError(f"{param} must be a non-empty string.")
     if not isinstance(id_column, str):
         raise ValueError("id_column must be a string.")
+    if id_column and not id_column.strip():
+        raise ValueError("id_column must be an empty string or a non-empty column name (whitespace-only values are not allowed).")
     if selection_train_size <= 0 or selection_train_size >= 1:
         raise ValueError("selection_train_size must be in a range 0 to 1.")
 
@@ -307,7 +309,7 @@ def timeseries_data_loader(
         )
         df = load_timeseries_data_truncate(bucket_name, file_key, MAX_SIZE_BYTES, PANDAS_CHUNK_SIZE)
 
-        if not id_column.strip():
+        if id_column == "":
             # Two-column mode: dataset must have exactly timestamp + target columns.
             required_columns = {timestamp_column, target}
             missing_columns = required_columns - set(df.columns)

--- a/components/data_processing/automl/timeseries_data_loader/tests/mocked_pandas.py
+++ b/components/data_processing/automl/timeseries_data_loader/tests/mocked_pandas.py
@@ -249,7 +249,13 @@ class MockedDataFrame:
 
     def __setitem__(self, key, value):
         """Assign a column from a list or ``MockSeries`` (same length as frame)."""
-        idx = self._columns.index(key)
+        if key in self._columns:
+            idx = self._columns.index(key)
+        else:
+            self._columns.append(key)
+            for row in self._rows:
+                row.append(None)
+            idx = len(self._columns) - 1
         if isinstance(value, MockSeries):
             vals = value._values
         else:

--- a/components/data_processing/automl/timeseries_data_loader/tests/test_component_unit.py
+++ b/components/data_processing/automl/timeseries_data_loader/tests/test_component_unit.py
@@ -604,6 +604,23 @@ class TestTimeseriesDataLoaderUnitTests:
         assert "inf" not in all_targets
         assert len(all_targets) >= MIN_VALID_RECORDS
 
+    @mock.patch.dict(os.environ, mocked_env_variables, clear=True)
+    def test_whitespace_only_id_column_raises(self, tmp_path):
+        """Whitespace-only id_column is rejected (only empty string or real column name allowed)."""
+        csv_body = _timeseries_csv()
+        sampled_test = _make_test_artifact(tmp_path)
+        with _mock_boto3_and_pandas(get_object_return={"Body": io.BytesIO(csv_body.encode("utf-8"))}):
+            with pytest.raises(ValueError, match="whitespace-only values are not allowed"):
+                timeseries_data_loader.python_func(
+                    file_key="ts.csv",
+                    bucket_name="b",
+                    workspace_path=str(tmp_path),
+                    target="target",
+                    id_column="   ",
+                    timestamp_column="timestamp",
+                    sampled_test_dataset=sampled_test,
+                )
+
 
 class TestTimeseriesDataLoaderScenarioMatrix:
     """Scenario tests inspired by fixture-driven and ordering-invariant patterns."""

--- a/components/data_processing/automl/timeseries_data_loader/tests/test_component_unit.py
+++ b/components/data_processing/automl/timeseries_data_loader/tests/test_component_unit.py
@@ -769,6 +769,7 @@ class TestTimeseriesDataLoaderScenarioMatrix:
         """Standard three-column path returns the user-provided id_column as effective_id_column."""
         result, _ = _run_loader(tmp_path, _timeseries_csv())
         assert result.effective_id_column == "item_id"
+        assert result.uses_synthetic_id is False
 
 
 class TestTwoColumnSyntheticItemId:
@@ -780,6 +781,7 @@ class TestTwoColumnSyntheticItemId:
         result, sampled_test = _run_loader(tmp_path, _two_column_timeseries_csv(), id_column="")
 
         assert result.effective_id_column == "__synthetic_item_id"
+        assert result.uses_synthetic_id is True
 
         selection_rows = _read_csv_rows(result.models_selection_train_data_path)
         extra_rows = _read_csv_rows(result.extra_train_data_path)
@@ -846,6 +848,7 @@ class TestTwoColumnSyntheticItemId:
         result, sampled_test = _run_loader(tmp_path, _timeseries_csv(), id_column="item_id")
 
         assert result.effective_id_column == "item_id"
+        assert result.uses_synthetic_id is False
 
         selection_rows = _read_csv_rows(result.models_selection_train_data_path)
         assert "__synthetic_item_id" not in selection_rows[0]

--- a/components/data_processing/automl/timeseries_data_loader/tests/test_component_unit.py
+++ b/components/data_processing/automl/timeseries_data_loader/tests/test_component_unit.py
@@ -133,7 +133,17 @@ def _pad_timeseries_csv(csv_content: str, min_rows: int = MIN_VALID_RECORDS + 1)
     return header + "\n" + "\n".join(data) + "\n"
 
 
-def _run_loader(tmp_path, csv_body, selection_train_size=0.3):
+def _two_column_timeseries_csv(n_rows=MIN_VALID_RECORDS):
+    """Build deterministic two-column timeseries CSV (timestamp + target only)."""
+    lines = ["timestamp,target"]
+    for i in range(n_rows):
+        day = (i % 28) + 1
+        month = (i // 28) + 1
+        lines.append(f"2024-{month:02d}-{day:02d},{i}")
+    return "\n".join(lines) + "\n"
+
+
+def _run_loader(tmp_path, csv_body, selection_train_size=0.3, id_column="item_id"):
     """Execute ``python_func`` with mocked S3/pandas; return paths and ``sample_config``."""
     sampled_test = _make_test_artifact(tmp_path)
     with _mock_boto3_and_pandas(get_object_return={"Body": io.BytesIO(csv_body.encode("utf-8"))}):
@@ -142,7 +152,7 @@ def _run_loader(tmp_path, csv_body, selection_train_size=0.3):
             bucket_name="b",
             workspace_path=str(tmp_path),
             target="target",
-            id_column="item_id",
+            id_column=id_column,
             timestamp_column="timestamp",
             sampled_test_dataset=sampled_test,
             selection_train_size=selection_train_size,
@@ -736,3 +746,116 @@ class TestTimeseriesDataLoaderScenarioMatrix:
                     timestamp_column="timestamp",
                     sampled_test_dataset=sampled_test,
                 )
+
+    @mock.patch.dict(os.environ, mocked_env_variables, clear=True)
+    def test_effective_id_column_matches_input_for_standard_path(self, tmp_path):
+        """Standard three-column path returns the user-provided id_column as effective_id_column."""
+        result, _ = _run_loader(tmp_path, _timeseries_csv())
+        assert result.effective_id_column == "item_id"
+
+
+class TestTwoColumnSyntheticItemId:
+    """Tests for two-column (timestamp + target) datasets with synthetic item ID injection."""
+
+    @mock.patch.dict(os.environ, mocked_env_variables, clear=True)
+    def test_two_column_csv_injects_synthetic_item_id(self, tmp_path):
+        """Two-column CSV with empty id_column injects synthetic __synthetic_item_id column."""
+        result, sampled_test = _run_loader(tmp_path, _two_column_timeseries_csv(), id_column="")
+
+        assert result.effective_id_column == "__synthetic_item_id"
+
+        selection_rows = _read_csv_rows(result.models_selection_train_data_path)
+        extra_rows = _read_csv_rows(result.extra_train_data_path)
+        test_rows = _read_csv_rows(sampled_test.path)
+
+        assert len(selection_rows) > 0
+        assert len(extra_rows) > 0
+        assert len(test_rows) > 0
+
+        for row in selection_rows:
+            assert "__synthetic_item_id" in row
+            assert row["__synthetic_item_id"] == "item_0"
+
+    @mock.patch.dict(os.environ, mocked_env_variables, clear=True)
+    def test_two_column_split_sizes_match_single_series(self, tmp_path):
+        """Two-column dataset produces the same split sizes as a single-series three-column dataset."""
+        result, sampled_test = _run_loader(tmp_path, _two_column_timeseries_csv(), id_column="")
+
+        selection_rows = _read_csv_rows(result.models_selection_train_data_path)
+        extra_rows = _read_csv_rows(result.extra_train_data_path)
+        test_rows = _read_csv_rows(sampled_test.path)
+
+        assert len(selection_rows) == 24
+        assert len(extra_rows) == 56
+        assert len(test_rows) == 20
+
+    @mock.patch.dict(os.environ, mocked_env_variables, clear=True)
+    def test_two_column_mode_rejects_three_column_dataset(self, tmp_path):
+        """Empty id_column with 3+ columns raises ValueError."""
+        csv_body = _timeseries_csv()
+        sampled_test = _make_test_artifact(tmp_path)
+        with _mock_boto3_and_pandas(get_object_return={"Body": io.BytesIO(csv_body.encode("utf-8"))}):
+            with pytest.raises(ValueError, match="exactly 2 columns"):
+                timeseries_data_loader.python_func(
+                    file_key="ts.csv",
+                    bucket_name="b",
+                    workspace_path=str(tmp_path),
+                    target="target",
+                    id_column="",
+                    timestamp_column="timestamp",
+                    sampled_test_dataset=sampled_test,
+                )
+
+    @mock.patch.dict(os.environ, mocked_env_variables, clear=True)
+    def test_two_column_mode_rejects_missing_target(self, tmp_path):
+        """Empty id_column with two columns but wrong column names raises ValueError."""
+        csv_body = "timestamp,wrong_col\n2024-01-01,1\n"
+        sampled_test = _make_test_artifact(tmp_path)
+        with _mock_boto3_and_pandas(get_object_return={"Body": io.BytesIO(csv_body.encode("utf-8"))}):
+            with pytest.raises(ValueError, match="Missing required columns"):
+                timeseries_data_loader.python_func(
+                    file_key="ts.csv",
+                    bucket_name="b",
+                    workspace_path=str(tmp_path),
+                    target="target",
+                    id_column="",
+                    timestamp_column="timestamp",
+                    sampled_test_dataset=sampled_test,
+                )
+
+    @mock.patch.dict(os.environ, mocked_env_variables, clear=True)
+    def test_three_column_path_unchanged_with_explicit_id_column(self, tmp_path):
+        """Explicit id_column bypasses synthetic injection; effective_id_column matches input."""
+        result, sampled_test = _run_loader(tmp_path, _timeseries_csv(), id_column="item_id")
+
+        assert result.effective_id_column == "item_id"
+
+        selection_rows = _read_csv_rows(result.models_selection_train_data_path)
+        assert "__synthetic_item_id" not in selection_rows[0]
+        assert "item_id" in selection_rows[0]
+
+    @mock.patch.dict(os.environ, mocked_env_variables, clear=True)
+    def test_two_column_too_few_records_raises(self, tmp_path):
+        """Two-column dataset with fewer than 100 records after cleansing raises ValueError."""
+        csv_body = _two_column_timeseries_csv(5)
+        sampled_test = _make_test_artifact(tmp_path)
+        with _mock_boto3_and_pandas(get_object_return={"Body": io.BytesIO(csv_body.encode("utf-8"))}):
+            with pytest.raises(ValueError, match="at least 100"):
+                timeseries_data_loader.python_func(
+                    file_key="ts.csv",
+                    bucket_name="b",
+                    workspace_path=str(tmp_path),
+                    target="target",
+                    id_column="",
+                    timestamp_column="timestamp",
+                    sampled_test_dataset=sampled_test,
+                )
+
+    @mock.patch.dict(os.environ, mocked_env_variables, clear=True)
+    def test_two_column_sample_rows_excludes_synthetic_id(self, tmp_path):
+        """sample_rows JSON from two-column path contains the synthetic column (it is in the CSV)."""
+        result, _ = _run_loader(tmp_path, _two_column_timeseries_csv(), id_column="")
+        parsed = json.loads(result.sample_rows)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 5
+        assert "__synthetic_item_id" in parsed[0]

--- a/components/training/automl/autogluon_timeseries_models_training/README.md
+++ b/components/training/automl/autogluon_timeseries_models_training/README.md
@@ -28,6 +28,7 @@ Refit outputs for all selected models are written under one ``models_artifact``,
 | `extra_train_data_path` | `str` | `None` | Path to extra train split for full refit. |
 | `html_artifact` | `dsl.Output[dsl.HTML]` | `None` | Output HTML artifact containing the ranked leaderboard page. |
 | `component_status` | `dsl.Output[dsl.Artifact]` | `None` | Output artifact containing stage-level progress tracking for this component. |
+| `uses_synthetic_id` | `bool` | `False` | True if the loader injected a synthetic ID column for two-column datasets. |
 | `sample_rows` | `str` | `[]` | Sample rows JSON string used in generated notebook placeholders. |
 | `sampling_config` | `Optional[dict]` | `None` | Optional sampling config stored in artifact metadata. |
 | `split_config` | `Optional[dict]` | `None` | Optional split config stored in artifact metadata. |

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -327,11 +327,11 @@ def autogluon_timeseries_models_training(
                     return "string"
 
         SYNTHETIC_ITEM_ID_COLUMN = "__synthetic_item_id"
+        is_synthetic_id = id_column == SYNTHETIC_ITEM_ID_COLUMN
 
         def _build_timeseries_inference_block():
             try:
                 covariates = known_covariates_names or []
-                is_synthetic_id = id_column == SYNTHETIC_ITEM_ID_COLUMN
 
                 def _cov_datatype(col):
                     return (
@@ -436,7 +436,6 @@ def autogluon_timeseries_models_training(
                     )
 
                 # Save additional metadata about the selected model
-                is_synthetic_id = id_column == SYNTHETIC_ITEM_ID_COLUMN
                 predictor_metadata = {
                     "model_name": model_name_full,
                     "base_model": model_name,

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -326,25 +326,29 @@ def autogluon_timeseries_models_training(
                 case _:
                     return "string"
 
+        SYNTHETIC_ITEM_ID_COLUMN = "__synthetic_item_id"
+
         def _build_timeseries_inference_block():
             try:
                 covariates = known_covariates_names or []
+                is_synthetic_id = id_column == SYNTHETIC_ITEM_ID_COLUMN
 
                 def _cov_datatype(col):
                     return (
                         _dtype_to_datatype(full_train_ts_df[col].dtype) if col in full_train_ts_df.columns else "string"
                     )
 
-                instance_fields = [
-                    {"name": id_column, "datatype": "string", "role": "id", "required": True},
-                    {"name": timestamp_column, "datatype": "string", "role": "timestamp", "required": True},
-                    {"name": target, "datatype": "number", "role": "target", "required": True},
-                ]
-                sample_instance = {
-                    id_column: "<string>",
-                    timestamp_column: "<string>",
-                    target: "<number>",
-                }
+                instance_fields = []
+                sample_instance = {}
+                if not is_synthetic_id:
+                    instance_fields.append({"name": id_column, "datatype": "string", "role": "id", "required": True})
+                    sample_instance[id_column] = "<string>"
+                instance_fields.append(
+                    {"name": timestamp_column, "datatype": "string", "role": "timestamp", "required": True}
+                )
+                sample_instance[timestamp_column] = "<string>"
+                instance_fields.append({"name": target, "datatype": "number", "role": "target", "required": True})
+                sample_instance[target] = "<number>"
                 for col in covariates:
                     dt = _cov_datatype(col)
                     instance_fields.append({"name": col, "datatype": dt, "role": "known_covariate", "required": True})
@@ -358,11 +362,15 @@ def autogluon_timeseries_models_training(
                 payload = {"instances": [sample_instance]}
 
                 if covariates:
-                    cov_fields = [
-                        {"name": id_column, "datatype": "string", "role": "id", "required": True},
-                        {"name": timestamp_column, "datatype": "string", "role": "timestamp", "required": True},
-                    ]
-                    sample_cov = {id_column: "<string>", timestamp_column: "<string>"}
+                    cov_fields = []
+                    sample_cov = {}
+                    if not is_synthetic_id:
+                        cov_fields.append({"name": id_column, "datatype": "string", "role": "id", "required": True})
+                        sample_cov[id_column] = "<string>"
+                    cov_fields.append(
+                        {"name": timestamp_column, "datatype": "string", "role": "timestamp", "required": True}
+                    )
+                    sample_cov[timestamp_column] = "<string>"
                     for col in covariates:
                         dt = _cov_datatype(col)
                         cov_fields.append({"name": col, "datatype": dt, "role": "known_covariate", "required": True})

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -436,6 +436,7 @@ def autogluon_timeseries_models_training(
                     )
 
                 # Save additional metadata about the selected model
+                is_synthetic_id = id_column == SYNTHETIC_ITEM_ID_COLUMN
                 predictor_metadata = {
                     "model_name": model_name_full,
                     "base_model": model_name,
@@ -445,6 +446,7 @@ def autogluon_timeseries_models_training(
                     "id_column": id_column,
                     "timestamp_column": timestamp_column,
                     "known_covariates_names": known_covariates_names or [],
+                    "uses_synthetic_id": is_synthetic_id,
                 }
                 predictor_output.mkdir(parents=True, exist_ok=True)
                 with (predictor_output / "predictor_metadata.json").open("w", encoding="utf-8") as f:

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -22,6 +22,7 @@ def autogluon_timeseries_models_training(
     extra_train_data_path: str,
     html_artifact: dsl.Output[dsl.HTML],
     component_status: dsl.Output[dsl.Artifact],
+    uses_synthetic_id: bool = False,
     sample_rows: str = "[]",
     sampling_config: Optional[dict] = None,
     split_config: Optional[dict] = None,
@@ -60,12 +61,13 @@ def autogluon_timeseries_models_training(
         models_artifact: Combined output artifact containing all refitted models.
         extra_train_data_path: Path to extra train split for full refit.
         html_artifact: Output HTML artifact containing the ranked leaderboard page.
+        component_status: Output artifact containing stage-level progress tracking for this component.
+        uses_synthetic_id: True if the loader injected a synthetic ID column for two-column datasets.
         sample_rows: Sample rows JSON string used in generated notebook placeholders.
         sampling_config: Optional sampling config stored in artifact metadata.
         split_config: Optional split config stored in artifact metadata.
         prediction_length: Forecast horizon (number of timesteps).
         known_covariates_names: Optional list of known covariate column names.
-        component_status: Output artifact containing stage-level progress tracking for this component.
         preset: Training quality tier. ``"speed"`` (default) or ``"balanced"``
             (may run more than 2x longer).
         eval_metric: Metric for model ranking (e.g. ``"mean_absolute_scaled_error"``,
@@ -326,9 +328,6 @@ def autogluon_timeseries_models_training(
                 case _:
                     return "string"
 
-        SYNTHETIC_ITEM_ID_COLUMN = "__synthetic_item_id"
-        is_synthetic_id = id_column == SYNTHETIC_ITEM_ID_COLUMN
-
         def _build_timeseries_inference_block():
             try:
                 covariates = known_covariates_names or []
@@ -340,7 +339,7 @@ def autogluon_timeseries_models_training(
 
                 instance_fields = []
                 sample_instance = {}
-                if not is_synthetic_id:
+                if not uses_synthetic_id:
                     instance_fields.append({"name": id_column, "datatype": "string", "role": "id", "required": True})
                     sample_instance[id_column] = "<string>"
                 instance_fields.append(
@@ -364,7 +363,7 @@ def autogluon_timeseries_models_training(
                 if covariates:
                     cov_fields = []
                     sample_cov = {}
-                    if not is_synthetic_id:
+                    if not uses_synthetic_id:
                         cov_fields.append({"name": id_column, "datatype": "string", "role": "id", "required": True})
                         sample_cov[id_column] = "<string>"
                     cov_fields.append(
@@ -445,7 +444,7 @@ def autogluon_timeseries_models_training(
                     "id_column": id_column,
                     "timestamp_column": timestamp_column,
                     "known_covariates_names": known_covariates_names or [],
-                    "uses_synthetic_id": is_synthetic_id,
+                    "uses_synthetic_id": uses_synthetic_id,
                 }
                 predictor_output.mkdir(parents=True, exist_ok=True)
                 with (predictor_output / "predictor_metadata.json").open("w", encoding="utf-8") as f:

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -1491,6 +1491,75 @@ class TestTimeseriesInferenceBlock:
     @mock.patch("pandas.concat")
     @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
     @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_inference_block_excludes_synthetic_item_id(
+        self, mock_predictor_cls, mock_ts_df_cls, mock_concat, mock_read_csv, mock_artifacts
+    ):
+        """model.json inference block excludes __synthetic_item_id from schema and payload."""
+        models_artifact, extra_train_path, html_artifact = mock_artifacts
+
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+
+        mock_refit_predictor = mock.MagicMock()
+        mock_refit_predictor.evaluate.return_value = {"MASE": 0.5}
+
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
+
+        full_train_ts = _mock_ts_df()
+        full_train_ts.columns = ["sales"]
+        mock_ts_df_cls.from_data_frame.return_value = _mock_ts_df()
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = full_train_ts
+        mock_concat.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        autogluon_timeseries_models_training.python_func(
+            target="sales",
+            id_column="__synthetic_item_id",
+            timestamp_column="date",
+            train_data_path="/tmp/train.csv",
+            test_data=test_data,
+            top_n=1,
+            workspace_path="/tmp/workspace",
+            pipeline_name="ts-pipeline-123",
+            run_id="run-123",
+            models_artifact=models_artifact,
+            extra_train_data_path=extra_train_path,
+            prediction_length=7,
+            html_artifact=html_artifact,
+            component_status=_DEFAULT_COMPONENT_STATUS,
+        )
+
+        model_json_path = Path(models_artifact.path) / "DeepAR_FULL" / "model.json"
+        assert model_json_path.exists()
+        model_json = json.loads(model_json_path.read_text())
+
+        assert "inference" in model_json
+        schema = model_json["inference"]["input_data_schema"]
+        fields = schema["instances"]["fields"]
+        assert len(fields) == 2
+        assert fields[0] == {"name": "date", "datatype": "string", "role": "timestamp", "required": True}
+        assert fields[1] == {"name": "sales", "datatype": "number", "role": "target", "required": True}
+
+        field_names = [f["name"] for f in fields]
+        assert "__synthetic_item_id" not in field_names
+
+        payload = model_json["inference"]["sample_payload"]
+        assert payload == {"instances": [{"date": "<string>", "sales": "<number>"}]}
+        assert "__synthetic_item_id" not in payload["instances"][0]
+
+        assert "known_covariates" not in schema
+        assert "known_covariates" not in payload
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
     def test_inference_block_skipped_on_metadata_failure(
         self, mock_predictor_cls, mock_ts_df_cls, mock_concat, mock_read_csv, mock_artifacts
     ):

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -1534,6 +1534,7 @@ class TestTimeseriesInferenceBlock:
             prediction_length=7,
             html_artifact=html_artifact,
             component_status=_DEFAULT_COMPONENT_STATUS,
+            uses_synthetic_id=True,
         )
 
         model_json_path = Path(models_artifact.path) / "DeepAR_FULL" / "model.json"

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -1255,6 +1255,7 @@ class TestPredictorMetadata:
             "id_column": "product_id",
             "timestamp_column": "date",
             "known_covariates_names": [],
+            "uses_synthetic_id": False,
         }
 
     @mock.patch("pandas.read_csv")
@@ -1555,6 +1556,10 @@ class TestTimeseriesInferenceBlock:
 
         assert "known_covariates" not in schema
         assert "known_covariates" not in payload
+
+        pred_metadata_path = Path(models_artifact.path) / "DeepAR_FULL" / "predictor" / "predictor_metadata.json"
+        pred_metadata = json.loads(pred_metadata_path.read_text())
+        assert pred_metadata["uses_synthetic_id"] is True
 
     @mock.patch("pandas.read_csv")
     @mock.patch("pandas.concat")

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -26,12 +26,6 @@ temporal** split on ``id_column`` / ``timestamp_column``: default **80/20** trai
 2. **Model generation + full refit** (``autogluon_timeseries_models_training``): Trains multiple AutoGluon TimeSeries models on the selection split, picks top ``top_n``, and refits each selected model on the full train portion (**selection + extra** splits). The component writes all refitted models
 to a single combined ``models_artifact``.
 
-### Two-column (timestamp + target) dataset support
-
-When `id_column=""` (empty string, default), the pipeline supports **single-item time series** datasets with only timestamp and target columns. The data loader automatically injects a synthetic item ID (`__synthetic_item_id = "item_0"`) during training. The deployed model's inference schema excludes this synthetic column — users send only timestamp + target in prediction requests.
-
-For multi-item forecasting or datasets with 3+ columns, provide an explicit `id_column` value (e.g., `"product_id"`).
-
 ## Inputs 📥
 
 | Parameter | Type | Default | Description |
@@ -41,7 +35,7 @@ For multi-item forecasting or datasets with 3+ columns, provide an explicit `id_
 | `train_data_file_key` | `str` | `None` | S3 object key of the data file (CSV or Parquet). File must include columns for item_id, timestamp, and target; optional columns for known covariates. |
 | `target` | `str` | `None` | Name of the column containing the numeric values to forecast. Corresponds to :attr:`~autogluon.timeseries.TimeSeriesDataFrame` target column. |
 | `timestamp_column` | `str` | `None` | Name of the column containing the timestamp/datetime for each observation. Passed as ``timestamp_column`` when constructing TimeSeriesDataFrame; result uses ``timestamp`` as the second index level. |
-| `id_column` | `str` | `""` | Name of the column that identifies each time series (e.g. product_id, store_id). Empty string (`""`) activates two-column mode with synthetic ID injection for single-item forecasting. |
+| `id_column` | `str` | `""` | Name of the column that identifies each time series (e.g. product_id, store_id). Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. |
 | `known_covariates_names` | `List[str]` | `[]` | Column names known in advance for the forecast horizon (e.g. holidays, promotions). Defaults to ``[]`` (no known covariates). See :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`. |
 | `prediction_length` | `int` | `1` | Number of time steps to forecast (horizon length). Positive integer (default: 1). |
 | `top_n` | `int` | `3` | Number of top models to select for the leaderboard and output (default: 3). |

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -21,9 +21,9 @@ Pipeline stages:
 
 0. **Component stage map**: Publishes the static component-to-stage-to-step map as a KFP artifact for dashboards before data loading.
 
-1. **Data loading & splitting** (``timeseries_data_loader``): Loads CSV from S3 (up to 100 MB), replaces ``+/-inf`` with NaN (missing targets stay for AutoGluon), requires parseable timestamps and non-null ids, deduplicates ``(id_column, timestamp_column)``, then applies a two-stage **per-series
-temporal** split on ``id_column`` / ``timestamp_column``: default **80/20** train vs test per series, then **30/70** of each series' train rows into ``models_selection_train_dataset.csv`` and ``extra_train_dataset.csv`` under ``{workspace_path}/datasets/``. The test split is written to the
-``sampled_test_dataset`` artifact.
+1. **Data loading & splitting** (``timeseries_data_loader``): Loads CSV from S3 (up to 100 MB), replaces ``+/-inf`` with NaN (missing targets stay for AutoGluon), requires parseable timestamps and non-null ids (or injects ``__synthetic_item_id`` for two-column datasets when ``id_column=""``),
+deduplicates ``(id_column, timestamp_column)``, then applies a two-stage **per-series temporal** split on ``id_column`` / ``timestamp_column``: default **80/20** train vs test per series, then **30/70** of each series' train rows into ``models_selection_train_dataset.csv`` and
+``extra_train_dataset.csv`` under ``{workspace_path}/datasets/``. The test split is written to the ``sampled_test_dataset`` artifact.
 
 2. **Model generation + full refit** (``autogluon_timeseries_models_training``): Trains multiple AutoGluon TimeSeries models on the selection split, picks top ``top_n``, and refits each selected model on the full train portion (**selection + extra** splits). The component writes all refitted models
 to a single combined ``models_artifact``.
@@ -34,7 +34,7 @@ to a single combined ``models_artifact``.
 | --------- | ---- | ------- | ----------- |
 | `train_data_secret_name` | `str` | `None` | Kubernetes secret name containing S3 credentials (e.g. AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT, AWS_DEFAULT_REGION). |
 | `train_data_bucket_name` | `str` | `None` | S3-compatible bucket name containing the time series data file. |
-| `train_data_file_key` | `str` | `None` | S3 object key of the data file (CSV or Parquet). File must include columns for item_id, timestamp, and target; optional columns for known covariates. |
+| `train_data_file_key` | `str` | `None` | S3 object key of the data file (CSV or Parquet). When ``id_column`` is provided, file must include columns for id, timestamp, and target. When ``id_column=""`` (single-series mode), file must have exactly timestamp and target columns (the loader injects ``__synthetic_item_id``). Optional columns for known covariates. |
 | `target` | `str` | `None` | Name of the column containing the numeric values to forecast. Corresponds to :attr:`~autogluon.timeseries.TimeSeriesDataFrame` target column. |
 | `timestamp_column` | `str` | `None` | Name of the column containing the timestamp/datetime for each observation. Passed as ``timestamp_column`` when constructing TimeSeriesDataFrame; result uses ``timestamp`` as the second index level. |
 | `id_column` | `str` | `""` | Name of the column that identifies each time series (e.g. product_id, store_id). Pass an empty string ("") for single-series two-column datasets (timestamp + target only); the loader will inject a synthetic ID column. Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. |

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -8,6 +8,8 @@ AutoGluon time series training pipeline.
 
 Trains AutoGluon TimeSeries models on data loaded from S3, scores candidates on a per-series temporal holdout, refits the top models on the full train portion (selection + extra splits), and aggregates metrics into a leaderboard.
 
+**API breaking change:** Parameter order changed: `timestamp_column` now precedes `id_column`. Update any positional calls to use keyword arguments to avoid errors.
+
 **Compiled pipeline encoding:** Keep this module ASCII-only (no Unicode in docstrings or string literals). Some deployments persist compiled pipeline YAML in MySQL ``utf8`` columns, which reject multi-byte characters.
 
 Storage strategy:
@@ -35,7 +37,7 @@ to a single combined ``models_artifact``.
 | `train_data_file_key` | `str` | `None` | S3 object key of the data file (CSV or Parquet). File must include columns for item_id, timestamp, and target; optional columns for known covariates. |
 | `target` | `str` | `None` | Name of the column containing the numeric values to forecast. Corresponds to :attr:`~autogluon.timeseries.TimeSeriesDataFrame` target column. |
 | `timestamp_column` | `str` | `None` | Name of the column containing the timestamp/datetime for each observation. Passed as ``timestamp_column`` when constructing TimeSeriesDataFrame; result uses ``timestamp`` as the second index level. |
-| `id_column` | `str` | `""` | Name of the column that identifies each time series (e.g. product_id, store_id). Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. |
+| `id_column` | `str` | `""` | Name of the column that identifies each time series (e.g. product_id, store_id). Pass an empty string ("") for single-series two-column datasets (timestamp + target only); the loader will inject a synthetic ID column. Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. |
 | `known_covariates_names` | `List[str]` | `[]` | Column names known in advance for the forecast horizon (e.g. holidays, promotions). Defaults to ``[]`` (no known covariates). See :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`. |
 | `prediction_length` | `int` | `1` | Number of time steps to forecast (horizon length). Positive integer (default: 1). |
 | `top_n` | `int` | `3` | Number of top models to select for the leaderboard and output (default: 3). |

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -26,6 +26,12 @@ temporal** split on ``id_column`` / ``timestamp_column``: default **80/20** trai
 2. **Model generation + full refit** (``autogluon_timeseries_models_training``): Trains multiple AutoGluon TimeSeries models on the selection split, picks top ``top_n``, and refits each selected model on the full train portion (**selection + extra** splits). The component writes all refitted models
 to a single combined ``models_artifact``.
 
+### Two-column (timestamp + target) dataset support
+
+When `id_column=""` (empty string, default), the pipeline supports **single-item time series** datasets with only timestamp and target columns. The data loader automatically injects a synthetic item ID (`__synthetic_item_id = "item_0"`) during training. The deployed model's inference schema excludes this synthetic column — users send only timestamp + target in prediction requests.
+
+For multi-item forecasting or datasets with 3+ columns, provide an explicit `id_column` value (e.g., `"product_id"`).
+
 ## Inputs 📥
 
 | Parameter | Type | Default | Description |
@@ -35,7 +41,7 @@ to a single combined ``models_artifact``.
 | `train_data_file_key` | `str` | `None` | S3 object key of the data file (CSV or Parquet). File must include columns for item_id, timestamp, and target; optional columns for known covariates. |
 | `target` | `str` | `None` | Name of the column containing the numeric values to forecast. Corresponds to :attr:`~autogluon.timeseries.TimeSeriesDataFrame` target column. |
 | `timestamp_column` | `str` | `None` | Name of the column containing the timestamp/datetime for each observation. Passed as ``timestamp_column`` when constructing TimeSeriesDataFrame; result uses ``timestamp`` as the second index level. |
-| `id_column` | `str` | `""` | Name of the column that identifies each time series (e.g. product_id, store_id). Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. |
+| `id_column` | `str` | `""` | Name of the column that identifies each time series (e.g. product_id, store_id). Empty string (`""`) activates two-column mode with synthetic ID injection for single-item forecasting. |
 | `known_covariates_names` | `List[str]` | `[]` | Column names known in advance for the forecast horizon (e.g. holidays, promotions). Defaults to ``[]`` (no known covariates). See :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`. |
 | `prediction_length` | `int` | `1` | Number of time steps to forecast (horizon length). Positive integer (default: 1). |
 | `top_n` | `int` | `3` | Number of top models to select for the leaderboard and output (default: 3). |

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/README.md
@@ -34,8 +34,8 @@ to a single combined ``models_artifact``.
 | `train_data_bucket_name` | `str` | `None` | S3-compatible bucket name containing the time series data file. |
 | `train_data_file_key` | `str` | `None` | S3 object key of the data file (CSV or Parquet). File must include columns for item_id, timestamp, and target; optional columns for known covariates. |
 | `target` | `str` | `None` | Name of the column containing the numeric values to forecast. Corresponds to :attr:`~autogluon.timeseries.TimeSeriesDataFrame` target column. |
-| `id_column` | `str` | `None` | Name of the column that identifies each time series (e.g. product_id, store_id). Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. |
 | `timestamp_column` | `str` | `None` | Name of the column containing the timestamp/datetime for each observation. Passed as ``timestamp_column`` when constructing TimeSeriesDataFrame; result uses ``timestamp`` as the second index level. |
+| `id_column` | `str` | `""` | Name of the column that identifies each time series (e.g. product_id, store_id). Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``. |
 | `known_covariates_names` | `List[str]` | `[]` | Column names known in advance for the forecast horizon (e.g. holidays, promotions). Defaults to ``[]`` (no known covariates). See :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`. |
 | `prediction_length` | `int` | `1` | Number of time steps to forecast (horizon length). Positive integer (default: 1). |
 | `top_n` | `int` | `3` | Number of top models to select for the leaderboard and output (default: 3). |

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
@@ -73,7 +73,8 @@ def autogluon_timeseries_training_pipeline(
 
     1. **Data loading & splitting** (``timeseries_data_loader``): Loads CSV from S3 (up to 100 MB),
        replaces ``+/-inf`` with NaN (missing targets stay for AutoGluon), requires parseable timestamps
-       and non-null ids, deduplicates ``(id_column, timestamp_column)``, then applies a two-stage
+       and non-null ids (or injects ``__synthetic_item_id`` for two-column datasets when ``id_column=""``),
+       deduplicates ``(id_column, timestamp_column)``, then applies a two-stage
        **per-series temporal** split on ``id_column`` / ``timestamp_column``:
        default **80/20** train vs test per series, then **30/70** of each series' train rows into
        ``models_selection_train_dataset.csv`` and ``extra_train_dataset.csv`` under
@@ -88,8 +89,10 @@ def autogluon_timeseries_training_pipeline(
         train_data_secret_name: Kubernetes secret name containing S3 credentials
             (e.g. AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_S3_ENDPOINT, AWS_DEFAULT_REGION).
         train_data_bucket_name: S3-compatible bucket name containing the time series data file.
-        train_data_file_key: S3 object key of the data file (CSV or Parquet). File must include
-            columns for item_id, timestamp, and target; optional columns for known covariates.
+        train_data_file_key: S3 object key of the data file (CSV or Parquet). When ``id_column`` is
+            provided, file must include columns for id, timestamp, and target. When ``id_column=""``
+            (single-series mode), file must have exactly timestamp and target columns (the loader injects
+            ``__synthetic_item_id``). Optional columns for known covariates.
         target: Name of the column containing the numeric values to forecast. Corresponds to
             :attr:`~autogluon.timeseries.TimeSeriesDataFrame` target column.
         timestamp_column: Name of the column containing the timestamp/datetime for each observation.

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
@@ -52,6 +52,9 @@ def autogluon_timeseries_training_pipeline(
     temporal holdout, refits the top models on the full train portion (selection + extra splits),
     and aggregates metrics into a leaderboard.
 
+    **API breaking change:** Parameter order changed: `timestamp_column` now precedes `id_column`.
+    Update any positional calls to use keyword arguments to avoid errors.
+
     **Compiled pipeline encoding:** Keep this module ASCII-only (no Unicode in docstrings or
     string literals). Some deployments persist compiled pipeline YAML in MySQL ``utf8`` columns,
     which reject multi-byte characters.
@@ -89,11 +92,13 @@ def autogluon_timeseries_training_pipeline(
             columns for item_id, timestamp, and target; optional columns for known covariates.
         target: Name of the column containing the numeric values to forecast. Corresponds to
             :attr:`~autogluon.timeseries.TimeSeriesDataFrame` target column.
-        id_column: Name of the column that identifies each time series (e.g. product_id, store_id).
-            Passed as ``id_column`` when constructing TimeSeriesDataFrame; result uses ``item_id``.
         timestamp_column: Name of the column containing the timestamp/datetime for each observation.
             Passed as ``timestamp_column`` when constructing TimeSeriesDataFrame; result uses
             ``timestamp`` as the second index level.
+        id_column: Name of the column that identifies each time series (e.g. product_id, store_id).
+            Pass an empty string ("") for single-series two-column datasets (timestamp + target only);
+            the loader will inject a synthetic ID column. Passed as ``id_column`` when constructing
+            TimeSeriesDataFrame; result uses ``item_id``.
         known_covariates_names: Column names known in advance for the forecast horizon
             (e.g. holidays, promotions). Defaults to ``[]`` (no known covariates). See
             :attr:`~autogluon.timeseries.TimeSeriesPredictor.known_covariates_names`.
@@ -181,6 +186,7 @@ def autogluon_timeseries_training_pipeline(
         known_covariates_names=known_covariates_names,
         pipeline_name=dsl.PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER,
         run_id=dsl.PIPELINE_JOB_ID_PLACEHOLDER,
+        uses_synthetic_id=data_loader_task.outputs["uses_synthetic_id"],
         sample_rows=data_loader_task.outputs["sample_rows"],
         sampling_config=data_loader_task.outputs["sample_config"],
         split_config=data_loader_task.outputs["split_config"],

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/pipeline.py
@@ -38,8 +38,8 @@ def autogluon_timeseries_training_pipeline(
     train_data_bucket_name: str,
     train_data_file_key: str,
     target: str,
-    id_column: str,
     timestamp_column: str,
+    id_column: str = "",
     known_covariates_names: List[str] = [],
     prediction_length: int = 1,
     top_n: int = 3,
@@ -171,7 +171,7 @@ def autogluon_timeseries_training_pipeline(
     # Resource limits differ by preset: medium_quality needs more CPU/memory.
     _training_kwargs = dict(
         target=target,
-        id_column=id_column,
+        id_column=data_loader_task.outputs["effective_id_column"],
         timestamp_column=timestamp_column,
         train_data_path=data_loader_task.outputs["models_selection_train_data_path"],
         test_data=data_loader_task.outputs["sampled_test_dataset"],

--- a/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
+++ b/pipelines/training/automl/autogluon_timeseries_training_pipeline/tests/test_pipeline_unit.py
@@ -60,6 +60,7 @@ class TestAutogluonTimeseriesTrainingPipelineUnitTests:
         inputs = autogluon_timeseries_training_pipeline.component_spec.inputs
         params = set(inputs.keys())
         assert params == expected_params, f"Pipeline params {params} != expected {expected_params}"
+        assert inputs["id_column"].default == ""
         assert inputs["prediction_length"].default == 1
         assert inputs["top_n"].default == 3
         assert inputs["known_covariates_names"].default == []


### PR DESCRIPTION

**Description of your changes:**
Support timeseries datasets with only timestamp + target columns by injecting synthetic `__synthetic_item_id` column when `id_column` parameter is empty string. Pipeline accepts `id_column=''` (optional), data loader injects `item_0` value, and training excludes synthetic ID from `model.json` inference schema.

**Checklist:**

### Pre-Submission Checklist

- [ ] All tests and CI checks pass
- [ ] Pre-commit hooks pass without errors
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support single-series time series datasets containing only timestamp and target columns.
  * Automatically add and report a synthetic series identifier for these datasets.
  * Inference schemas and sample payloads omit the synthetic identifier.

* **Bug Fixes**
  * Added validation for column layouts, identifier values, minimum records, and workspace paths.

* **Documentation**
  * Clarified identifier handling, output metadata, and the updated parameter order.

* **Tests**
  * Expanded coverage for synthetic identifiers, validation, data splits, metadata, and inference payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->