### PR TITLE
Remove nsingla from OWNERS files

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -4,6 +4,5 @@ approvers:
 reviewers:
   - hbelmiro
   - VaniHaripriya
-  - nsingla
 emeritus_approvers:
   - gmfrasca

--- a/components/data_processing/yoda_data_processor/OWNERS
+++ b/components/data_processing/yoda_data_processor/OWNERS
@@ -1,5 +1,5 @@
 no_parent_owners: true
 approvers:
   - mprahl
-  - nsingla
+  - hbelmiro
   - HumairAK

--- a/components/data_processing/yoda_data_processor/README.md
+++ b/components/data_processing/yoda_data_processor/README.md
@@ -37,7 +37,7 @@ Downloads the yoda_sentences dataset from HuggingFace, renames columns to match 
   - No Parent Owners: Yes
   - Approvers:
     - mprahl
-    - nsingla
+    - hbelmiro
     - HumairAK
 
 ## Additional Resources 📚

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -4,6 +4,5 @@ approvers:
 reviewers:
   - hbelmiro
   - VaniHaripriya
-  - nsingla
 emeritus_approvers:
   - gmfrasca

--- a/scripts/OWNERS
+++ b/scripts/OWNERS
@@ -4,6 +4,5 @@ approvers:
 reviewers:
   - hbelmiro
   - VaniHaripriya
-  - nsingla
 emeritus_approvers:
   - gmfrasca

--- a/scripts/validate_metadata/tests/resources/directories_metadata/subcategory_invalid_owners/OWNERS
+++ b/scripts/validate_metadata/tests/resources/directories_metadata/subcategory_invalid_owners/OWNERS
@@ -1,2 +1,2 @@
 reviewers:
-  - nsingla
+  - hbelmiro

--- a/scripts/validate_metadata/tests/resources/directories_metadata/subcategory_invalid_owners/comp_a/OWNERS
+++ b/scripts/validate_metadata/tests/resources/directories_metadata/subcategory_invalid_owners/comp_a/OWNERS
@@ -1,3 +1,3 @@
 ---
 approvers:
-- nsingla
+- hbelmiro

--- a/scripts/validate_metadata/tests/resources/directories_metadata/subcategory_missing_owners/comp_a/OWNERS
+++ b/scripts/validate_metadata/tests/resources/directories_metadata/subcategory_missing_owners/comp_a/OWNERS
@@ -1,3 +1,3 @@
 ---
 approvers:
-- nsingla
+- hbelmiro

--- a/scripts/validate_metadata/tests/resources/directories_metadata/subcategory_valid/OWNERS
+++ b/scripts/validate_metadata/tests/resources/directories_metadata/subcategory_valid/OWNERS
@@ -1,2 +1,2 @@
 approvers:
-  - nsingla
+  - hbelmiro

--- a/scripts/validate_metadata/tests/resources/directories_metadata/subcategory_valid/comp_a/OWNERS
+++ b/scripts/validate_metadata/tests/resources/directories_metadata/subcategory_valid/comp_a/OWNERS
@@ -1,3 +1,3 @@
 ---
 approvers:
-- nsingla
+- hbelmiro

--- a/test_data/OWNERS
+++ b/test_data/OWNERS
@@ -4,6 +4,5 @@ approvers:
 reviewers:
   - hbelmiro
   - VaniHaripriya
-  - nsingla
 emeritus_approvers:
   - gmfrasca

--- a/test_data/components/grouped/ml_models/linear_model/OWNERS
+++ b/test_data/components/grouped/ml_models/linear_model/OWNERS
@@ -5,7 +5,6 @@
 # Approvers are responsible for approving code changes
 # These are the KFP maintainers who have write access
 approvers:
-  - nsingla
   - hbelmiro
 reviewers:
-  - nsingla
+  - hbelmiro

--- a/test_data/components/grouped/ml_models/linear_model/README.md
+++ b/test_data/components/grouped/ml_models/linear_model/README.md
@@ -50,7 +50,6 @@ def example_pipeline(data_path: str = "/data/train.csv", target_col: str = "pric
   - subcategory
 - **Owners**:
   - Approvers:
-    - nsingla
     - hbelmiro
   - Reviewers:
-    - nsingla
+    - hbelmiro

--- a/test_data/pipelines/grouped/etl_flows/daily_ingest/OWNERS
+++ b/test_data/pipelines/grouped/etl_flows/daily_ingest/OWNERS
@@ -5,7 +5,6 @@
 # Approvers are responsible for approving code changes
 # These are the KFP maintainers who have write access
 approvers:
-  - nsingla
   - hbelmiro
 reviewers:
-  - nsingla
+  - hbelmiro

--- a/test_data/pipelines/grouped/etl_flows/daily_ingest/README.md
+++ b/test_data/pipelines/grouped/etl_flows/daily_ingest/README.md
@@ -23,7 +23,6 @@ This pipeline orchestrates the daily ingestion of data from an external source i
   - subcategory
 - **Owners**:
   - Approvers:
-    - nsingla
     - hbelmiro
   - Reviewers:
-    - nsingla
+    - hbelmiro


### PR DESCRIPTION
## Summary
- Remove nsingla from OWNERS files across the repo
- Replace with hbelmiro where not already present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated code ownership assignments across project areas and test fixtures.
  - Replaced former reviewer and approver assignments with the current designated maintainer where required.
  - Removed outdated reviewer assignments from applicable ownership lists.
  - Aligned approval and review responsibilities across related metadata and ownership records for more consistent project governance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->