### PR TITLE
build(autox): Use uv pip compile in script for pipeline requirements generation

### DIFF
--- a/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
+++ b/pipelines/training/automl/autogluon_tabular_training_pipeline/requirements.txt
@@ -71,11 +71,10 @@ autogluon-features==1.5.0+rhaiv.5 \
     # via
     #   autogluon-tabular
     #   autogluon-timeseries
-autogluon-tabular[fastai,lightgbm,tabm,xgboost]==1.5.0+rhaiv.5 \
+autogluon-tabular==1.5.0+rhaiv.5 \
     --hash=sha256:dbfe5e5f0a59fe969f6da2d68958b0f748260dd2c23764428bf107e524292fe9
     # via
     #   -r requirements.in
-    #   autogluon-tabular
     #   autogluon-timeseries
 autogluon-timeseries==1.5.0+rhaiv.5 \
     --hash=sha256:fd454bde4ebe575481a814cb199e15df838821b4a0f3e9627f367b9dcedb525f
@@ -251,7 +250,7 @@ frozenlist==1.8.0 \
     # via
     #   aiohttp
     #   aiosignal
-fsspec[http]==2026.6.0 \
+fsspec==2026.6.0 \
     --hash=sha256:9a76dd86f01d5e2034c8192684e131d070de32d4d9d76843821351819e6ee2ef
     # via
     #   huggingface-hub
@@ -836,6 +835,13 @@ sentencepiece==0.2.2 \
     --hash=sha256:783e2c63cc9389a9049887908db0577997f19d887db6c4eb2cfc3c12f63a0078 \
     --hash=sha256:d9a0be1cca4d5885319a63c5f36f1d927d0c9e3e09e46508974b1bb450c620c1
     # via transformers
+setuptools==81.0.0 \
+    --hash=sha256:f6e4d2e589c5fa14b5bbda3d170eac0db8852c7fe7a357f708d172726353778e
+    # via
+    #   spacy
+    #   tensorboard
+    #   thinc
+    #   torch
 shellingham==1.5.4 \
     --hash=sha256:c62d421a942ec6b2400acb0091f31f7bd860d133dfcc8e7c5a252afedba20f8f
     # via typer
@@ -991,7 +997,7 @@ traitlets==5.15.1 \
     # via
     #   ipython
     #   matplotlib-inline
-transformers[sentencepiece]==5.14.1 \
+transformers==5.14.1 \
     --hash=sha256:3e917182ca1be0140cac8411afb52e0df0999e106c4eea2e81a052b6b5015a8d
     # via
     #   autogluon-timeseries
@@ -1002,7 +1008,7 @@ triad==1.0.2 \
     # via
     #   adagio
     #   fugue
-triton==3.6.0 ; platform_machine != "s390x" \
+triton==3.6.0 \
     --hash=sha256:1fd543ee4b888f749e186f87fb4c669894fd2f74849b820ffee3014a54e99d05 \
     --hash=sha256:669850f373cd9bd588b5a4d86c6849f16be98b3e8087130ad945082842ae631b \
     --hash=sha256:a64f6de7b2d45d0426474a980776161e626ccdcbb35e8b540686411fe204e0c9
@@ -1062,7 +1068,7 @@ utilsforecast==0.2.11 \
     #   autogluon-timeseries
     #   mlforecast
     #   statsforecast
-uvicorn[standard]==0.51.0 \
+uvicorn==0.51.0 \
     --hash=sha256:e510a18c6896c39d758bd41eeddb9f736034fe2fcb19c55d0b601762e34ac193
     # via python-fasthtml
 uvloop==0.22.1 \
@@ -1126,12 +1132,3 @@ yarl==1.24.2 \
     --hash=sha256:c72aabbf544bceb3fa895376a188a90b7152efd47045b589fd358505ad8a85d4 \
     --hash=sha256:fcf4442656e2947f3a7e7d3cc85c8030a92570c133df0c9a3ab576a8be8e55fd
     # via aiohttp
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==81.0.0 \
-    --hash=sha256:f6e4d2e589c5fa14b5bbda3d170eac0db8852c7fe7a357f708d172726353778e
-    # via
-    #   spacy
-    #   tensorboard
-    #   thinc
-    #   torch

--- a/pipelines/training/autorag/documents_rag_optimization_pipeline/requirements.txt
+++ b/pipelines/training/autorag/documents_rag_optimization_pipeline/requirements.txt
@@ -135,7 +135,7 @@ distro==1.9.0 \
 docling==2.107.0 \
     --hash=sha256:c8ac4187176ea475dfc9129ccefd3439ec07b76348a6429cae7999634ceb685e
     # via ai4rag
-docling-core[chunking]==2.84.0 \
+docling-core==2.84.0 \
     --hash=sha256:42958a59062a0cb30e17c676e4b72786f5badd4cb14ad52ee41c33875d896ae7
     # via
     #   ai4rag
@@ -151,7 +151,7 @@ docling-parse==7.0.0 \
     --hash=sha256:ae57b46827efa15ff89d5718fa033182a878ce9f66a9966a86e33d2ab9858a7b \
     --hash=sha256:c7fa94783a50aae413cece94c9c73ca47b33201b85ad9e4e98308292696b50fc
     # via docling-slim
-docling-slim[standard]==2.107.0 \
+docling-slim==2.107.0 \
     --hash=sha256:00c806485802a9f21dd98a94518d6d112441c3b9c9de38f610197e5933a7f000
     # via docling
 docstring-parser==0.18.0 \
@@ -192,7 +192,7 @@ frozenlist==1.8.0 \
     # via
     #   aiohttp
     #   aiosignal
-fsspec[http]==2026.4.0 \
+fsspec==2026.4.0 \
     --hash=sha256:ef0c6ca507776eab560612d5785f243e2e3f6cfe42468aacdce3609353366b5b
     # via
     #   datasets
@@ -386,7 +386,7 @@ mmh3==5.2.1 \
     --hash=sha256:cf4bc684dcc8e8d04585858d7d29d39b03b2b0f352949f62c4f4601687c96c37 \
     --hash=sha256:e4448c1a745cbf008bc1294a23c928e12955f9922816f8e2e10c8ffc03ba53be
     # via chromadb
-mpire[dill]==2.10.2 \
+mpire==2.10.2 \
     --hash=sha256:c63736615fb601645a93020d906bd4eccd0ca1f5d6a8547b73df8110b0dd0be6
     # via semchunk
 mpmath==1.3.0 \
@@ -764,7 +764,7 @@ rtree==1.4.1 \
 s3transfer==0.19.1 \
     --hash=sha256:3514b610ae555d9b8948879d13da86f116dc5fec2f93ef4e11f11234d639a7a4
     # via boto3
-safetensors[numpy,torch]==0.8.0 \
+safetensors==0.8.0 \
     --hash=sha256:23e3a3c88c19ad1a2d282a4eb04a84433aa406daeaa4e1d8f49b0123cafc9e62 \
     --hash=sha256:800d4a5cf3320f0c0b49dfb7b4ec6cfe9a5e735b33b8254a74d5a2e452dc4408 \
     --hash=sha256:ae8e482791a7348f972072ac995368904d8fe58ee62c7e410ec2b6b03cc76cab \
@@ -792,6 +792,9 @@ scipy==1.16.3 \
 semchunk==3.2.5 \
     --hash=sha256:492433c61f8de87000e7f7faecf765b7a324c635d0804401952333dc29ccb98b
     # via docling-core
+setuptools==81.0.0 \
+    --hash=sha256:f6e4d2e589c5fa14b5bbda3d170eac0db8852c7fe7a357f708d172726353778e
+    # via torch
 shapely==2.1.2 \
     --hash=sha256:3c824c33fc461af903326eb400f697b5ebdc74e7407adb31c2ac94abf5f9b909 \
     --hash=sha256:94220d057a2b101eb59cc69d352075ce1a6008a475b33f91d74e0214daedbea7 \
@@ -923,7 +926,7 @@ tree-sitter-typescript==0.23.2 \
     --hash=sha256:0fa0c96de9e44aad636ec2bdbfbd4fc8a14497aa0656ae60021a8a20fe611e41 \
     --hash=sha256:e3f6058625e88bb057a5aa1aee8fe2aa8e1758c912bb6aadb72720a61fae586e
     # via docling-core
-triton==3.6.0 ; platform_machine != "s390x" \
+triton==3.6.0 \
     --hash=sha256:1fd543ee4b888f749e186f87fb4c669894fd2f74849b820ffee3014a54e99d05 \
     --hash=sha256:669850f373cd9bd588b5a4d86c6849f16be98b3e8087130ad945082842ae631b \
     --hash=sha256:a64f6de7b2d45d0426474a980776161e626ccdcbb35e8b540686411fe204e0c9
@@ -992,7 +995,7 @@ uuid-utils==0.17.0 \
     # via
     #   langchain-core
     #   langsmith
-uvicorn[standard]==0.51.0 \
+uvicorn==0.51.0 \
     --hash=sha256:e510a18c6896c39d758bd41eeddb9f736034fe2fcb19c55d0b601762e34ac193
     # via chromadb
 uvloop==0.22.1 \
@@ -1050,8 +1053,3 @@ zstandard==0.25.0 \
     --hash=sha256:c734ffe543d7aaf7ff9848fb06fcc4c251e2c1670eab845b8983b6ff24f993fd \
     --hash=sha256:fdc7ec1d57af80b7b7d2cadb025366aae714533322e5f908acd8e2da2dc75bb4
     # via langsmith
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==81.0.0 \
-    --hash=sha256:f6e4d2e589c5fa14b5bbda3d170eac0db8852c7fe7a357f708d172726353778e
-    # via torch

--- a/scripts/refresh_pipeline_requirements/README.md
+++ b/scripts/refresh_pipeline_requirements/README.md
@@ -3,8 +3,10 @@
 Refresh Hermeto-compatible `requirements.txt` lockfiles for RHOAI pipelines.
 
 The RHOAI PyPI index does not publish macOS-compatible wheels, so this script
-runs `pip-compile` inside a Linux container (`registry.access.redhat.com/ubi9/python-312:9.8`).
-Use Podman or Docker; the runtime is auto-detected (podman first, then docker).
+runs `uv pip compile` inside a Linux container (`registry.access.redhat.com/ubi9/python-312:9.8`).
+`uv` is used instead of `pip-compile` for a much faster resolve while producing an
+equivalent hashed lockfile. Use Podman or Docker; the runtime is auto-detected
+(podman first, then docker).
 
 ## Usage
 
@@ -60,7 +62,7 @@ uv run python -m scripts.refresh_pipeline_requirements.refresh_pipeline_requirem
 | `IMAGE` | image ref | Container image override |
 | `NO_UPGRADE` | `true` | Keep existing pins from `requirements.txt` |
 | `DRY_RUN` | `true` | Show changes without writing `requirements.txt` |
-| `QUIET` | `true` | Suppress live pip-compile progress output |
+| `QUIET` | `true` | Suppress live uv pip compile progress output |
 
 ## Defaults
 

--- a/scripts/refresh_pipeline_requirements/refresh_pipeline_requirements.py
+++ b/scripts/refresh_pipeline_requirements/refresh_pipeline_requirements.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Refresh Hermeto-compatible requirements.txt lockfiles for RHOAI pipelines.
 
-Compiles ``requirements.in`` into ``requirements.txt`` using ``pip-compile``
+Compiles ``requirements.in`` into ``requirements.txt`` using ``uv pip compile``
 with ``--generate-hashes`` inside a container (Podman or Docker). The RHOAI PyPI
 index does not publish macOS-compatible wheels, so compilation must run on Linux
-(UBI9 Python 3.12).
+(UBI9 Python 3.12). ``uv`` is used instead of ``pip-compile`` because its resolver
+is dramatically faster while producing an equivalent hashed lockfile.
 
 See: https://hermetoproject.github.io/hermeto/pip/#requirementstxt
 """
@@ -118,27 +119,24 @@ def build_container_command(
     dry_run: bool,
     verbose: bool,
 ) -> list[str]:
-    """Build the container command that runs pip-compile."""
+    """Build the container command that runs uv pip compile."""
     python_bin = "python3 -u"
     compile_flags = [
-        f"{python_bin} -m piptools compile",
+        f"{python_bin} -m uv pip compile",
         _REQUIREMENTS_IN,
         "--generate-hashes",
         "--emit-index-url",
-        "--allow-unsafe",
         "--no-header",
-        f"--output-file {_REQUIREMENTS_TXT}",
     ]
+    # uv pip compile has no --dry-run; emit to stdout instead of writing the lockfile.
+    if not dry_run:
+        compile_flags.append(f"--output-file {_REQUIREMENTS_TXT}")
     if upgrade:
         compile_flags.append("--upgrade")
-    if dry_run:
-        compile_flags.append("--dry-run")
-    if verbose:
-        compile_flags.append("-v")
+    if not verbose:
+        compile_flags.append("--quiet")
 
-    pip_install = (
-        f"{python_bin} -m pip install pip-tools" if verbose else f"{python_bin} -m pip install --quiet pip-tools"
-    )
+    pip_install = f"{python_bin} -m pip install uv" if verbose else f"{python_bin} -m pip install --quiet uv"
     compile_command = " ".join([pip_install, "&&", " ".join(compile_flags)])
 
     command = [
@@ -220,7 +218,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Refresh Hermeto-compatible requirements.txt lockfiles for RHOAI pipelines "
-            "using pip-compile in Podman or Docker"
+            "using uv pip compile in Podman or Docker"
         ),
     )
     parser.add_argument(
@@ -231,7 +229,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--image",
         default=DEFAULT_CONTAINER_IMAGE,
-        help=f"Container image to run pip-compile in (default: {DEFAULT_CONTAINER_IMAGE})",
+        help=f"Container image to run uv pip compile in (default: {DEFAULT_CONTAINER_IMAGE})",
     )
     parser.add_argument(
         "--runtime",
@@ -246,12 +244,12 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Show what pip-compile would change without writing requirements.txt",
+        help="Show the resolved requirements on stdout without writing requirements.txt",
     )
     parser.add_argument(
         "--quiet",
         action="store_true",
-        help="Suppress live pip-compile progress output",
+        help="Suppress live uv pip compile progress output",
     )
     return parser.parse_args(argv)
 

--- a/scripts/refresh_pipeline_requirements/tests/test_refresh_pipeline_requirements.py
+++ b/scripts/refresh_pipeline_requirements/tests/test_refresh_pipeline_requirements.py
@@ -150,7 +150,7 @@ class TestBuildContainerCommand:
     """Tests for build_container_command."""
 
     def test_builds_expected_podman_command(self, tmp_path: Path):
-        """Builds a verbose Podman command with Hermeto-compatible pip-compile flags."""
+        """Builds a verbose Podman command with Hermeto-compatible uv pip compile flags."""
         pipeline_dir = tmp_path / "pipeline"
         _write_requirements_in(pipeline_dir)
 
@@ -167,15 +167,13 @@ class TestBuildContainerCommand:
         assert "/bin/bash" in command
         assert "-lc" in command
         compile_command = command[command.index("-lc") + 1]
-        assert "python3 -u -m piptools compile requirements.in" in compile_command
-        assert "python3 -u -m pip install pip-tools" in compile_command
+        assert "python3 -u -m uv pip compile requirements.in" in compile_command
+        assert "python3 -u -m pip install uv" in compile_command
         assert "--generate-hashes" in compile_command
-        assert "--allow-unsafe" in compile_command
+        assert "--emit-index-url" in compile_command
         assert "--no-header" in compile_command
-        assert " -v" in compile_command
         assert "--upgrade" in compile_command
         assert "--output-file requirements.txt" in compile_command
-        assert "--dry-run" not in compile_command
         assert "--quiet" not in compile_command
 
     def test_no_upgrade_omits_upgrade_flag(self, tmp_path: Path):
@@ -228,12 +226,11 @@ class TestBuildContainerCommand:
         )
 
         compile_command = command[command.index("-lc") + 1]
-        assert " -v" not in compile_command
         assert "--quiet" in compile_command
-        assert "python3 -u -m piptools compile requirements.in" in compile_command
+        assert "python3 -u -m uv pip compile requirements.in" in compile_command
 
-    def test_includes_upgrade_and_dry_run_flags(self, tmp_path: Path):
-        """Passes upgrade and dry-run flags through to pip-compile."""
+    def test_dry_run_omits_output_file(self, tmp_path: Path):
+        """Emits to stdout (no --output-file) in dry-run mode, since uv has no --dry-run."""
         pipeline_dir = tmp_path / "pipeline"
         _write_requirements_in(pipeline_dir)
 
@@ -247,7 +244,7 @@ class TestBuildContainerCommand:
         )
 
         assert "--upgrade" in command[-1]
-        assert "--dry-run" in command[-1]
+        assert "--output-file" not in command[-1]
 
 
 class TestCompilePipelineRequirements:
@@ -273,7 +270,7 @@ class TestCompilePipelineRequirements:
         assert run_kwargs["stderr"] is subprocess.DEVNULL
 
     def test_runs_container_compile(self, tmp_path: Path):
-        """Invokes the container runtime to run pip-compile for a valid pipeline directory."""
+        """Invokes the container runtime to run uv pip compile for a valid pipeline directory."""
         pipeline_dir = tmp_path / "pipeline"
         _write_requirements_in(pipeline_dir, index_url="https://user:secret@example.com/simple")
 
@@ -290,7 +287,7 @@ class TestCompilePipelineRequirements:
         run_mock.assert_called_once()
         command = run_mock.call_args.args[0]
         assert command[0] == "docker"
-        assert "python3 -u -m piptools compile requirements.in" in command[-1]
+        assert "python3 -u -m uv pip compile requirements.in" in command[-1]
         printed = " ".join(str(call.args[0]) for call in print_mock.call_args_list)
         assert "user:secret" not in printed
         assert "https://example.com" in printed


### PR DESCRIPTION
**Description of your changes:**
Using `uv pip compile` is also compatible with Hermeto and it's significantly faster from native pip compile (less 5 min vs. ~ 40 minuts)

Assisted by Cursor

(Updates for new index 3.6 EA1 will be delivered in separate PR). 

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->

