### PR TITLE
fix(autorag): standardized status format for component stages

### DIFF
--- a/components/training/autorag/component_stage_map_publisher/component_status.schema.json
+++ b/components/training/autorag/component_stage_map_publisher/component_status.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AutoRAG component_status.json (canonical)",
+  "description": "Per-component progress artifact emitted by ComponentStatusTracker. Dashboard joins this to the stage map published by component_stage_map_publisher.",
+  "type": "object",
+  "required": ["component_id", "started_at", "stages", "metadata"],
+  "additionalProperties": false,
+  "properties": {
+    "component_id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "description": "Must equal run_status_templates components[].id."
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC with Z suffix. Set by tracker init."
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Set only when the component has finished (all stages completed or failed)."
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["display_name"],
+      "additionalProperties": true,
+      "properties": {
+        "display_name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable title shown in the Dashboard."
+        }
+      }
+    },
+    "stages": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/stage" },
+      "description": "One object per recorded stage id. Later writes update the same id."
+    }
+  },
+  "$defs": {
+    "statusMessage": {
+      "type": "object",
+      "required": ["level", "text"],
+      "additionalProperties": false,
+      "properties": {
+        "level": {
+          "type": "string",
+          "enum": ["info", "warning", "error"]
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "stageStatus": {
+      "type": "object",
+      "required": ["state"],
+      "additionalProperties": false,
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": ["started", "running", "completed", "failed"]
+        },
+        "step": {
+          "type": "string",
+          "description": "Current sub-step id. Only when the stage map lists steps[] for this stage."
+        },
+        "message": {
+          "$ref": "#/$defs/statusMessage"
+        },
+        "running_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Auto-set when state is running."
+        }
+      }
+    },
+    "stage": {
+      "type": "object",
+      "required": ["id", "status"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Must equal run_status_templates components[].stages[].id."
+        },
+        "status": {
+          "$ref": "#/$defs/stageStatus"
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "number", "boolean", "array", "null"],
+            "items": { "type": ["string", "number", "boolean"] }
+          },
+          "description": "Counters and measurements. Open key set, snake_case convention."
+        },
+        "error": {
+          "type": "string",
+          "description": "Only when status.state is failed. Prefer 'ExceptionType: message' format."
+        }
+      }
+    }
+  }
+}

--- a/components/training/autorag/rag_templates_optimization/component.py
+++ b/components/training/autorag/rag_templates_optimization/component.py
@@ -108,13 +108,11 @@ def rag_templates_optimization(
         status = _status_module.bootstrap_status_tracker(
             embedded_artifact, component_status, "rag_templates_optimization"
         )
-    optimize_templates_steps = ["chunking", "embedding", "retrieval", "generation", "evaluation"]
-
     with status:
         if component_status is not None:
             status.set_metadata(display_name="RAG Templates Optimization Status")
             component_status.metadata["display_name"] = "RAG Templates Optimization Status"
-        with status.stage("optimize_templates", steps=optimize_templates_steps):
+        with status.stage("optimize_templates"):
             maas_client = create_maas_client(
                 base_url=os.environ["MAAS_BASE_URL"],
                 api_key=os.environ["MAAS_API_KEY"],
@@ -165,9 +163,10 @@ def rag_templates_optimization(
             status.record(
                 "optimize_templates",
                 "completed",
-                max_rag_patterns=len(result.patterns),
-                selected_patterns=[p.get("name", "") for p in result.patterns],
-                steps=optimize_templates_steps,
+                metrics={
+                    "max_rag_patterns": len(result.patterns),
+                    "selected_patterns": [p.get("name", "") for p in result.patterns],
+                },
             )
 
             rag_patterns.metadata["name"] = "rag_patterns_artifact"

--- a/components/training/autorag/shared/component_status.py
+++ b/components/training/autorag/shared/component_status.py
@@ -61,6 +61,8 @@ STATUS_RUNNING = "running"
 STATUS_COMPLETED = "completed"
 STATUS_FAILED = "failed"
 
+_VALID_STATES = frozenset({STATUS_STARTED, STATUS_RUNNING, STATUS_COMPLETED, STATUS_FAILED})
+
 
 class NullComponentStatusTracker:
     """No-op status tracker for notebook or direct ``python_func`` invocations."""
@@ -80,7 +82,7 @@ class NullComponentStatusTracker:
         return False
 
     @contextmanager
-    def stage(self, _stage_id: str, **_start_metadata: Any) -> Iterator[None]:
+    def stage(self, _stage_id: str, **_start_kwargs: Any) -> Iterator[None]:
         """Yield without recording stage transitions."""
         yield
 
@@ -91,7 +93,12 @@ def null_component_status_tracker() -> NullComponentStatusTracker:
 
 
 class ComponentStatusTracker:
-    """Track stage-level progress within a single AutoRAG component."""
+    """Track stage-level progress within a single AutoRAG component.
+
+    Emits the canonical AutoX component_status.json schema: each stage carries a
+    nested ``status`` object (state, optional step/message/running_at), an optional
+    ``metrics`` bag for counters, and an optional ``error`` string.
+    """
 
     def __init__(self, artifact_path: str, component_id: str) -> None:
         """Initialize the status tracker.
@@ -104,47 +111,96 @@ class ComponentStatusTracker:
         self.component_id = component_id
         self.stages: list[dict[str, Any]] = []
         self.started_at = utc_now_z()
+        self.completed_at: str | None = None
         self.metadata: dict[str, Any] = {}
 
-    def record(self, stage_id: str, status: str, **metadata: Any) -> None:
-        """Record or update a stage's status."""
+    def record(
+        self,
+        stage_id: str,
+        state: str,
+        *,
+        step: str | None = None,
+        message: dict[str, str] | None = None,
+        metrics: dict[str, Any] | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Record or update a stage's status.
+
+        Args:
+            stage_id: Stage identifier (e.g., "load_benchmark", "optimize_templates").
+            state: Stage state ("started", "running", "completed", "failed").
+            step: Current sub-step id. Only when the stage map lists steps[].
+            message: Status message dict with "level" (info/warning/error) and "text".
+            metrics: Counters and measurements for this stage (e.g., {"rows": 1000}).
+            error: Error description. Only when state is "failed".
+        """
+        if state not in _VALID_STATES:
+            raise ValueError(f"state must be one of {sorted(_VALID_STATES)}; got {state!r}")
+
+        status_obj: dict[str, Any] = {"state": state}
+        if step is not None:
+            status_obj["step"] = step
+        if message is not None:
+            status_obj["message"] = message
+        if state == STATUS_RUNNING:
+            status_obj["running_at"] = utc_now_z()
+
+        stage_data: dict[str, Any] = {"id": stage_id, "status": status_obj}
+        if metrics:
+            stage_data["metrics"] = metrics
+        if error is not None:
+            stage_data["error"] = error
+
         existing_idx = next((i for i, s in enumerate(self.stages) if s["id"] == stage_id), None)
 
-        stage_data = {
-            "id": stage_id,
-            "status": status,
-            "timestamp": utc_now_z(),
-            **metadata,
-        }
-
         if existing_idx is not None:
-            self.stages[existing_idx].update(stage_data)
+            existing = self.stages[existing_idx]
+            existing["status"] = stage_data["status"]
+            if "metrics" in stage_data:
+                existing.setdefault("metrics", {}).update(stage_data["metrics"])
+            if state == STATUS_FAILED:
+                if "error" in stage_data:
+                    existing["error"] = stage_data["error"]
+            else:
+                existing.pop("error", None)
         else:
             self.stages.append(stage_data)
 
         logger.info(
-            "COMPONENT_STATUS component=%s stage=%s status=%s %s",
+            "COMPONENT_STATUS component=%s stage=%s state=%s%s",
             self.component_id,
             stage_id,
-            status,
-            " ".join(f"{k}={v}" for k, v in metadata.items()),
+            state,
+            f" metrics={metrics}" if metrics else "",
         )
 
     def set_metadata(self, **metadata: Any) -> None:
         """Set component-level metadata."""
         self.metadata.update(metadata)
 
+    def _is_finished(self) -> bool:
+        """Return True if all recorded stages are completed or any stage has failed."""
+        if not self.stages:
+            return False
+        states = [s["status"]["state"] for s in self.stages]
+        if STATUS_FAILED in states:
+            return True
+        return all(s == STATUS_COMPLETED for s in states)
+
     def save(self) -> None:
         """Write the final status to the artifact."""
         self.artifact_path.mkdir(parents=True, exist_ok=True)
 
-        data = {
+        data: dict[str, Any] = {
             "component_id": self.component_id,
             "started_at": self.started_at,
-            "completed_at": utc_now_z(),
             "stages": self.stages,
             "metadata": self.metadata,
         }
+
+        if self._is_finished():
+            self.completed_at = self.completed_at or utc_now_z()
+            data["completed_at"] = self.completed_at
 
         output_file = self.artifact_path / COMPONENT_STATUS_FILENAME
         with output_file.open("w", encoding="utf-8") as f:
@@ -169,7 +225,6 @@ class ComponentStatusTracker:
 
     def mark_active_failed(self, error: str | BaseException) -> None:
         """Mark the in-progress stage as failed, or the last open stage if none is active."""
-        # Handle empty str(exc) by including exception type
         if isinstance(error, BaseException):
             error_msg = f"{type(error).__name__}: {error}" if str(error) else type(error).__name__
         else:
@@ -177,30 +232,36 @@ class ComponentStatusTracker:
 
         active_statuses = (STATUS_STARTED, STATUS_RUNNING)
         for stage in reversed(self.stages):
-            if stage.get("status") in active_statuses:
+            if stage["status"]["state"] in active_statuses:
                 self.record(stage["id"], STATUS_FAILED, error=error_msg)
                 return
 
-        if self.stages and self.stages[-1].get("status") != STATUS_COMPLETED:
+        if self.stages and self.stages[-1]["status"]["state"] != STATUS_COMPLETED:
             self.record(self.stages[-1]["id"], STATUS_FAILED, error=error_msg)
             return
 
         self.set_metadata(status=STATUS_FAILED, error=error_msg)
 
     @contextmanager
-    def stage(self, stage_id: str, **start_metadata: Any) -> Iterator[None]:
+    def stage(
+        self,
+        stage_id: str,
+        *,
+        step: str | None = None,
+        message: dict[str, str] | None = None,
+        metrics: dict[str, Any] | None = None,
+    ) -> Iterator[None]:
         """Record stage started/completed, or failed when an exception escapes the block."""
-        self.record(stage_id, STATUS_STARTED, **start_metadata)
+        self.record(stage_id, STATUS_STARTED, step=step, message=message, metrics=metrics)
         try:
             yield
         except BaseException as exc:
-            # Use exception-aware error formatting
             error_msg = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
             self.record(stage_id, STATUS_FAILED, error=error_msg)
             raise
         else:
             latest = next((s for s in reversed(self.stages) if s["id"] == stage_id), None)
-            if latest is None or latest.get("status") not in (STATUS_COMPLETED, STATUS_FAILED):
+            if latest is None or latest["status"]["state"] not in (STATUS_COMPLETED, STATUS_FAILED):
                 self.record(stage_id, STATUS_COMPLETED)
 
     def __enter__(self) -> ComponentStatusTracker:

--- a/components/training/autorag/shared/tests/test_component_status.py
+++ b/components/training/autorag/shared/tests/test_component_status.py
@@ -14,24 +14,107 @@ from kfp_components.components.training.autorag.shared.component_status import (
     bootstrap_status_tracker,
     load_component_status,
     load_embedded_component_status_module,
+    utc_now_z,
 )
+
+_CANONICAL_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["component_id", "started_at", "stages", "metadata"],
+    "additionalProperties": False,
+    "properties": {
+        "component_id": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$"},
+        "started_at": {"type": "string", "format": "date-time"},
+        "completed_at": {"type": "string", "format": "date-time"},
+        "metadata": {
+            "type": "object",
+            "required": ["display_name"],
+            "additionalProperties": True,
+            "properties": {
+                "display_name": {"type": "string", "minLength": 1},
+            },
+        },
+        "stages": {
+            "type": "array",
+            "items": {"$ref": "#/$defs/stage"},
+        },
+    },
+    "$defs": {
+        "statusMessage": {
+            "type": "object",
+            "required": ["level", "text"],
+            "additionalProperties": False,
+            "properties": {
+                "level": {"type": "string", "enum": ["info", "warning", "error"]},
+                "text": {"type": "string", "minLength": 1},
+            },
+        },
+        "stageStatus": {
+            "type": "object",
+            "required": ["state"],
+            "additionalProperties": False,
+            "properties": {
+                "state": {"type": "string", "enum": ["started", "running", "completed", "failed"]},
+                "step": {"type": "string"},
+                "message": {"$ref": "#/$defs/statusMessage"},
+                "running_at": {"type": "string", "format": "date-time"},
+            },
+        },
+        "stage": {
+            "type": "object",
+            "required": ["id", "status"],
+            "additionalProperties": False,
+            "properties": {
+                "id": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$"},
+                "status": {"$ref": "#/$defs/stageStatus"},
+                "metrics": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": ["string", "number", "boolean", "array", "null"],
+                        "items": {"type": ["string", "number", "boolean"]},
+                    },
+                },
+                "error": {"type": "string"},
+            },
+        },
+    },
+}
+
+
+@pytest.fixture()
+def canonical_schema() -> dict:
+    """Return the canonical component_status JSON Schema."""
+    return _CANONICAL_SCHEMA
+
+
+def _save_and_load(tracker: ComponentStatusTracker) -> dict:
+    """Save tracker to disk and return the parsed JSON."""
+    tracker.save()
+    return json.loads((Path(tracker.artifact_path) / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
+
+
+def _assert_schema_valid(instance: dict, schema: dict) -> None:
+    """Validate instance against schema (lazy-import jsonschema for import guard)."""
+    from jsonschema import validate
+
+    validate(instance=instance, schema=schema)
 
 
 class TestComponentStatusTracker:
     """Tests for ComponentStatusTracker."""
 
     def test_record_and_save(self, tmp_path: Path) -> None:
-        """save() writes stages and component_id to component_status.json."""
+        """save() writes stages with nested status and metrics to component_status.json."""
         tracker = ComponentStatusTracker(str(tmp_path), "test_data_loader")
-        tracker.record("load_benchmark", "started", rows=5)
+        tracker.record("load_benchmark", "started", metrics={"rows": 5})
         tracker.record("load_benchmark", "completed")
         tracker.save()
 
         data = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
         assert data["component_id"] == "test_data_loader"
         assert len(data["stages"]) == 1
-        assert data["stages"][0]["status"] == "completed"
-        assert data["stages"][0]["rows"] == 5
+        assert data["stages"][0]["status"]["state"] == "completed"
+        assert data["stages"][0]["metrics"]["rows"] == 5
 
     def test_context_manager_marks_failed_and_saves(self, tmp_path: Path) -> None:
         """Context manager marks active stage failed and persists status on exception."""
@@ -41,86 +124,179 @@ class TestComponentStatusTracker:
                 raise RuntimeError("boom")
 
         data = load_component_status(str(tmp_path))
-        assert data["stages"][-1]["status"] == "failed"
+        assert data["stages"][-1]["status"]["state"] == "failed"
         assert "boom" in data["stages"][-1]["error"]
-
-    def test_record_completed_with_steps(self, tmp_path: Path) -> None:
-        """Completed stages can include manifest step ids for dashboard display."""
-        tracker = ComponentStatusTracker(str(tmp_path), "rag_templates_optimization")
-        steps = ["chunking", "embedding", "retrieval", "generation", "evaluation"]
-        tracker.record("optimize_templates", "started")
-        tracker.record("optimize_templates", "completed", steps=steps)
-        tracker.save()
-
-        data = load_component_status(str(tmp_path))
-        assert data["stages"][-1]["steps"] == steps
 
     def test_stage_skips_auto_complete_when_completed_inside_block(self, tmp_path: Path) -> None:
         """stage() does not overwrite a completed record written inside the block."""
         tracker = ComponentStatusTracker(str(tmp_path), "rag_templates_optimization")
-        with tracker.stage("optimize_templates", steps=["chunking"]):
-            tracker.record("optimize_templates", "completed", max_rag_patterns=8)
+        with tracker.stage("optimize_templates"):
+            tracker.record(
+                "optimize_templates",
+                "completed",
+                metrics={"max_rag_patterns": 8},
+            )
         tracker.save()
 
         data = load_component_status(str(tmp_path))
         run_stage = next(stage for stage in data["stages"] if stage["id"] == "optimize_templates")
-        assert run_stage["status"] == "completed"
-        assert run_stage["max_rag_patterns"] == 8
+        assert run_stage["status"]["state"] == "completed"
+        assert run_stage["metrics"]["max_rag_patterns"] == 8
 
     def test_utc_now_z_ends_with_z(self) -> None:
         """Timestamps use UTC ISO-8601 with Z suffix."""
-        from kfp_components.components.training.autorag.shared.component_status import utc_now_z
-
         assert utc_now_z().endswith("Z")
 
-    def test_component_status_json_schema_compliance(self, tmp_path: Path) -> None:
-        """component_status.json follows expected schema for dashboard consumption."""
-        from datetime import datetime
-
-        tracker = ComponentStatusTracker(str(tmp_path), "test_component")
-        tracker.record("stage1", "started")
-        tracker.record("stage1", "completed", rows=100, files=5)
-        tracker.record("stage2", "started", input_size_mb=50)
-        tracker.record("stage2", "completed", output_size_mb=45)
+    def test_mark_active_failed_marks_started_stage(self, tmp_path: Path) -> None:
+        """mark_active_failed() updates the in-progress stage to failed."""
+        tracker = ComponentStatusTracker(str(tmp_path), "rag_templates_optimization")
+        tracker.record("optimize_templates", "started")
+        tracker.mark_active_failed("optimization timeout")
         tracker.save()
 
         data = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
+        assert data["stages"][-1]["status"]["state"] == "failed"
+        assert data["stages"][-1]["error"] == "optimization timeout"
 
-        # Top-level structure
-        required_fields = {"component_id", "started_at", "completed_at", "stages", "metadata"}
-        assert set(data.keys()) >= required_fields, f"Missing fields: {required_fields - set(data.keys())}"
-        assert data["component_id"] == "test_component"
+    def test_save_best_effort_swallows_io_errors(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """save_best_effort() logs I/O errors instead of raising."""
+        tracker = ComponentStatusTracker(str(tmp_path), "rag_templates_optimization")
+        tracker.record("build_leaderboard", "started")
 
-        # ISO-8601 timestamps with Z suffix
-        assert data["started_at"].endswith("Z"), "started_at should end with Z"
-        assert data["completed_at"].endswith("Z"), "completed_at should end with Z"
+        def _raise_save() -> None:
+            raise OSError("disk full")
 
-        # Verify timestamps are valid ISO-8601
-        datetime.fromisoformat(data["started_at"].replace("Z", "+00:00"))
-        datetime.fromisoformat(data["completed_at"].replace("Z", "+00:00"))
+        monkeypatch.setattr(tracker, "save", _raise_save)
+        tracker.save_best_effort()
 
-        # Stages array structure
-        assert isinstance(data["stages"], list), "stages should be a list"
-        assert len(data["stages"]) == 2, "Should have 2 stages"
+    def test_context_manager_saves_on_success(self, tmp_path: Path) -> None:
+        """Context manager persists status when the block completes normally."""
+        with ComponentStatusTracker(str(tmp_path), "documents_discovery") as status:
+            status.record("discover_documents", "completed")
 
-        # Verify each stage has required fields
-        for stage in data["stages"]:
-            assert "id" in stage, "Each stage must have an id"
-            assert "status" in stage, "Each stage must have a status"
-            assert "timestamp" in stage, "Each stage must have a timestamp"
-            assert stage["timestamp"].endswith("Z"), "Stage timestamps should end with Z"
+        assert (tmp_path / COMPONENT_STATUS_FILENAME).exists()
 
-        # Verify stage 1 metadata
-        stage1 = next(s for s in data["stages"] if s["id"] == "stage1")
-        assert stage1["status"] == "completed"
-        assert stage1["rows"] == 100
-        assert stage1["files"] == 5
+    def test_stage_context_manager_records_completed(self, tmp_path: Path) -> None:
+        """stage() records started then completed when no exception is raised."""
+        tracker = ComponentStatusTracker(str(tmp_path), "documents_discovery")
+        with tracker.stage("discover_documents"):
+            pass
+        tracker.save()
 
-        # Verify stage 2 metadata
-        stage2 = next(s for s in data["stages"] if s["id"] == "stage2")
-        assert stage2["status"] == "completed"
-        assert stage2["input_size_mb"] == 50
-        assert stage2["output_size_mb"] == 45
+        data = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
+        assert data["stages"][-1]["id"] == "discover_documents"
+        assert data["stages"][-1]["status"]["state"] == "completed"
+
+    def test_stage_context_manager_records_failed(self, tmp_path: Path) -> None:
+        """stage() records failed when an exception escapes the block."""
+        tracker = ComponentStatusTracker(str(tmp_path), "text_extraction")
+        with pytest.raises(ValueError, match="bad format"):
+            with tracker.stage("extract_documents"):
+                raise ValueError("bad format")
+        tracker.save()
+
+        data = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
+        assert data["stages"][-1]["status"]["state"] == "failed"
+        assert "bad format" in data["stages"][-1]["error"]
+
+    def test_running_state_sets_running_at(self, tmp_path: Path) -> None:
+        """Recording state=running auto-sets running_at timestamp."""
+        tracker = ComponentStatusTracker(str(tmp_path), "search_space_preparation")
+        tracker.record("prepare_search_space", "running")
+        tracker.save()
+
+        data = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
+        assert data["stages"][0]["status"]["state"] == "running"
+        assert "running_at" in data["stages"][0]["status"]
+        assert data["stages"][0]["status"]["running_at"].endswith("Z")
+
+    def test_step_field_on_status(self, tmp_path: Path) -> None:
+        """Step is placed inside the nested status object."""
+        tracker = ComponentStatusTracker(str(tmp_path), "rag_templates_optimization")
+        tracker.record("optimize_templates", "running", step="embedding")
+        tracker.save()
+
+        data = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
+        assert data["stages"][0]["status"]["step"] == "embedding"
+
+    def test_message_field_on_status(self, tmp_path: Path) -> None:
+        """Message is placed inside the nested status object."""
+        tracker = ComponentStatusTracker(str(tmp_path), "documents_discovery")
+        tracker.record("load_benchmark", "running", message={"level": "info", "text": "Loading data..."})
+        tracker.save()
+
+        data = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
+        assert data["stages"][0]["status"]["message"] == {"level": "info", "text": "Loading data..."}
+
+    def test_metrics_accumulate_across_records(self, tmp_path: Path) -> None:
+        """Metrics from multiple record() calls on the same stage merge together."""
+        tracker = ComponentStatusTracker(str(tmp_path), "documents_discovery")
+        tracker.record("load_benchmark", "started", metrics={"rows": 100})
+        tracker.record("load_benchmark", "completed", metrics={"duplicates_dropped": 5})
+        tracker.save()
+
+        data = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
+        assert data["stages"][0]["metrics"]["rows"] == 100
+        assert data["stages"][0]["metrics"]["duplicates_dropped"] == 5
+
+    def test_completed_at_set_when_finished(self, tmp_path: Path) -> None:
+        """completed_at is set only when all stages are completed."""
+        tracker = ComponentStatusTracker(str(tmp_path), "documents_discovery")
+        tracker.record("load_benchmark", "completed")
+        tracker.record("discover_documents", "completed")
+        tracker.save()
+
+        data = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
+        assert "completed_at" in data
+
+    def test_completed_at_not_set_while_running(self, tmp_path: Path) -> None:
+        """completed_at is not set while stages are still in progress."""
+        tracker = ComponentStatusTracker(str(tmp_path), "documents_discovery")
+        tracker.record("load_benchmark", "completed")
+        tracker.record("discover_documents", "started")
+        tracker.save()
+
+        data = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
+        assert "completed_at" not in data
+
+    def test_completed_at_preserved_across_repeated_saves(self, tmp_path: Path) -> None:
+        """First terminal completed_at is kept when save() is called again."""
+        tracker = ComponentStatusTracker(str(tmp_path), "documents_discovery")
+        tracker.record("load_benchmark", "completed")
+        tracker.save()
+        first = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))["completed_at"]
+
+        tracker.save()
+        second = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))["completed_at"]
+        assert second == first
+
+    def test_failed_to_completed_clears_stale_error(self, tmp_path: Path) -> None:
+        """Updating a failed stage to completed removes the previous error."""
+        tracker = ComponentStatusTracker(str(tmp_path), "text_extraction")
+        tracker.record("extract_documents", "failed", error="ValueError: boom")
+        tracker.record("extract_documents", "completed")
+        tracker.save()
+
+        data = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
+        assert data["stages"][0]["status"]["state"] == "completed"
+        assert "error" not in data["stages"][0]
+
+    def test_invalid_state_raises(self, tmp_path: Path) -> None:
+        """record() rejects invalid state values."""
+        tracker = ComponentStatusTracker(str(tmp_path), "documents_discovery")
+        with pytest.raises(ValueError, match="state must be one of"):
+            tracker.record("load_benchmark", "unknown_state")
+
+    def test_no_flat_keys_on_stage(self, tmp_path: Path) -> None:
+        """Stage objects only contain id, status, metrics, and error — no flat keys."""
+        tracker = ComponentStatusTracker(str(tmp_path), "documents_discovery")
+        tracker.record("load_benchmark", "completed", metrics={"rows": 10})
+        tracker.save()
+
+        data = json.loads((tmp_path / COMPONENT_STATUS_FILENAME).read_text(encoding="utf-8"))
+        allowed_keys = {"id", "status", "metrics", "error"}
+        actual_keys = set(data["stages"][0].keys())
+        assert actual_keys <= allowed_keys, f"Unexpected stage keys: {actual_keys - allowed_keys}"
 
 
 class TestComponentStatusEncoder:
@@ -128,10 +304,14 @@ class TestComponentStatusEncoder:
 
     def test_encodes_datetime_path_bytes_and_set(self) -> None:
         """Known non-JSON types are converted for serialization."""
+        from datetime import UTC, datetime
+
         encoder = ComponentStatusEncoder()
         assert encoder.default(Path("/tmp/out")) == "/tmp/out"
         assert encoder.default(b"abc") == "YWJj"
         assert encoder.default({1, 2}) == [1, 2]
+        encoded = encoder.default(datetime(2026, 6, 10, 12, 0, 0, tzinfo=UTC))
+        assert encoded.endswith("Z")
 
     def test_unknown_type_raises_type_error(self) -> None:
         """Unsupported metadata types fail fast instead of being stringified."""
@@ -192,7 +372,6 @@ class TestNullComponentStatusTracker:
             with status.stage("stage2"):
                 pass
 
-        # Verify no files created in tmp_path
         assert list(tmp_path.iterdir()) == []
 
     def test_null_tracker_stage_propagates_exceptions(self) -> None:
@@ -218,5 +397,124 @@ class TestComponentStatusTrackerStage:
                     raise KeyboardInterrupt
 
         data = load_component_status(str(tmp_path))
-        assert data["stages"][-1]["status"] == "failed"
+        assert data["stages"][-1]["status"]["state"] == "failed"
         assert data["stages"][-1]["error"] == "KeyboardInterrupt"
+
+
+class TestLoadComponentStatus:
+    """Tests for load_component_status edge cases."""
+
+    def test_corrupt_json_returns_empty_dict(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Corrupt status files return {} and log a warning."""
+        status_file = tmp_path / COMPONENT_STATUS_FILENAME
+        status_file.write_text("{not json", encoding="utf-8")
+        with caplog.at_level("WARNING"):
+            assert load_component_status(str(tmp_path)) == {}
+        assert "Failed to load status" in caplog.text
+
+
+class TestSchemaCompliance:
+    """Validate tracker output against the canonical JSON Schema."""
+
+    def test_completed_documents_discovery(self, tmp_path: Path, canonical_schema: dict) -> None:
+        """Completed documents_discovery output validates against the schema."""
+        tracker = ComponentStatusTracker(str(tmp_path), "documents_discovery")
+        tracker.set_metadata(display_name="Documents Discovery Status")
+        tracker.record("load_benchmark", "started")
+        tracker.record("load_benchmark", "completed")
+        tracker.record("discover_documents", "started")
+        tracker.record("discover_documents", "completed")
+
+        _assert_schema_valid(_save_and_load(tracker), canonical_schema)
+
+    def test_completed_text_extraction(self, tmp_path: Path, canonical_schema: dict) -> None:
+        """Completed text_extraction output validates against the schema."""
+        tracker = ComponentStatusTracker(str(tmp_path), "text_extraction")
+        tracker.set_metadata(display_name="Text Extraction Status")
+        tracker.record("extract_documents", "started")
+        tracker.record("extract_documents", "completed")
+
+        _assert_schema_valid(_save_and_load(tracker), canonical_schema)
+
+    def test_completed_search_space_preparation(self, tmp_path: Path, canonical_schema: dict) -> None:
+        """Completed search_space_preparation output validates against the schema."""
+        tracker = ComponentStatusTracker(str(tmp_path), "search_space_preparation")
+        tracker.set_metadata(display_name="Search Space Preparation Status")
+        tracker.record("prepare_search_space", "started")
+        tracker.record("prepare_search_space", "completed")
+
+        _assert_schema_valid(_save_and_load(tracker), canonical_schema)
+
+    def test_completed_models_pre_selector(self, tmp_path: Path, canonical_schema: dict) -> None:
+        """Completed models_pre_selector output validates against the schema."""
+        tracker = ComponentStatusTracker(str(tmp_path), "models_pre_selector")
+        tracker.set_metadata(display_name="Model Pre-Selection Status")
+        tracker.record("model_pre_selection", "started")
+        tracker.record("model_pre_selection", "completed")
+
+        _assert_schema_valid(_save_and_load(tracker), canonical_schema)
+
+    def test_completed_rag_templates_optimization(self, tmp_path: Path, canonical_schema: dict) -> None:
+        """Completed rag_templates_optimization output validates against the schema."""
+        tracker = ComponentStatusTracker(str(tmp_path), "rag_templates_optimization")
+        tracker.set_metadata(display_name="RAG Templates Optimization Status")
+        tracker.record("optimize_templates", "started")
+        tracker.record(
+            "optimize_templates",
+            "completed",
+            metrics={
+                "max_rag_patterns": 5,
+                "selected_patterns": ["pattern_a", "pattern_b"],
+            },
+        )
+        tracker.record("build_leaderboard", "started")
+        tracker.record("build_leaderboard", "completed")
+
+        _assert_schema_valid(_save_and_load(tracker), canonical_schema)
+
+    def test_running_with_step(self, tmp_path: Path, canonical_schema: dict) -> None:
+        """In-progress stage with step and message validates against the schema."""
+        tracker = ComponentStatusTracker(str(tmp_path), "rag_templates_optimization")
+        tracker.set_metadata(display_name="RAG Templates Optimization Status")
+        tracker.record(
+            "optimize_templates",
+            "running",
+            step="embedding",
+            message={"level": "info", "text": "Embedding documents..."},
+        )
+
+        _assert_schema_valid(_save_and_load(tracker), canonical_schema)
+
+    def test_failed_stage(self, tmp_path: Path, canonical_schema: dict) -> None:
+        """Failed component output validates against the schema."""
+        tracker = ComponentStatusTracker(str(tmp_path), "text_extraction")
+        tracker.set_metadata(display_name="Text Extraction Status")
+        tracker.record("extract_documents", "started")
+        tracker.record("extract_documents", "failed", error="ValueError: unsupported format")
+
+        _assert_schema_valid(_save_and_load(tracker), canonical_schema)
+
+    def test_context_manager_failure(self, tmp_path: Path, canonical_schema: dict) -> None:
+        """Output from context manager exception path validates against the schema."""
+        with pytest.raises(RuntimeError):
+            with ComponentStatusTracker(str(tmp_path), "documents_discovery") as status:
+                status.set_metadata(display_name="Documents Discovery Status")
+                status.record("load_benchmark", "started")
+                raise RuntimeError("connection lost")
+
+        data = load_component_status(str(tmp_path))
+        _assert_schema_valid(data, canonical_schema)
+
+    def test_flat_keys_rejected_by_schema(self, tmp_path: Path, canonical_schema: dict) -> None:
+        """Manually injected flat keys on a stage fail schema validation."""
+        from jsonschema import ValidationError, validate
+
+        tracker = ComponentStatusTracker(str(tmp_path), "documents_discovery")
+        tracker.set_metadata(display_name="Documents Discovery Status")
+        tracker.record("load_benchmark", "completed")
+
+        data = _save_and_load(tracker)
+        data["stages"][0]["rows"] = 100
+
+        with pytest.raises(ValidationError, match="Additional properties are not allowed"):
+            validate(instance=data, schema=canonical_schema)


### PR DESCRIPTION
Assisted-by: Cursor

**Description of your changes:**
Introduced a standardized status format for tracking component stages, including progress states, messages, metrics, and errors. Added a formal schema to validate generated component status artifacts (https://redhat.atlassian.net/browse/RHOAIENG-78573).

The same alignment work is being done for automl and tracked here: https://github.com/opendatahub-io/pipelines-components/pull/219

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [x] `metadata.yaml` includes fresh `lastVerified` timestamp
- [x] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [x] OWNERS file lists appropriate maintainers
- [x] README provides clear documentation with usage examples
- [x] Component follows `snake_case` naming convention
- [x] No security vulnerabilities in dependencies
- [x] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized component status format with structured stage progress, metrics, messages, timestamps, and error details.
  * Added validation for status records to ensure required fields and supported values are used.

* **Bug Fixes**
  * Improved status tracking for completed and failed stages, including accurate completion timestamps and optimization progress.

* **Tests**
  * Expanded coverage for successful, failed, and no-op workflows, serialization, and invalid status records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->