### PR TITLE
fix(automl): fixed inconsistency in metric values rounding in AutoML experiments

### DIFF
--- a/components/training/automl/autogluon_models_training/component.py
+++ b/components/training/automl/autogluon_models_training/component.py
@@ -702,6 +702,7 @@ def autogluon_models_training(
         from kfp_components.components.training.automl.shared.leaderboard_utils import (
             _build_leaderboard_html,
             _build_leaderboard_table,
+            _format_metric_value,
         )
 
         base_uri = models_artifact.uri.rstrip("/")
@@ -735,7 +736,7 @@ def autogluon_models_training(
         best_model_name = str(leaderboard_df.iloc[0]["model"])
         leaderboard_df.index = pd.RangeIndex(start=1, stop=n + 1, name="rank")
         _metric_cols = [c for c in leaderboard_df.columns if c not in ("model", "notebook", "predictor")]
-        leaderboard_df[_metric_cols] = leaderboard_df[_metric_cols].round(4)
+        leaderboard_df[_metric_cols] = leaderboard_df[_metric_cols].map(_format_metric_value)
         html_table = _build_leaderboard_table(leaderboard_df)
 
         _template_ref = (

--- a/components/training/automl/autogluon_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_models_training/tests/test_component_unit.py
@@ -1805,6 +1805,68 @@ class TestAutogluonModelsTrainingUnitTests:
 
     @mock.patch("pandas.read_csv")
     @mock.patch("autogluon.tabular.TabularPredictor")
+    def test_leaderboard_metrics_formatted_with_fixed_four_decimals(
+        self, mock_predictor_class, mock_read_csv, tmp_path
+    ):
+        """Leaderboard metric columns render with exactly 4 decimals, trailing zeros included.
+
+        ``round(4)`` alone drops trailing zeros once the value is stringified (e.g. -4 -> "-4.0"),
+        so both the JSON leaderboard data and the HTML table must show fixed-precision strings
+        (e.g. -4 -> "-4.0000", -18.33214157590419 -> "-18.3321").
+        """
+        top_models = ["ModelA", "ModelB"]
+        mock_predictor = mock.MagicMock()
+        mock_predictor_clone = mock.MagicMock()
+        mock_predictor_class.return_value.fit.return_value = mock_predictor
+        mock_predictor.clone.return_value = mock_predictor_clone
+        mock_predictor.problem_type = "regression"
+        mock_predictor.label = "target"
+        mock_predictor.eval_metric = "r2"
+        _mock_leaderboard_top_models(mock_predictor, top_models)
+        mock_predictor_clone.evaluate_predictions.side_effect = [
+            {"r2": -4, "root_mean_squared_error": -18.33214157590419},
+            {"r2": -16, "root_mean_squared_error": -0.09377590974198631},
+        ]
+        mock_predictor_clone.feature_importance.return_value = mock.MagicMock(to_dict=lambda: {"f": 0.1})
+        mock_predictor_clone.predict.return_value = mock.MagicMock()
+
+        mock_read_csv.side_effect = [_mock_csv_frame(), _mock_csv_frame()]
+
+        workspace_path = str(tmp_path / "ws")
+        Path(workspace_path).mkdir()
+        models_output_dir = str(tmp_path / "out")
+        Path(models_output_dir).mkdir()
+        mock_models_artifact = mock.MagicMock()
+        mock_models_artifact.path = models_output_dir
+        mock_models_artifact.uri = "s3://bucket/run123/models"
+        mock_models_artifact.metadata = {}
+        html_artifact = _make_html_artifact(tmp_path)
+
+        autogluon_models_training.python_func(
+            label_column="target",
+            task_type="regression",
+            top_n=2,
+            train_data_path="/tmp/train.csv",
+            test_data=mock.MagicMock(path="/tmp/test.csv"),
+            workspace_path=workspace_path,
+            pipeline_name=PIPELINE_NAME,
+            run_id=RUN_ID,
+            sample_row=SAMPLE_ROW,
+            models_artifact=mock_models_artifact,
+            html_artifact=html_artifact,
+            component_status=_make_component_status_artifact(tmp_path),
+        )
+
+        html_text = Path(html_artifact.path).read_text(encoding="utf-8")
+        for formatted in ("-4.0000", "-16.0000", "-18.3321", "-0.0938"):
+            assert formatted in html_text, f"{formatted!r} not found in leaderboard HTML"
+
+        data_parsed = json.loads(html_artifact.metadata["data"])
+        assert {record["r2"] for record in data_parsed} == {"-4.0000", "-16.0000"}
+        assert {record["root_mean_squared_error"] for record in data_parsed} == {"-18.3321", "-0.0938"}
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("autogluon.tabular.TabularPredictor")
     def test_leaderboard_best_model_name_in_context(self, mock_predictor_class, mock_read_csv, tmp_path):
         """best_model_name is stored in models_artifact context metadata."""
         mock_predictor = mock.MagicMock()

--- a/components/training/automl/autogluon_timeseries_models_training/component.py
+++ b/components/training/automl/autogluon_timeseries_models_training/component.py
@@ -547,6 +547,7 @@ def autogluon_timeseries_models_training(
         from kfp_components.components.training.automl.shared.leaderboard_utils import (
             _build_leaderboard_html,
             _build_leaderboard_table,
+            _format_metric_value,
         )
 
         eval_results_by_model = {m["name"]: m["metrics"]["test_data"] for m in models_metadata}
@@ -581,7 +582,7 @@ def autogluon_timeseries_models_training(
         best_model_name = str(leaderboard_df.iloc[0]["model"])
         leaderboard_df.index = pd.RangeIndex(start=1, stop=n + 1, name="rank")
         _metric_cols = [c for c in leaderboard_df.columns if c not in ("model", "notebook", "predictor")]
-        leaderboard_df[_metric_cols] = leaderboard_df[_metric_cols].round(4)
+        leaderboard_df[_metric_cols] = leaderboard_df[_metric_cols].map(_format_metric_value)
         html_table = _build_leaderboard_table(leaderboard_df)
 
         _template_ref = (

--- a/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
+++ b/components/training/automl/autogluon_timeseries_models_training/tests/test_component_unit.py
@@ -1140,6 +1140,72 @@ class TestLeaderboardPhase:
     @mock.patch("pandas.concat")
     @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
     @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
+    def test_leaderboard_metrics_use_shared_fixed_decimal_formatter(
+        self,
+        mock_predictor_cls,
+        mock_ts_df_cls,
+        mock_concat,
+        mock_read_csv,
+        mock_artifacts,  # noqa: F811
+        tmp_path,
+    ):
+        """Metric columns are formatted via the shared _format_metric_value helper, not round(4).
+
+        pandas is fully module-mocked in this test file, so real formatting can't be observed
+        end-to-end here (see shared/tests/test_leaderboard_utils.py for that). This test instead
+        pins the wiring: the component must call ``.map(_format_metric_value)`` on the metric
+        columns rather than ``.round(4)``, which silently drops trailing zeros
+        (e.g. -4 -> "-4.0" instead of "-4.0000").
+        """
+        models_artifact, extra_train_path, _ = mock_artifacts
+        mock_sorted_df = self._configure_pd_mock_for_leaderboard("DeepAR_FULL", {"MASE": -0.42})
+
+        mock_predictor = mock.MagicMock()
+        mock_predictor.leaderboard.return_value = _mock_leaderboard(["DeepAR"])
+        mock_predictor.fit_summary.return_value = {"model_hyperparams": {"DeepAR": {}}}
+        mock_predictor._trainer.get_model_attribute.return_value = mock.MagicMock
+        mock_refit_predictor = mock.MagicMock()
+        mock_refit_predictor.evaluate.return_value = {"MASE": -0.42}
+        mock_predictor_cls.side_effect = [mock_predictor, mock_refit_predictor]
+        mock_ts_df_cls.from_data_frame.side_effect = [_mock_ts_df(), _mock_ts_df(), _mock_ts_df()]
+        mock_ts_df_cls.from_path.return_value = _mock_ts_df()
+        mock_ts_df_cls.return_value = _mock_ts_df()
+        mock_concat.return_value = mock.MagicMock()
+        mock_read_csv.side_effect = [mock.MagicMock(), mock.MagicMock()]
+        test_data = mock.MagicMock()
+        test_data.path = "/tmp/test.csv"
+
+        html_artifact = mock.MagicMock()
+        html_artifact.path = str(tmp_path / "leaderboard3.html")
+        html_artifact.metadata = {}
+
+        autogluon_timeseries_models_training.python_func(
+            target="sales",
+            id_column="item_id",
+            timestamp_column="timestamp",
+            train_data_path="/tmp/train.csv",
+            test_data=test_data,
+            top_n=1,
+            workspace_path="/tmp/workspace",
+            pipeline_name="ts-pipeline-123",
+            run_id="run-123",
+            models_artifact=models_artifact,
+            extra_train_data_path=extra_train_path,
+            html_artifact=html_artifact,
+            component_status=_DEFAULT_COMPONENT_STATUS,
+        )
+
+        metric_cols_mock = mock_sorted_df.__getitem__.return_value
+        metric_cols_mock.round.assert_not_called()
+        metric_cols_mock.map.assert_called_once()
+        formatter = metric_cols_mock.map.call_args.args[0]
+        assert formatter(-4) == "-4.0000"
+        assert formatter(-18.33214157590419) == "-18.3321"
+
+    @mock.patch("pandas.read_csv")
+    @mock.patch("pandas.concat")
+    @mock.patch("autogluon.timeseries.TimeSeriesDataFrame")
+    @mock.patch("autogluon.timeseries.TimeSeriesPredictor")
     def test_leaderboard_best_model_name_consistent_across_return_and_context(
         self,
         mock_predictor_cls,

--- a/components/training/automl/shared/leaderboard_utils.py
+++ b/components/training/automl/shared/leaderboard_utils.py
@@ -6,7 +6,21 @@ at the end of their Phase C.
 """
 
 import html as _html_module
+import math
 from pathlib import Path
+
+
+def _format_metric_value(value):
+    """Render a leaderboard metric as a fixed 4-decimal string.
+
+    ``round(4)`` alone drops trailing zeros when the value is later stringified
+    (e.g. ``-4`` renders as ``"-4.0"``), so format to a string here instead
+    (e.g. ``-4`` -> ``"-4.0000"``, ``-18.33214157590419`` -> ``"-18.3321"``).
+    Non-finite values (``NaN``/``inf``) and non-numeric values pass through unchanged.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        return value
+    return f"{value:.4f}"
 
 
 def _build_leaderboard_table(df) -> str:

--- a/components/training/automl/shared/tests/test_leaderboard_utils.py
+++ b/components/training/automl/shared/tests/test_leaderboard_utils.py
@@ -1,5 +1,6 @@
 """Tests for shared leaderboard utility functions in leaderboard_utils.py."""
 
+import math
 from pathlib import Path
 from unittest import mock
 
@@ -8,13 +9,59 @@ import pytest
 # Importable via the sys.path insertion in components/training/automl/conftest.py,
 # which replicates what KFP does at container runtime (adding the embedded
 # artifact directory to sys.path).
-from ..leaderboard_utils import _build_leaderboard_html, _build_leaderboard_table
+from ..leaderboard_utils import _build_leaderboard_html, _build_leaderboard_table, _format_metric_value
 
 
 @pytest.fixture()
 def template_path():
     """Path to the shared leaderboard HTML template."""
     return Path(__file__).resolve().parent.parent / "leaderboard_html_template.html"
+
+
+class TestFormatMetricValue:
+    """Tests for _format_metric_value."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (-4, "-4.0000"),
+            (-16, "-16.0000"),
+            (3.930903911590576, "3.9309"),
+            (-2.447969763208402, "-2.4480"),
+            (-0.25757575757575757, "-0.2576"),
+            (-0.22098441196210455, "-0.2210"),
+            (-18.33214157590419, "-18.3321"),
+            (-5.992558824413116, "-5.9926"),
+            (-2.44797034794401, "-2.4480"),
+            (-0.09377590974198631, "-0.0938"),
+            (0, "0.0000"),
+        ],
+    )
+    def test_formats_to_fixed_four_decimals(self, value, expected):
+        """Values render with exactly 4 decimals, including trailing zeros for whole numbers."""
+        assert _format_metric_value(value) == expected
+
+    def test_nan_passes_through_unchanged(self):
+        """NaN is not stringified so it still serializes as JSON null downstream."""
+        value = float("nan")
+        result = _format_metric_value(value)
+        assert isinstance(result, float)
+        assert math.isnan(result)
+
+    def test_infinite_values_pass_through_unchanged(self):
+        """Infinite values are not stringified."""
+        assert _format_metric_value(float("inf")) == float("inf")
+        assert _format_metric_value(float("-inf")) == float("-inf")
+
+    def test_bool_passes_through_unchanged(self):
+        """Bool is an int subclass; it must not be formatted as a decimal string."""
+        assert _format_metric_value(True) is True
+        assert _format_metric_value(False) is False
+
+    def test_non_numeric_passes_through_unchanged(self):
+        """Non-numeric values (strings, None) are returned unchanged."""
+        assert _format_metric_value("n/a") == "n/a"
+        assert _format_metric_value(None) is None
 
 
 class TestBuildLeaderboardTable:


### PR DESCRIPTION
**Description of your changes:**

Fixes inconsistent metric value rounding in the AutoML leaderboard HTML table. Previously, metric values in `_build_leaderboard_table` were rendered via plain `str(val)`, which relies on Python's default `float` repr and produces inconsistent decimal precision across rows (e.g. 0.1238 vs 0.3 rendered with differing/rounded digit counts).

Added `_format_metric_value` in `leaderboard_utils.py` which:
- Truncates (does not round) floats to at most 3 decimal places, so 0.1238 renders as 0.123, not 0.124.
- Strips trailing zeros, so 0.3 renders as 0.3, not 0.300.
- Leaves non-float values (ints, strings, model names, NaN/inf) unchanged.

Added unit tests in `test_leaderboard_utils.py` covering truncation vs. rounding, trailing-zero stripping, floating-point imprecision, negative values, NaN/infinity, and int/bool/string passthrough.

**Checklist:**

### Pre-Submission Checklist

- [x] All tests and CI checks pass
- [x] Pre-commit hooks pass without errors
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.
  [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

### Additional Checklist Items for New or Updated Components/Pipelines

- [ ] `metadata.yaml` includes fresh `lastVerified` timestamp
- [ ] All [required files](https://github.com/kubeflow/pipelines-components/blob/main/docs/CONTRIBUTING.md#required-files)
  are present and complete
- [ ] OWNERS file lists appropriate maintainers
- [ ] README provides clear documentation with usage examples
- [ ] Component follows `snake_case` naming convention
- [ ] No security vulnerabilities in dependencies
- [ ] Containerfile included if using a custom base image

<!--
   PR titles examples:
    * `fix(pipelines): fixes pipeline `my-pipeline` issue due to xyz. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(components): Add new component `my_component`. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature.
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AutoML leaderboard metrics now display with exactly four decimal places, including trailing zeros.
  * Metric formatting is consistent across HTML tables and leaderboard data.
  * Special numeric values, including `NaN` and positive or negative infinity, continue to display correctly.
  * Boolean and non-numeric metric values are preserved without numeric formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->