### PR TITLE
chore: update finetuning owners and reviewers

### DIFF
--- a/components/training/finetuning/OWNERS
+++ b/components/training/finetuning/OWNERS
@@ -5,3 +5,6 @@ approvers:
   - Sridhar1030
   - hrathina
   - JaZeeGH
+reviewers:
+  - ChughShilpa
+  - hrathina

--- a/components/training/finetuning/OWNERS
+++ b/components/training/finetuning/OWNERS
@@ -1,8 +1,7 @@
 no_parent_owners: true
 approvers:
-  - briangallagher
   - efazal
-  - Fiona-Waters
-  - kramaranya
-  - MStokluska
-  - szaher
+  - ChughShilpa
+  - Sridhar1030
+  - hrathina
+  - JaZeeGH

--- a/components/training/finetuning/OWNERS
+++ b/components/training/finetuning/OWNERS
@@ -1,10 +1,10 @@
 no_parent_owners: true
 approvers:
-  - efazal
   - ChughShilpa
-  - Sridhar1030
+  - efazal
   - hrathina
   - JaZeeGH
+  - Sridhar1030
 reviewers:
   - ChughShilpa
   - hrathina

--- a/pipelines/training/finetuning/OWNERS
+++ b/pipelines/training/finetuning/OWNERS
@@ -5,3 +5,6 @@ approvers:
   - Sridhar1030
   - hrathina
   - JaZeeGH
+reviewers:
+  - ChughShilpa
+  - hrathina

--- a/pipelines/training/finetuning/OWNERS
+++ b/pipelines/training/finetuning/OWNERS
@@ -1,8 +1,7 @@
 no_parent_owners: true
 approvers:
-  - briangallagher
   - efazal
-  - Fiona-Waters
-  - kramaranya
-  - MStokluska
-  - szaher
+  - ChughShilpa
+  - Sridhar1030
+  - hrathina
+  - JaZeeGH

--- a/pipelines/training/finetuning/OWNERS
+++ b/pipelines/training/finetuning/OWNERS
@@ -1,10 +1,10 @@
 no_parent_owners: true
 approvers:
-  - efazal
   - ChughShilpa
-  - Sridhar1030
+  - efazal
   - hrathina
   - JaZeeGH
+  - Sridhar1030
 reviewers:
   - ChughShilpa
   - hrathina

--- a/pipelines/training/finetuning_evalhub/OWNERS
+++ b/pipelines/training/finetuning_evalhub/OWNERS
@@ -1,9 +1,9 @@
 approvers:
-  - efazal
   - ChughShilpa
-  - Sridhar1030
+  - efazal
   - hrathina
   - JaZeeGH
+  - Sridhar1030
 reviewers:
   - ChughShilpa
   - hrathina

--- a/pipelines/training/finetuning_evalhub/OWNERS
+++ b/pipelines/training/finetuning_evalhub/OWNERS
@@ -1,7 +1,9 @@
 approvers:
-  - briangallagher
   - efazal
-  - Fiona-Waters
-  - kramaranya
-  - MStokluska
-  - szaher
+  - ChughShilpa
+  - Sridhar1030
+  - hrathina
+  - JaZeeGH
+reviewers:
+  - ChughShilpa
+  - hrathina


### PR DESCRIPTION
**Description of your changes:**

Update ownership in `pipelines/training/finetuning/OWNERS`, `components/training/finetuning/OWNERS`, and `pipelines/training/finetuning_evalhub/OWNERS`:

- Retain `efazal` and remove the other existing approvers.
- Add `ChughShilpa`, `Sridhar1030`, `hrathina`, and `JaZeeGH` as approvers.
- Add `ChughShilpa` and `hrathina` as reviewers in all three files, while retaining them as approvers.
- Preserve the existing parent-ownership settings in all three files.

**Validation:**

- Applicable pre-commit hooks pass, including README and metadata validation.
- YAML parsing confirms all three files contain exactly the five intended approvers and two reviewers, with their parent-ownership settings preserved.
- Repository OWNERS validation and `git diff --cached --check` pass.

**Checklist:**

### Pre-Submission Checklist

- [ ] All tests and CI checks pass (GitHub CI pending)
- [x] Pre-commit hooks pass without errors
- [x] Commits are signed off
- [x] PR title follows the repository title convention

### Additional Checklist Items for New or Updated Components/Pipelines

- [x] OWNERS files list appropriate maintainers
- Other component/pipeline checklist items are not applicable to this ownership-only change.
